### PR TITLE
Allow creation of specific html aliases

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -604,13 +604,13 @@ impl Site {
 
                 // If the alias ends with an html file name, use that instead of mapping
                 // as a path containing an `index.html`
-                let page_name: String = match split.pop() {
-                    Some(part) if part.ends_with(".html") => part.to_string(),
+                let page_name = match split.pop() {
+                    Some(part) if part.ends_with(".html") => part,
                     Some(part) => {
                         split.push(part);
-                        "index.html".into()
+                        "index.html"
                     }
-                    None => "index.html".into()
+                    None => "index.html"
                 };
 
                 for component in split {
@@ -620,7 +620,7 @@ impl Site {
                         create_directory(&output_path)?;
                     }
                 }
-                create_file(&output_path.join(&page_name), &render_redirect_template(&page.permalink, &self.tera)?)?;
+                create_file(&output_path.join(page_name), &render_redirect_template(&page.permalink, &self.tera)?)?;
             }
         }
         Ok(())

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -128,6 +128,10 @@ fn can_build_site_without_live_reload() {
     assert!(file_exists!(public, "an-old-url/old-page/index.html"));
     assert!(file_contains!(public, "an-old-url/old-page/index.html", "something-else"));
 
+    // html aliases work
+    assert!(file_exists!(public, "an-old-url/an-old-alias.html"));
+    assert!(file_contains!(public, "an-old-url/an-old-alias.html", "something-else"));
+
     // redirect_to works
     assert!(file_exists!(public, "posts/tutorials/devops/index.html"));
     assert!(file_contains!(public, "posts/tutorials/devops/index.html", "docker"));

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -23,7 +23,7 @@ description = ""
 # The date of the post.
 # 2 formats are allowed: YYYY-MM-DD (2012-10-02) and RFC3339 (2002-10-02T15:00:00Z)
 # Do not wrap dates in quotes, the line below only indicates that there is no default date
-date = 
+date =
 
 # A draft page will not be present in prev/next pagination
 draft = false
@@ -50,12 +50,17 @@ order = 0
 # The weight as defined in the Section page
 weight = 0
 
-# Use aliases if you are moving content but want to redirect previous URLs to the 
-# current one. This takes an array of path, not URLs.
+# Use aliases if you are moving content but want to redirect previous URLs to the
+# current one. Each element in the array of aliases may take one of two forms:
+#   * "some/alias/path", which will generate "some/alias/path/index.html"
+#   * "some/alias/path.html", which will generate "some/alias/path.html"
+#
+# The former is useful if your previous site had the form "example.com/some/alias/path",
+# the latter is useful if your previous site had the form "example.com/some/alias/path.html"
 aliases = []
 
 # Whether the page should be in the search index. This is only used if
-# `build_search_index` is set to true in the config and the parent section 
+# `build_search_index` is set to true in the config and the parent section
 # hasn't set `in_search_index` to false in its front-matter
 in_search_index = true
 
@@ -71,7 +76,7 @@ Some content
 
 ## Summary
 
-You can ask Gutenberg to create a summary if you only want to show the first 
+You can ask Gutenberg to create a summary if you only want to show the first
 paragraph of each page in a list for example.
 
 To do so, add <code>&lt;!-- more --&gt;</code> in your content at the point
@@ -79,6 +84,6 @@ where you want the summary to end and the content up to that point will be also
 available separately in the
 [template](./documentation/templates/pages-sections.md#page-variables).
 
-An anchor link to this position named `continue-reading` is created so you can link 
+An anchor link to this position named `continue-reading` is created so you can link
 directly to it if needed for example:
 `<a href="{{ page.permalink }}#continue-reading">Continue Reading</a>`

--- a/test_site/content/posts/fixed-slug.md
+++ b/test_site/content/posts/fixed-slug.md
@@ -3,7 +3,7 @@ title = "Fixed slug"
 description = ""
 slug = "something-else"
 date = 2017-01-01
-aliases = ["/an-old-url/old-page"]
+aliases = ["/an-old-url/old-page", "/an-old-url/an-old-alias.html"]
 +++
 
 A simple page with a slug defined


### PR DESCRIPTION
Hey there,

I wrote this change before realizing that the existing behavior of taking the alias `foo/bar/baz.html` and creating `foo/bar/baz.html/index.html` worked sufficiently.

I thought I would offer it up in case you would prefer the behavior of creating `foo/bar/baz.html` directly instead of `foo/bar/baz.html/index.html`, but if not, feel free to reject the PR.

Thanks for all the work with Gutenberg, porting my Jekyll based blog has been pretty painless so far!