### PR TITLE
Edit docs to clarify RSS process

### DIFF
--- a/docs/content/documentation/templates/rss.md
+++ b/docs/content/documentation/templates/rss.md
@@ -3,9 +3,12 @@ title = "RSS"
 weight = 50
 +++
 
-Gutenberg will look for a `rss.xml` file in the `templates` directory or 
-use the built-in one. Currently it is only possible to have one RSS feed for the whole
-site, you cannot create a RSS feed per section or taxonomy.
+If the site `config.toml` file sets `generate_rss = true`, then Gutenberg will 
+generate an `rss.xml` page for the site, which will live at `base_url/rss.xml`. To
+generate the `rss.xml` page, Gutenberg will look for a `rss.xml` file in the `templates`
+directory or, if one does not exist, will use the use the built-in rss template.
+Currently it is only possible to have one RSS feed for the whole site; you cannot
+create a RSS feed per section or taxonomy.
 
 **Only pages with a date and that are not draft will be available.**
 


### PR DESCRIPTION
I intially had some dificulty with the process for setting up the RSS feed for my site: I read the RSS page in the documentation, and thought that an RSS page would be automatically generated.  After one was not generated, I spent some time troubleshooting, and then realized that I had missed the mention of the `generate_rss = true` setting in the Configuration page in the docs.  I [posted about the issue](https://fosstodon.org/@codesections/100339377455576322) on social media and got a reply from somone who said the same thing had happened to them.

To avoid this confusion, I suggest adding details to the templates/RSS page to clarify that the `rss.xml`page is only generated if the `generate_rss = true` variable is setin the site's `config.toml` page.  This information is already present in other parts of the documentation, but is not present in the RSS page.