### PR TITLE
Add the detection of ChangeKind::Sass to tests

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -296,6 +296,10 @@ mod tests {
                 (ChangeKind::Content, "/content/posts/hello.md".to_string()),
                 "/home/vincent/site", Path::new("/home/vincent/site/content/posts/hello.md")
             ),
+            (
+                (ChangeKind::Sass, "/sass/print.scss".to_string()),
+                "/home/vincent/site", Path::new("/home/vincent/site/sass/print.scss")
+            )
         ];
 
         for (expected, pwd, path) in test_cases {


### PR DESCRIPTION
Hello,

While looking for how to add a watcher for `config.toml` in `serve`, I noticed that `ChangeKind::Sass` is not tested in `can_detect_kind_of_changes`.
This PR intends to fix that.

Best regards,
Thomas