### PR TITLE
Minimal test to reproduce issue #160

### DIFF
--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -138,6 +138,33 @@ fn can_render_body_shortcode_with_markdown_char_in_name() {
 }
 
 #[test]
+fn can_render_body_shortcode_and_paragraph_after() {
+    let permalinks_ctx = HashMap::new();
+    let mut tera = Tera::default();
+    tera.extend(&GUTENBERG_TERA).unwrap();
+
+    let shortcode = "<p>{{ body }}</p>";
+    let markdown_string = r#"
+{% figure() %}
+This is a figure caption.
+{% end %}
+
+Here is another paragraph.
+"#;
+
+    let expected = "<p>This is a figure caption.</p>
+<p>Here is another paragraph.</p>
+";
+
+    tera.add_raw_template(&format!("shortcodes/{}.html", "figure"), shortcode).unwrap();
+    let context = Context::new(&tera, true, "base16-ocean-dark".to_string(), "", &permalinks_ctx, InsertAnchor::None);
+
+    let res = markdown_to_html(markdown_string, &context).unwrap();
+    println!("{:?}", res);
+    assert_eq!(res.0, expected);
+}
+
+#[test]
 fn can_render_several_shortcode_in_row() {
     let permalinks_ctx = HashMap::new();
     let context = Context::new(&GUTENBERG_TERA, true, "base16-ocean-dark".to_string(), "", &permalinks_ctx, InsertAnchor::None);


### PR DESCRIPTION
Here is a minimal test to reproduce the problem describe in #160.

Test output:
```
[13:02:26] tucker@khanti:~/Projects/gutenberg/components/rendering git:(test_case_issue_160) $ cargo test can_render_body_shortcode_and_paragraph_after
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running /home/tucker/Projects/gutenberg/target/debug/deps/rendering-587d7974cf425a61

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out

     Running /home/tucker/Projects/gutenberg/target/debug/deps/markdown-7ea55b9ed89c348a

running 1 test
test can_render_body_shortcode_and_paragraph_after ... FAILED

failures:

---- can_render_body_shortcode_and_paragraph_after stdout ----
        ("<p>This is a figure caption.</p>\n\n", [])
thread 'can_render_body_shortcode_and_paragraph_after' panicked at 'assertion failed: `(left == right)`
  left: `"<p>This is a figure caption.</p>\n\n"`,
 right: `"<p>This is a figure caption.</p>\n<p>Here is another paragraph.</p>\n"`', tests/markdown.rs:164:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.


failures:
    can_render_body_shortcode_and_paragraph_after

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 27 filtered out

error: test failed, to rerun pass '--test markdown'
```