### PR TITLE
Obfuscate <!-- more --> in docs so that it doesn't get replaced

### DIFF
--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -74,9 +74,10 @@ Some content
 You can ask Gutenberg to create a summary if you only want to show the first 
 paragraph of each page in a list for example.
 
-To do so, add `<!-- more -->` in your content at the point where you want the
-summary to end and the content up to that point will be also available separately
-in the [template](./documentation/templates/pages-sections.md#page-variables).
+To do so, add <code>&lt;!-- more --&gt;</code> in your content at the point
+where you want the summary to end and the content up to that point will be also
+available separately in the
+[template](./documentation/templates/pages-sections.md#page-variables).
 
 An anchor link to this position named `continue-reading` is created so you can link 
 directly to it if needed for example:


### PR DESCRIPTION
Obfuscate `<!-- more -->` in docs so that it doesn't get replaced with `<a name="continue-reading"></a>`.

Basically, this on the [website|https://www.getgutenberg.io/documentation/content/page/#summary]:

> To do so, add `<a name="continue-reading"></a>` in your content at the point where you want the summary to end and the content up to that point will be also available separately in the template.

should be:

> To do so, add `<!-- more -->` in your content at the point where you want the summary to end and the content up to that point will be also available separately in the template.