### PR TITLE
Add a link to a live demo for the After Dark theme

### DIFF
--- a/docs/content/themes/after-dark/index.md
+++ b/docs/content/themes/after-dark/index.md
@@ -10,6 +10,7 @@ created = 2018-02-22T19:13:36+01:00
 updated = 2017-11-07T17:39:37+01:00
 repository = "https://github.com/Keats/after-dark"
 homepage = "https://github.com/Keats/after-dark"
+live_demo = "https://after-dark--gutenberg-theme-demo.netlify.com/"
 minimum_version = "0.2"
 license = "MIT"
 

--- a/docs/content/themes/after-dark/index.md
+++ b/docs/content/themes/after-dark/index.md
@@ -10,7 +10,6 @@ created = 2018-02-22T19:13:36+01:00
 updated = 2017-11-07T17:39:37+01:00
 repository = "https://github.com/Keats/after-dark"
 homepage = "https://github.com/Keats/after-dark"
-live_demo = "https://after-dark--gutenberg-theme-demo.netlify.com/"
 minimum_version = "0.2"
 license = "MIT"
 

--- a/docs/templates/theme.html
+++ b/docs/templates/theme.html
@@ -10,6 +10,9 @@
             <p><b>Author:</b> {{page.extra.author.name}}</p>
             <p><b>License:</b> {{page.extra.license}}</p>
             <p><b>Homepage:</b> <a href="{{page.extra.homepage}}">{{page.extra.homepage}}</a></p>
+            {% if page.extra.live_demo%}
+              <p><b>Live Demo:</b> <a href="{{page.extra.live_demo}}">{{page.extra.live_demo}}</a></p>
+            {% endif %}
             <p><b>Last updated:</b> {{page.extra.updated }}</p>
         </div>
     </div>


### PR DESCRIPTION
After hearing no objection to the plan I suggested in issue #332, I went ahead and put together a live site that demos the After Dark theme (I plan to do them all, and started with After Dark simply because it comes first alphabetically).  The demo site is available at <https://after-dark--gutenberg-theme-demo.netlify.com/>.

One reason I think that live demos would be helpful is that Hugo tends to have them (see, e.g, <https://themes.gohugo.io/theme/after-dark/>), and I found them to be much more helpful in getting a feel for a theme than a screenshot or description is.

Happy to make any changes to this commit or to the live demo if you would like.