### PR TITLE
Added installation method for Void Linux

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -30,6 +30,14 @@ Use your favourite AUR helper to install the `gutenberg-bin` package.
 $ yaourt -S gutenberg-bin
 ```
 
+## Void Linux
+
+From the terminal, run the following command:
+
+```bash
+$ xbps-install -S gutenberg
+```
+
 ## From source
 To build it from source, you will need to have Git, [Rust and Cargo](https://www.rust-lang.org/)
 installed.


### PR DESCRIPTION
I have created a package (voidlinux/void-packages#9008) for Void Linux. This PR updates the install docs to show how to install gutenberg if you are a Void Linux user.

On a side note, I have been using gutenberg for the past couple of days and really like it!