### PR TITLE
Fix panicking handling content file without extension

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -253,7 +253,7 @@ fn is_temp_file(path: &Path) -> bool {
             }
         },
         None => {
-            path.ends_with(".DS_STORE")
+            true
         },
     }
 }


### PR DESCRIPTION
Prevent panic when there're events for files without extension in `content` folder.

Somehow, when I update file using vim, it also generate events for some unknown number-only filename in that folder.
For example, after editing `my_blog.md`:

```
-> Content changed /Workspace/SideProject/blog/content/my_blog.md
Done in 56ms.

Change detected @ 2018-06-03 02:36:21
-> Content changed /Workspace/SideProject/blog/content/4913
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', libcore/option.rs:335:21
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```