### PR TITLE
Update comparison in README for Hugo 0.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ in the `docs/content` folder of the repository.
 | Single binary            |     ✔     |    ✔   |   ✔  |    ✕    |
 | Language                 |    Rust   |  Rust  |  Go  |  Python |
 | Syntax highlighting      |     ✔     |    ✔   |   ✔  |    ✔    |
-| Sass compilation         |     ✔     |    ✕   |   ✕  |    ✔    |
+| Sass compilation         |     ✔     |    ✕   |      |    ✔    |
 | Assets co-location       |     ✔     |    ✔   |   ✔  |    ✔    |
 | i18n                     |     ✕     |    ✕   |   ✔  |    ✔    |
 | Image processing         |     ✕     |    ✕   |   ✔  |    ✔    |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ in the `docs/content` folder of the repository.
 | Single binary            |     ✔     |    ✔   |   ✔  |    ✕    |
 | Language                 |    Rust   |  Rust  |  Go  |  Python |
 | Syntax highlighting      |     ✔     |    ✔   |   ✔  |    ✔    |
-| Sass compilation         |     ✔     |    ✕   |      |    ✔    |
+| Sass compilation         |     ✔     |    ✕   |   ✔  |    ✔    |
 | Assets co-location       |     ✔     |    ✔   |   ✔  |    ✔    |
 | i18n                     |     ✕     |    ✕   |   ✔  |    ✔    |
 | Image processing         |     ✕     |    ✕   |   ✔  |    ✔    |


### PR DESCRIPTION
As of version 0.43, Hugo now supports Sass compilation and minification, unfortunately for Gutenberg's competitive edge (but fortunately for the overall ecosystem of static site generators).  See <https://gohugo.io/news/0.43-relnotes/>