### PR TITLE
Hack fix and new tests for body-shortcodes

### DIFF
--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -138,6 +138,65 @@ fn can_render_body_shortcode_with_markdown_char_in_name() {
 }
 
 #[test]
+fn can_render_body_shortcode_and_paragraph_after() {
+    let permalinks_ctx = HashMap::new();
+    let mut tera = Tera::default();
+    tera.extend(&GUTENBERG_TERA).unwrap();
+
+    let shortcode = "<p>{{ body }}</p>";
+    let markdown_string = r#"
+{% figure() %}
+This is a figure caption.
+{% end %}
+
+Here is another paragraph.
+"#;
+
+    let expected = "<p>This is a figure caption.</p>
+<p>Here is another paragraph.</p>
+";
+
+    tera.add_raw_template(&format!("shortcodes/{}.html", "figure"), shortcode).unwrap();
+    let context = Context::new(&tera, true, "base16-ocean-dark".to_string(), "", &permalinks_ctx, InsertAnchor::None);
+
+    let res = markdown_to_html(markdown_string, &context).unwrap();
+    println!("{:?}", res);
+    assert_eq!(res.0, expected);
+}
+
+#[test]
+fn can_render_two_body_shortcode_and_paragraph_after_with_line_break_between() {
+    let permalinks_ctx = HashMap::new();
+    let mut tera = Tera::default();
+    tera.extend(&GUTENBERG_TERA).unwrap();
+
+    let shortcode = "<p>{{ body }}</p>";
+    let markdown_string = r#"
+{% figure() %}
+This is a figure caption.
+{% end %}
+
+{% figure() %}
+This is a figure caption.
+{% end %}
+
+Here is another paragraph.
+"#;
+
+    let expected = "<p>This is a figure caption.</p>
+<p>This is a figure caption.</p>
+<p>Here is another paragraph.</p>
+";
+
+    tera.add_raw_template(&format!("shortcodes/{}.html", "figure"), shortcode).unwrap();
+    let context = Context::new(&tera, true, "base16-ocean-dark".to_string(), "", &permalinks_ctx, InsertAnchor::None);
+
+    let res = markdown_to_html(markdown_string, &context).unwrap();
+    println!("{:?}", res);
+    assert_eq!(res.0, expected);
+}
+
+#[test]
 fn can_render_several_shortcode_in_row() {
     let permalinks_ctx = HashMap::new();
     let context = Context::new(&GUTENBERG_TERA, true, "base16-ocean-dark".to_string(), "", &permalinks_ctx, InsertAnchor::None);


### PR DESCRIPTION
This fix is a total hack, but it fixes the issue described in #160, without massively restructuring the code.

The essential problem is that shortcodes really _should_ be a "Gutenberg Flavored Markdown" extension but we don't get events that signal "start shortcode" and "end startcode" which would vastly simplify implementing the actual processing of shortcodes.

@reillysiemens, @fuginator, and I think this is a reasonable short term fix to include, but longer term (like maybe for 0.3.0?) the code should probably be restructured to make this way less hacky to implement.