### PR TITLE
Make indented syntax available for SASS via the "sass" file extension

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use glob::glob;
 use tera::{Tera, Context};
 use walkdir::WalkDir;
-use sass_rs::{Options, OutputStyle, compile_file};
+use sass_rs::{Options as SassOptions, OutputStyle, compile_file};
 
 use errors::{Result, ResultExt};
 use config::{Config, get_config};
@@ -537,7 +537,7 @@ impl Site {
             sass_path
         };
 
-        let mut options = Options::default();
+        let mut options = SassOptions::default();
         options.output_style = OutputStyle::Compressed;
         let mut compiled_paths = self.compile_sass_glob(&sass_path, "scss", options.clone())?;
 
@@ -547,14 +547,19 @@ impl Site {
         compiled_paths.sort();
         for window in compiled_paths.windows(2) {
             if window[0].1 == window[1].1 {
-                bail!("SASS path conflict: \"{}\" and \"{}\" both compile to \"{}\"", window[0].0.display(), window[1].0.display(), window[0].1.display());
+                bail!(
+                    "SASS path conflict: \"{}\" and \"{}\" both compile to \"{}\"",
+                    window[0].0.display(),
+                    window[1].0.display(),
+                    window[0].1.display(),
+                );
             }
         }
 
         Ok(())
     }
 
-    fn compile_sass_glob(&self, sass_path: &Path, extension: &str, options: Options) -> Result<Vec<(PathBuf, PathBuf)>> {
+    fn compile_sass_glob(&self, sass_path: &Path, extension: &str, options: SassOptions) -> Result<Vec<(PathBuf, PathBuf)>> {
         let glob_string = format!("{}/**/*.{}", sass_path.display(), extension);
         let files = glob(&glob_string)
             .unwrap()

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -148,6 +148,8 @@ fn can_build_site_without_live_reload() {
     assert!(file_contains!(public, "blog.css", "2rem")); // check include
     assert!(!file_exists!(public, "_included.css"));
     assert!(file_exists!(public, "scss.css"));
+    assert!(file_exists!(public, "sass.css"));
+    assert!(file_exists!(public, "nested_sass/sass.css"));
     assert!(file_exists!(public, "nested_sass/scss.css"));
 
     // no live reload code


### PR DESCRIPTION
Add support for [indented syntax in SASS](http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html) via the `sass` file extension (instead of `scss`) for files inside the `sass` folder.