### PR TITLE
<documentation/page.md: Fix a typo into page.md doc>

### DIFF
--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -4,7 +4,7 @@ weight = 30
 +++
 
 A page is any file ending with `.md` in the `content` directory, except files
-named `_index/md`.
+named `_index.md`.
 
 ## Front-matter
 


### PR DESCRIPTION
I believe that there is an typo in the page.md documentation where an extra slash could be replaced by a dot.