### PR TITLE
Allow sorting pages by order and date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fix XML templates overriding and reloading
 - `title` and `description` are now optional in the front matter
 - Add GenericConfig, Vim syntax
+- Add `_index.md` for homepage as well
+- Allow sorting by `none`, `date` and `order` for sections
 
 ## 0.0.4 (2017-04-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term-painter 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.0 (git+https://github.com/alexcrichton/toml-rs)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "toml"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/alexcrichton/toml-rs#95b3545938f67ca98d313be5c9c8930ee2407a30"
 dependencies = [
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1172,7 +1172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
-"checksum toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3063405db158de3dce8efad5fc89cf1baffb9501a3647dc9505ba109694ce31f"
+"checksum toml 0.4.0 (git+https://github.com/alexcrichton/toml-rs)" = "<none>"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ tera = "0.10"
 slug = "0.1"
 syntect = { version = "1", features = ["static-onig"] }
 chrono = "0.3"
-toml = "0.4"
+# toml = "0.4"
+toml = { git = "https://github.com/alexcrichton/toml-rs" }
 term-painter = "0.2"
 base64 = "0.5"
 

--- a/benches/gutenberg.rs
+++ b/benches/gutenberg.rs
@@ -44,5 +44,5 @@ fn bench_populate_previous_and_next_pages(b: &mut test::Bencher) {
     let mut pages = site.pages.values().cloned().collect::<Vec<_>>();
     pages.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-    b.iter(|| populate_previous_and_next_pages(pages.as_slice(), false));
+    b.iter(|| populate_previous_and_next_pages(pages.as_slice()));
 }

--- a/src/front_matter.rs
+++ b/src/front_matter.rs
@@ -111,8 +111,8 @@ impl FrontMatter {
 impl Default for FrontMatter {
     fn default() -> FrontMatter {
         FrontMatter {
-            title: "default".to_string(),
-            description: " A default front matter".to_string(),
+            title: None,
+            description: None,
             date: None,
             slug: None,
             url: None,

--- a/src/front_matter.rs
+++ b/src/front_matter.rs
@@ -14,6 +14,13 @@ lazy_static! {
     static ref PAGE_RE: Regex = Regex::new(r"^\r?\n?\+\+\+\r?\n((?s).*?(?-s))\+\+\+\r?\n?((?s).*(?-s))$").unwrap();
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortBy {
+    Date,
+    Order,
+    None,
+}
 
 /// The front matter of every page
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -37,6 +44,11 @@ pub struct FrontMatter {
     pub draft: Option<bool>,
     /// Only one category allowed
     pub category: Option<String>,
+    /// Whether to sort by "date", "order" or "none"
+    #[serde(skip_serializing)]
+    pub sort_by: Option<SortBy>,
+    /// Integer to use to order content. Lowest is at the bottom, highest first
+    pub order: Option<usize>,
     /// Optional template, if we want to specify which template to render for that page
     #[serde(skip_serializing)]
     pub template: Option<String>,
@@ -71,7 +83,7 @@ impl FrontMatter {
     }
 
     /// Converts the date in the front matter, which can be in 2 formats, into a NaiveDateTime
-    pub fn parse_date(&self) -> Option<NaiveDateTime> {
+    pub fn date(&self) -> Option<NaiveDateTime> {
         match self.date {
             Some(ref d) => {
                 if d.contains('T') {
@@ -83,12 +95,40 @@ impl FrontMatter {
             None => None,
         }
     }
+
+    pub fn order(&self) -> usize {
+        self.order.unwrap()
+    }
+
+    pub fn sort_by(&self) -> SortBy {
+        match self.sort_by {
+            Some(ref s) => s.clone(),
+            None => SortBy::Date,
+        }
+    }
 }
 
+impl Default for FrontMatter {
+    fn default() -> FrontMatter {
+        FrontMatter {
+            title: "default".to_string(),
+            description: " A default front matter".to_string(),
+            date: None,
+            slug: None,
+            url: None,
+            tags: None,
+            draft: None,
+            category: None,
+            sort_by: None,
+            order: None,
+            template: None,
+            extra: None,
+        }
+    }
+}
 
 /// Split a file between the front matter and its content
 /// It will parse the front matter as well and returns any error encountered
-/// TODO: add tests
 pub fn split_content(file_path: &Path, content: &str) -> Result<(FrontMatter, String)> {
     if !PAGE_RE.is_match(content) {
         bail!("Couldn't find front matter in `{}`. Did you forget to add `+++`?", file_path.to_string_lossy());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod filters;
 
 pub use site::{Site, GUTENBERG_TERA};
 pub use config::{Config, get_config};
-pub use front_matter::{FrontMatter, split_content};
+pub use front_matter::{FrontMatter, split_content, SortBy};
 pub use page::{Page, populate_previous_and_next_pages};
 pub use section::{Section};
 pub use utils::{create_file};

--- a/src/page.rs
+++ b/src/page.rs
@@ -12,7 +12,8 @@ use slug::slugify;
 
 use errors::{Result, ResultExt};
 use config::Config;
-use front_matter::{FrontMatter, split_content};
+use front_matter::{FrontMatter, SortBy, split_content};
+use section::Section;
 use markdown::markdown_to_html;
 use utils::{read_file, find_content_components};
 
@@ -76,14 +77,10 @@ pub struct Page {
     /// as summary
     pub summary: Option<String>,
 
-    /// The previous page, by date globally
+    /// The previous page, by whatever sorting is used for the index/section
     pub previous: Option<Box<Page>>,
-    /// The previous page, by date only for the section the page is in
-    pub previous_in_section: Option<Box<Page>>,
-    /// The next page, by date
+    /// The next page, by whatever sorting is used for the index/section
     pub next: Option<Box<Page>>,
-    /// The next page, by date only for the section the page is in
-    pub next_in_section: Option<Box<Page>>,
 }
 
 
@@ -104,9 +101,7 @@ impl Page {
             summary: None,
             meta: meta,
             previous: None,
-            previous_in_section: None,
             next: None,
-            next_in_section: None,
         }
     }
 
@@ -222,7 +217,7 @@ impl Page {
 
 impl ser::Serialize for Page {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error> where S: ser::Serializer {
-        let mut state = serializer.serialize_struct("page", 18)?;
+        let mut state = serializer.serialize_struct("page", 16)?;
         state.serialize_field("content", &self.content)?;
         state.serialize_field("title", &self.meta.title)?;
         state.serialize_field("description", &self.meta.description)?;
@@ -239,13 +234,63 @@ impl ser::Serialize for Page {
         state.serialize_field("word_count", &word_count)?;
         state.serialize_field("reading_time", &reading_time)?;
         state.serialize_field("previous", &self.previous)?;
-        state.serialize_field("previous_in_section", &self.previous_in_section)?;
         state.serialize_field("next", &self.next)?;
-        state.serialize_field("next_in_section", &self.next_in_section)?;
         state.end()
     }
 }
 
+/// Sort pages
+/// TODO: write doc and tests
+pub fn sort_pages(pages: Vec<Page>, section: Option<&Section>) -> Vec<Page> {
+    let sort_by = if let Some(ref sec) = section {
+        sec.meta.sort_by()
+    } else {
+        SortBy::Date
+    };
+
+    match sort_by {
+        SortBy::Date => {
+            let mut can_be_sorted = vec![];
+            let mut cannot_be_sorted = vec![];
+            for page in pages {
+                if page.meta.date.is_some() {
+                    can_be_sorted.push(page);
+                } else {
+                    cannot_be_sorted.push(page);
+                }
+            }
+            can_be_sorted.sort_by(|a, b| b.meta.date().unwrap().cmp(&a.meta.date().unwrap()));
+            can_be_sorted.append(&mut cannot_be_sorted);
+
+            can_be_sorted
+        },
+        SortBy::Order => {
+            let mut can_be_sorted = vec![];
+            let mut cannot_be_sorted = vec![];
+            for page in pages {
+                if page.meta.order.is_some() {
+                    can_be_sorted.push(page);
+                } else {
+                    cannot_be_sorted.push(page);
+                }
+            }
+            can_be_sorted.sort_by(|a, b| b.meta.order().cmp(&a.meta.order()));
+            can_be_sorted.append(&mut cannot_be_sorted);
+
+            can_be_sorted
+        },
+        SortBy::None => {
+            let mut p = vec![];
+            for page in pages {
+                p.push(page);
+            }
+
+            p
+        },
+    }
+}
+
+/// Used only by the RSS feed (I think)
 impl PartialOrd for Page {
     fn partial_cmp(&self, other: &Page) -> Option<Ordering> {
         if self.meta.date.is_none() {
@@ -256,8 +301,8 @@ impl PartialOrd for Page {
             return Some(Ordering::Greater);
         }
 
-        let this_date = self.meta.parse_date().unwrap();
-        let other_date = other.meta.parse_date().unwrap();
+        let this_date = self.meta.date().unwrap();
+        let other_date = other.meta.date().unwrap();
 
         if this_date > other_date {
             return Some(Ordering::Less);
@@ -273,36 +318,23 @@ impl PartialOrd for Page {
 
 /// Horribly inefficient way to set previous and next on each pages
 /// So many clones
-pub fn populate_previous_and_next_pages(input: &[Page], in_section: bool) -> Vec<Page> {
+pub fn populate_previous_and_next_pages(input: &[Page]) -> Vec<Page> {
     let pages = input.to_vec();
     let mut res = Vec::new();
 
-    // the input is sorted from most recent to least recent already
+    // the input is already sorted
+    // We might put prev/next randomly if a page is missing date/order, probably fine
     for (i, page) in input.iter().enumerate() {
         let mut new_page = page.clone();
 
-        if new_page.has_date() {
-            if i > 0 {
-                let next = &pages[i - 1];
-                if next.has_date() {
-                    if in_section {
-                        new_page.next_in_section = Some(Box::new(next.clone()));
-                    } else {
-                        new_page.next = Some(Box::new(next.clone()));
-                    }
-                }
-            }
+        if i > 0 {
+            let next = &pages[i - 1];
+            new_page.next = Some(Box::new(next.clone()));
+        }
 
-            if i < input.len() - 1 {
-                let previous = &pages[i + 1];
-                if previous.has_date() {
-                    if in_section {
-                        new_page.previous_in_section = Some(Box::new(previous.clone()));
-                    } else {
-                        new_page.previous = Some(Box::new(previous.clone()));
-                    }
-                }
-            }
+        if i < input.len() - 1 {
+            let previous = &pages[i + 1];
+            new_page.previous = Some(Box::new(previous.clone()));
         }
         res.push(new_page);
     }
@@ -315,8 +347,23 @@ mod tests {
     use tempdir::TempDir;
 
     use std::fs::File;
+    use std::path::Path;
 
-    use super::{find_related_assets};
+    use front_matter::{FrontMatter, SortBy};
+    use section::Section;
+    use super::{Page, find_related_assets, sort_pages, populate_previous_and_next_pages};
+
+    fn create_page_with_date(date: &str) -> Page {
+        let mut front_matter = FrontMatter::default();
+        front_matter.date = Some(date.to_string());
+        Page::new(front_matter)
+    }
+
+    fn create_page_with_order(order: usize) -> Page {
+        let mut front_matter = FrontMatter::default();
+        front_matter.order = Some(order);
+        Page::new(front_matter)
+    }
 
     #[test]
     fn test_find_related_assets() {
@@ -332,5 +379,76 @@ mod tests {
         assert_eq!(assets.iter().filter(|p| p.file_name().unwrap() == "example.js").count(), 1);
         assert_eq!(assets.iter().filter(|p| p.file_name().unwrap() == "graph.jpg").count(), 1);
         assert_eq!(assets.iter().filter(|p| p.file_name().unwrap() == "fail.png").count(), 1);
+    }
+
+    #[test]
+    fn test_can_default_sort() {
+        let input = vec![
+            create_page_with_date("2018-01-01"),
+            create_page_with_date("2017-01-01"),
+            create_page_with_date("2019-01-01"),
+        ];
+        let pages = sort_pages(input, None);
+        // Should be sorted by date
+        assert_eq!(pages[0].clone().meta.date.unwrap(), "2019-01-01");
+        assert_eq!(pages[1].clone().meta.date.unwrap(), "2018-01-01");
+        assert_eq!(pages[2].clone().meta.date.unwrap(), "2017-01-01");
+    }
+
+    #[test]
+    fn test_can_sort_dates() {
+        let input = vec![
+            create_page_with_date("2018-01-01"),
+            create_page_with_date("2017-01-01"),
+            create_page_with_date("2019-01-01"),
+        ];
+        let mut front_matter = FrontMatter::default();
+        front_matter.sort_by = Some(SortBy::Date);
+        let section = Section::new(Path::new("hey"), front_matter);
+        let pages = sort_pages(input, Some(&section));
+        // Should be sorted by date
+        assert_eq!(pages[0].clone().meta.date.unwrap(), "2019-01-01");
+        assert_eq!(pages[1].clone().meta.date.unwrap(), "2018-01-01");
+        assert_eq!(pages[2].clone().meta.date.unwrap(), "2017-01-01");
+    }
+
+    #[test]
+    fn test_can_sort_order() {
+        let input = vec![
+            create_page_with_order(2),
+            create_page_with_order(3),
+            create_page_with_order(1),
+        ];
+        let mut front_matter = FrontMatter::default();
+        front_matter.sort_by = Some(SortBy::Order);
+        let section = Section::new(Path::new("hey"), front_matter);
+        let pages = sort_pages(input, Some(&section));
+        // Should be sorted by date
+        assert_eq!(pages[0].clone().meta.order.unwrap(), 3);
+        assert_eq!(pages[1].clone().meta.order.unwrap(), 2);
+        assert_eq!(pages[2].clone().meta.order.unwrap(), 1);
+    }
+
+    #[test]
+    fn test_populate_previous_and_next_pages() {
+        let input = vec![
+            create_page_with_order(3),
+            create_page_with_order(2),
+            create_page_with_order(1),
+        ];
+        let pages = populate_previous_and_next_pages(input.as_slice());
+
+        assert!(pages[0].clone().next.is_none());
+        assert!(pages[0].clone().previous.is_some());
+        assert_eq!(pages[0].clone().previous.unwrap().meta.order.unwrap(), 2);
+
+        assert!(pages[1].clone().next.is_some());
+        assert!(pages[1].clone().previous.is_some());
+        assert_eq!(pages[1].clone().next.unwrap().meta.order.unwrap(), 3);
+        assert_eq!(pages[1].clone().previous.unwrap().meta.order.unwrap(), 1);
+
+        assert!(pages[2].clone().next.is_some());
+        assert!(pages[2].clone().previous.is_none());
+        assert_eq!(pages[2].clone().next.unwrap().meta.order.unwrap(), 2);
     }
 }

--- a/test_site/content/posts/tutorials/devops/_index.md
+++ b/test_site/content/posts/tutorials/devops/_index.md
@@ -1,4 +1,4 @@
 +++
 title = "DevOps"
-description = ""
+sort_by = "order"
 +++

--- a/test_site/content/posts/tutorials/devops/docker.md
+++ b/test_site/content/posts/tutorials/devops/docker.md
@@ -1,7 +1,6 @@
 +++
 title = "Docker"
-description = ""
-date = "2017-02-01"
+order = 1
 +++
 
 A simple page

--- a/test_site/content/posts/tutorials/devops/nix.md
+++ b/test_site/content/posts/tutorials/devops/nix.md
@@ -1,7 +1,6 @@
 +++
 title = "Nix"
-description = ""
-date = "2017-03-01"
+order = 2
 +++
 
 A simple page

--- a/test_site/content/posts/tutorials/programming/_index.md
+++ b/test_site/content/posts/tutorials/programming/_index.md
@@ -1,4 +1,4 @@
 +++
 title = "Programming"
-description = ""
+sort_by = "order"
 +++

--- a/test_site/content/posts/tutorials/programming/python.md
+++ b/test_site/content/posts/tutorials/programming/python.md
@@ -1,6 +1,6 @@
 +++
 title = "Python tutorial"
-description = ""
+order = 1
 +++
 
 A simple page

--- a/test_site/content/posts/tutorials/programming/rust.md
+++ b/test_site/content/posts/tutorials/programming/rust.md
@@ -1,6 +1,6 @@
 +++
 title = "Rust"
-description = ""
+order = 2
 +++
 
 A simple page

--- a/tests/front_matter.rs
+++ b/tests/front_matter.rs
@@ -125,7 +125,7 @@ title = "Hello"
 description = "hey there"
 date = "2016-10-10""#;
     let res = FrontMatter::parse(content).unwrap();
-    assert!(res.parse_date().is_some());
+    assert!(res.date().is_some());
 }
 
 #[test]
@@ -135,7 +135,7 @@ title = "Hello"
 description = "hey there"
 date = "2002-10-02T15:00:00Z""#;
     let res = FrontMatter::parse(content).unwrap();
-    assert!(res.parse_date().is_some());
+    assert!(res.date().is_some());
 }
 
 #[test]
@@ -145,9 +145,41 @@ title = "Hello"
 description = "hey there"
 date = "2002/10/12""#;
     let res = FrontMatter::parse(content).unwrap();
-    assert!(res.parse_date().is_none());
+    assert!(res.date().is_none());
 }
 
+#[test]
+fn test_cant_parse_sort_by_date() {
+    let content = r#"
+title = "Hello"
+description = "hey there"
+sort_by = "date""#;
+    let res = FrontMatter::parse(content).unwrap();
+    assert!(res.sort_by.is_some());
+    assert!(res.sort_by.unwrap(), SortBy::Date);
+}
+
+#[test]
+fn test_cant_parse_sort_by_order() {
+    let content = r#"
+title = "Hello"
+description = "hey there"
+sort_by = "order""#;
+    let res = FrontMatter::parse(content).unwrap();
+    assert!(res.sort_by.is_some());
+    assert!(res.sort_by.unwrap(), SortBy::Order);
+}
+
+#[test]
+fn test_cant_parse_sort_by_none() {
+    let content = r#"
+title = "Hello"
+description = "hey there"
+sort_by = "none""#;
+    let res = FrontMatter::parse(content).unwrap();
+    assert!(res.sort_by.is_some());
+    assert!(res.sort_by.unwrap(), SortBy::None);
+}
 
 #[test]
 fn test_can_split_content_valid() {

--- a/tests/front_matter.rs
+++ b/tests/front_matter.rs
@@ -3,7 +3,7 @@ extern crate tera;
 
 use std::path::Path;
 
-use gutenberg::{FrontMatter, split_content};
+use gutenberg::{FrontMatter, split_content, SortBy};
 use tera::to_value;
 
 
@@ -156,7 +156,7 @@ description = "hey there"
 sort_by = "date""#;
     let res = FrontMatter::parse(content).unwrap();
     assert!(res.sort_by.is_some());
-    assert!(res.sort_by.unwrap(), SortBy::Date);
+    assert_eq!(res.sort_by.unwrap(), SortBy::Date);
 }
 
 #[test]
@@ -167,7 +167,7 @@ description = "hey there"
 sort_by = "order""#;
     let res = FrontMatter::parse(content).unwrap();
     assert!(res.sort_by.is_some());
-    assert!(res.sort_by.unwrap(), SortBy::Order);
+    assert_eq!(res.sort_by.unwrap(), SortBy::Order);
 }
 
 #[test]
@@ -178,7 +178,7 @@ description = "hey there"
 sort_by = "none""#;
     let res = FrontMatter::parse(content).unwrap();
     assert!(res.sort_by.is_some());
-    assert!(res.sort_by.unwrap(), SortBy::None);
+    assert_eq!(res.sort_by.unwrap(), SortBy::None);
 }
 
 #[test]

--- a/tests/site.rs
+++ b/tests/site.rs
@@ -44,7 +44,7 @@ fn test_can_parse_site() {
     let posts_section = &site.sections[&posts_path];
     assert_eq!(posts_section.subsections.len(), 1);
     //println!("{:#?}", posts_section.pages);
-    assert_eq!(posts_section.pages.len(), 5);
+    assert_eq!(posts_section.pages.len(), 4);
 
     let tutorials_section = &site.sections[&posts_path.join("tutorials")];
     assert_eq!(tutorials_section.subsections.len(), 2);


### PR DESCRIPTION
Closes #14, #43

Currently not working because of bug in the TOML crate for ser/de of enums