### PR TITLE
Use proper Unicode word count; fixes #304

### DIFF
--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
 [dependencies]
 errors = { path = "../errors" }
 tera = "0.11"
+unicode-segmentation = "1.2"
 walkdir = "2"
-
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/components/utils/src/site.rs
+++ b/components/utils/src/site.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
+use unicode_segmentation::UnicodeSegmentation;
 
 use errors::Result;
 
 /// Get word count and estimated reading time
 pub fn get_reading_analytics(content: &str) -> (usize, usize) {
-    // Only works for latin language but good enough for a start
-    let word_count: usize = content.split_whitespace().count();
+    let word_count: usize = content.unicode_words().count();
 
     // https://help.medium.com/hc/en-us/articles/214991667-Read-time
     // 275 seems a bit too high though

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -63,7 +63,7 @@ extra: HashMap<String, Any>;
 pages: Array<Pages>;
 // Direct subsections to this section, sorted by subsections weight
 subsections: Array<Section>;
-// Naive word count, will not work for languages without whitespace
+// Unicode word count
 word_count: Number;
 // Based on https://help.medium.com/hc/en-us/articles/214991667-Read-time
 reading_time: Number;


### PR DESCRIPTION
This pulls in a dependency on the `unicode-segmentation` crate, which is relatively small. Now, the word count will be based off of the Unicode definition of word boundaries, rather than just whitespace, which will give a more accurate count for more languages. It also will give a more accurate count in languages with whitespace as well.