### PR TITLE
Add trailing_slash opt. to get_url

### DIFF
--- a/components/templates/src/global_fns.rs
+++ b/components/templates/src/global_fns.rs
@@ -59,7 +59,13 @@ pub fn make_get_url(permalinks: HashMap<String, String>, config: Config) -> Glob
             .map_or(false, |c| {
                 from_value::<bool>(c.clone()).unwrap_or(false)
             });
-
+        
+        let trailing_slash = args
+            .get("trailing_slash")
+            .map_or(true, |c| {
+                from_value::<bool>(c.clone()).unwrap_or(true)
+            });
+        
         match args.get("path") {
             Some(val) => match from_value::<String>(val.clone()) {
                 Ok(v) => {
@@ -72,6 +78,10 @@ pub fn make_get_url(permalinks: HashMap<String, String>, config: Config) -> Glob
                     } else {
                         // anything else
                         let mut permalink = config.make_permalink(&v);
+                        if !trailing_slash && permalink.ends_with("/") {
+                            permalink.pop(); // Removes the slash
+                        }
+
                         if cachebust {
                             permalink = format!("{}?t={}", permalink, config.build_timestamp.unwrap());
                         }

--- a/components/templates/src/global_fns.rs
+++ b/components/templates/src/global_fns.rs
@@ -125,6 +125,17 @@ mod tests {
         args.insert("trailing_slash".to_string(), to_value(false).unwrap());
         assert_eq!(static_fn(args).unwrap(), "http://a-website.com/app.css");
     }
+    
+    #[test]
+    fn can_remove_slashes_and_cachebust() {
+        let config = Config::default();
+        let static_fn = make_get_url(HashMap::new(), config);
+        let mut args = HashMap::new();
+        args.insert("path".to_string(), to_value("app.css").unwrap());
+        args.insert("trailing_slash".to_string(), to_value(false).unwrap());
+        args.insert("cachebust".to_string(), to_value(true).unwrap());
+        assert_eq!(static_fn(args).unwrap(), "http://a-website.com/app.css?t=1");
+    }
 
     #[test]
     fn can_link_to_some_static_file() {

--- a/components/templates/src/global_fns.rs
+++ b/components/templates/src/global_fns.rs
@@ -115,6 +115,16 @@ mod tests {
         args.insert("cachebust".to_string(), to_value(true).unwrap());
         assert_eq!(static_fn(args).unwrap(), "http://a-website.com/app.css/?t=1");
     }
+    
+    #[test]
+    fn can_remove_trailing_slashes() {
+        let config = Config::default();
+        let static_fn = make_get_url(HashMap::new(), config);
+        let mut args = HashMap::new();
+        args.insert("path".to_string(), to_value("app.css").unwrap());
+        args.insert("trailing_slash".to_string(), to_value(false).unwrap());
+        assert_eq!(static_fn(args).unwrap(), "http://a-website.com/app.css");
+    }
 
     #[test]
     fn can_link_to_some_static_file() {

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -70,5 +70,12 @@ we want to link to the file that is located at `static/css/app.css`:
 {{ get_url(path="css/app.css") }}
 ```
 
+For assets it is reccommended that you pass `trailing_slash=false` to the `get_url` function. This prevents errors
+when dealing with certain hosting providers. An example is:
+
+```jinja2
+{{ get_url(path="css/app.css", trailing_slash=false) }}
+```
+
 In the case of non-internal links, you can also add a cachebust of the format `?t=1290192` at the end of a URL
 by passing `cachebust=true` to the `get_url` function.

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -7,8 +7,8 @@
         <meta name="description" content="{% block description %}{{ config.description }}{% endblock description %}">
         <meta name="author" content="{{ config.extra.author }}">
         <title>{% block title %}{{ config.title }}{% endblock title %}</title>
-        <link rel="stylesheet" href="{{ get_url(path="site.css") }}"/>
-        <link rel="icon" href="{{ get_url(path="favicon.ico") }}">
+        <link rel="stylesheet" href="{{ get_url(path="site.css", trailing_slash=false) }}"/>
+        <link rel="icon" href="{{ get_url(path="favicon.ico", trailing_slash=false) }}">
     </head>
     <body>
 


### PR DESCRIPTION
This PR addresses issue #171, adding a trailing_slash option as discussed in that thread, which defaults to true. I have updated the documentation and used the new fix on the docs site itself.

Please let me know if any adjustments are needed!