### PR TITLE
Custom 404 page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ term-painter = "0.2"
 url = "1.5"
 # Below is for the serve cmd
 actix = "~0.5"
-actix-web = "0.6"
+actix-web = "~0.6"
 notify = "4"
 ws = "0.7"
 ctrlc = "3"

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -526,6 +526,7 @@ impl Site {
         if self.config.generate_rss {
             self.render_rss_feed()?;
         }
+        self.render_404()?;
         self.render_robots()?;
         // `render_categories` and `render_tags` will check whether the config allows
         // them to render or not
@@ -658,6 +659,15 @@ impl Site {
             }
         }
         Ok(())
+    }
+
+    /// Renders 404.html
+    pub fn render_404(&self) -> Result<()> {
+        ensure_directory_exists(&self.output_path)?;
+        create_file(
+            &self.output_path.join("404.html"),
+            &render_template("404.html", &self.tera, &Context::new(), &self.config.theme)?
+        )
     }
 
     /// Renders robots.txt

--- a/components/templates/src/builtins/404.html
+++ b/components/templates/src/builtins/404.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+    <head>
+        <title>File Not Found: 404.</title>
+    </head>
+    <body>
+        <h1>Oops!</h1>
+        <h2>File Not Found: 404.</h2>
+    </body>
+</html>

--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -24,6 +24,7 @@ lazy_static! {
     pub static ref GUTENBERG_TERA: Tera = {
         let mut tera = Tera::default();
         tera.add_raw_templates(vec![
+            ("404.html", include_str!("builtins/404.html")),
             ("rss.xml", include_str!("builtins/rss.xml")),
             ("sitemap.xml", include_str!("builtins/sitemap.xml")),
             ("robots.txt", include_str!("builtins/robots.txt")),


### PR DESCRIPTION
Looking over the original discussion on #296, there was some talk about whether there should be a template or if this should be a plain static file. I haven't yet looked at how/where the default templates are, or how to add a new one, so to start I've opted to use the static file approach from the original PR.

I've adapted the original rev via rebase so as to not erase @m-laniakea's contribution, but I've omitted the "plug the status code into the target file name"  bit since I don't see the value in responding to much more than 404. There could be a case for 403 but there is a quick slide from here to "why doesn't gutenberg provide a production http server?"

I think 404 is the only sane default we can provide without slipping.

Lingering questions:

* Should the target page be a template? If so, how to introduce a new default template?
* If remaining as a static file, should there be a config option to specify the file rather than hardcoding the path?

EDIT: I should also call out that an earlier rev where `cargo update` happened broke the server. I tightened up the version spec for actix in 56033e37, but this is something to look out for moving forward (I guess). actix 0.6 appears to not be compatible with actix-web 0.6.