### PR TITLE
Remove www.bharatkalluri.in from EXAMPLES.md

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,18 +1,19 @@
 # Example sites
 
-- [vincent.is](https://vincent.is): https://gitlab.com/Keats/vincent.is
-- [code<future](http://www.codelessfuture.com/)
-- http://t-rex.tileserver.ch (https://github.com/pka/t-rex-website/)
-- [adrien.is](https://adrien.is): https://github.com/Fandekasp/fandekasp.github.io
-- [Philipp Oppermann's blog](https://os.phil-opp.com/): https://github.com/phil-opp/blog_os/tree/master/blog
-- [seventeencups](https://www.seventeencups.net): https://github.com/17cupsofcoffee/seventeencups.net
-- [j1m.net](https://j1m.net): https://gitlab.com/jwcampbell/j1mnet
-- [vaporsoft.net](http://vaporsoft.net): https://github.com/piedoom/vaporsoft
-- [verpeteren.nl](http://www.verpeteren.nl)
-- [atlasreports.nl](http://www.atlasreports.nl)
-- [groksome.com](http://www.groksome.com)
-- [tuckersiemens.com](https://tuckersiemens.com): https://github.com/reillysiemens/tuckersiemens.com
-- [andrei.blue](https://andrei.blue): https://github.com/azah/personal-blog
-- [Axiomatic Semantics](https://axiomatic.neophilus.net): https://github.com/Libbum/AxiomaticSemantics
-- [Tinkering](https://tinkering.xyz)
-- [Daniel Sockwell's codesections.com](https://www.codesections.com): https://gitlab.com/codesections/codesections-website
+| Site                                                               |                   Source Code                        |
+|:-------------------------------------------------------------------|:----------------------------------------------------:|
+| [vincent.is](https://vincent.is)                                   | https://gitlab.com/Keats/vincent.is                  |
+| [code<future](http://www.codelessfuture.com/)                      |                                                      |
+| http://t-rex.tileserver.ch                                         | https://github.com/pka/t-rex-website/                |
+| [Philipp Oppermann's blog](https://os.phil-opp.com/)               | https://github.com/phil-opp/blog_os/tree/master/blog |
+| [seventeencups](https://www.seventeencups.net)                     | https://github.com/17cupsofcoffee/seventeencups.net  |
+| [j1m.net](https://j1m.net)                                         | https://gitlab.com/jwcampbell/j1mnet                 |
+| [vaporsoft.net](http://vaporsoft.net)                              | https://github.com/piedoom/vaporsoft                 |
+| [verpeteren.nl](http://www.verpeteren.nl)                          |                                                      |
+| [atlasreports.nl](http://www.atlasreports.nl)                      |                                                      |
+| [groksome.com](http://www.groksome.com)                            |                                                      |
+| [tuckersiemens.com](https://tuckersiemens.com)                     | https://github.com/reillysiemens/tuckersiemens.com   |
+| [andrei.blue](https://andrei.blue)                                 | https://github.com/azah/personal-blog                |
+| [Axiomatic Semantics](https://axiomatic.neophilus.net)             | https://github.com/Libbum/AxiomaticSemantics         |
+| [Tinkering](https://tinkering.xyz)                                 |                                                      |
+| [Daniel Sockwell's codesections.com](https://www.codesections.com) | https://gitlab.com/codesections/codesections-website |

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -8,7 +8,6 @@
 - [seventeencups](https://www.seventeencups.net): https://github.com/17cupsofcoffee/seventeencups.net
 - [j1m.net](https://j1m.net): https://gitlab.com/jwcampbell/j1mnet
 - [vaporsoft.net](http://vaporsoft.net): https://github.com/piedoom/vaporsoft
-- [bharatkalluri.in](https://bharatkalluri.in): https://github.com/BharatKalluri/Blog
 - [verpeteren.nl](http://www.verpeteren.nl)
 - [atlasreports.nl](http://www.atlasreports.nl)
 - [groksome.com](http://www.groksome.com)


### PR DESCRIPTION
The footer and source code at <https://www.bharatkalluri.in/> state that the site was made with Hugo, so it should be deleted as an example of a Gutenberg site.

I considered also removing the link to https://adrien.is/, since the link appears to be dead.  But I left it for now, since that could be a temporary outage.

If you would like, I'd be happy to format EXAMPLES.md as a table, which might help keep it looking clean as it gets more entries.