### PR TITLE
Use lazy front-matter regex

### DIFF
--- a/src/front_matter.rs
+++ b/src/front_matter.rs
@@ -11,7 +11,7 @@ use errors::{Result, ResultExt};
 
 
 lazy_static! {
-    static ref PAGE_RE: Regex = Regex::new(r"^\n?\+\+\+\n((?s).*(?-s))\+\+\+\n?((?s).*(?-s))$").unwrap();
+    static ref PAGE_RE: Regex = Regex::new(r"^\n?\+\+\+\n((?s).*?(?-s))\+\+\+\n?((?s).*(?-s))$").unwrap();
 }
 
 

--- a/tests/front_matter.rs
+++ b/tests/front_matter.rs
@@ -185,6 +185,20 @@ date = "2002/10/12"
 }
 
 #[test]
+fn test_can_split_content_lazily() {
+    let content = r#"
++++
+title = "Title"
+description = "hey there"
+date = "2002-10-02T15:00:00Z"
++++
++++"#;
+    let (front_matter, content) = split_content(Path::new(""), content).unwrap();
+    assert_eq!(content, "+++");
+    assert_eq!(front_matter.title, "Title");
+}
+
+#[test]
 fn test_error_if_cannot_locate_frontmatter() {
     let content = r#"
 +++


### PR DESCRIPTION
Using a greedy regex could lead to unintended consequences, like the inability to syntax highlight a unified diff. This resolves issues like that by using `.*?` instead of `.*` so that the closing `+++` is matched as soon as possible.