### PR TITLE
Proper Arch Linux spelling

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -22,7 +22,7 @@ Gutenberg is available on [Scoop](http://scoop.sh):
 $ scoop install gutenberg
 ```
 
-## Archlinux
+## Arch Linux
 
 Use your favourite AUR helper to install the `gutenberg-bin` package.
 


### PR DESCRIPTION
It's either Arch Linux or archlinux but never Archlinux or ArchLinux.