### PR TITLE
Anchor tag for summary

### DIFF
--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -170,7 +170,7 @@ impl Page {
             permalinks,
             anchor_insert
         );
-        let res = markdown_to_html(&self.raw_content, &context)?;
+        let res = markdown_to_html(&self.raw_content.replacen("<!-- more -->", "<a name=\"more\"></a>", 1), &context)?;
         self.content = res.0;
         self.toc = res.1;
         if self.raw_content.contains("<!-- more -->") {

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -170,7 +170,7 @@ impl Page {
             permalinks,
             anchor_insert
         );
-        let res = markdown_to_html(&self.raw_content.replacen("<!-- more -->", "<a name=\"more\"></a>", 1), &context)?;
+        let res = markdown_to_html(&self.raw_content.replacen("<!-- more -->", "<a name=\"continue-reading\"></a>", 1), &context)?;
         self.content = res.0;
         self.toc = res.1;
         if self.raw_content.contains("<!-- more -->") {

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -80,4 +80,4 @@ in the [template](./documentation/templates/pages-sections.md#page-variables).
 
 An anchor link to this position is created so you can link directly to it if needed
 for example:
-`<a href="{{ page.permalink }}#more">Continue Reading</a>`
+`<a href="{{ page.permalink }}#continue-reading">Continue Reading</a>`

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -77,3 +77,7 @@ paragraph of each page in a list for example.
 To do so, add `<!-- more -->` in your content at the point where you want the
 summary to end and the content up to that point will be also available separately
 in the [template](./documentation/templates/pages-sections.md#page-variables).
+
+An anchor link to this position is created so you can link directly to it if needed
+for example:
+`<a href="{{ page.permalink }}#more">Continue Reading</a>`


### PR DESCRIPTION
A simple addition, which allows you to use something like the following on your index page:

```htmldjango
{% block content %}                                                                                                                                    
    {% for page in paginator.pages %}
        <h1>{{ page.title }}</h1>
        {{ page.summary | safe }}
        <a href="{{ page.permalink }}#more">Continue Reading</a>
    {% endfor %}
{% endblock content %}
```

The `#more` anchor link directs you to the position after the summary, rather than having to scroll to this point yourself.