### PR TITLE
Runtime syntax loading

### DIFF
--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -107,6 +107,9 @@ pub struct Config {
     /// Whether to check all external links for validity
     pub check_external_links: bool,
 
+    /// A list of directories containing extra syntax definitions to load.
+    pub extra_syntaxes: Vec<String>,
+
     /// All user params set in [extra] in the config
     pub extra: HashMap<String, Toml>,
 
@@ -233,6 +236,7 @@ impl Default for Config {
             ignored_content: Vec::new(),
             ignored_content_globset: None,
             translations: HashMap::new(),
+            extra_syntaxes: Vec::new(),
             extra: HashMap::new(),
             build_timestamp: Some(1),
         }

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -166,12 +166,13 @@ impl Page {
 
     /// We need access to all pages url to render links relative to content
     /// so that can't happen at the same time as parsing
-    pub fn render_markdown(&mut self, permalinks: &HashMap<String, String>, tera: &Tera, config: &Config, anchor_insert: InsertAnchor) -> Result<()> {
+    pub fn render_markdown(&mut self, permalinks: &HashMap<String, String>, tera: &Tera, config: &Config, base_path: &Path, anchor_insert: InsertAnchor) -> Result<()> {
         let mut context = RenderContext::new(
             tera,
             config,
             &self.permalink,
             permalinks,
+            base_path,
             anchor_insert,
         );
 

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -123,12 +123,13 @@ impl Section {
 
     /// We need access to all pages url to render links relative to content
     /// so that can't happen at the same time as parsing
-    pub fn render_markdown(&mut self, permalinks: &HashMap<String, String>, tera: &Tera, config: &Config) -> Result<()> {
+    pub fn render_markdown(&mut self, permalinks: &HashMap<String, String>, tera: &Tera, config: &Config, base_path: &Path) -> Result<()> {
         let mut context = RenderContext::new(
             tera,
             config,
             &self.permalink,
             permalinks,
+            base_path,
             self.meta.insert_anchor_links,
         );
 

--- a/components/highlighting/src/lib.rs
+++ b/components/highlighting/src/lib.rs
@@ -3,6 +3,7 @@ extern crate lazy_static;
 extern crate syntect;
 
 use std::cell::RefCell;
+use std::path::Path;
 
 use syntect::LoadingError;
 use syntect::dumps::from_binary;
@@ -23,12 +24,12 @@ lazy_static! {
     pub static ref THEME_SET: ThemeSet = from_binary(include_bytes!("../../../sublime_themes/all.themedump"));
 }
 
-pub fn get_highlighter<'a>(theme: &'a Theme, info: &str, extra_syntaxes: &[String]) -> Result<HighlightLines<'a>, LoadingError> {
+pub fn get_highlighter<'a>(theme: &'a Theme, info: &str, base_path: &Path, extra_syntaxes: &[String]) -> Result<HighlightLines<'a>, LoadingError> {
     SYNTAX_SET.with(|rc| {
         let (ss, extras_added) = &mut *rc.borrow_mut();
         if !*extras_added {
             for dir in extra_syntaxes {
-                ss.load_syntaxes(dir, true)?;
+                ss.load_syntaxes(base_path.join(dir), true)?;
             }
             ss.link_syntaxes();
             *extras_added = true;

--- a/components/rendering/src/context.rs
+++ b/components/rendering/src/context.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use tera::{Tera, Context};
 use front_matter::InsertAnchor;
@@ -13,6 +14,7 @@ pub struct RenderContext<'a> {
     pub tera_context: Context,
     pub current_page_permalink: &'a str,
     pub permalinks: &'a HashMap<String, String>,
+    pub base_path: &'a Path,
     pub insert_anchor: InsertAnchor,
 }
 
@@ -22,6 +24,7 @@ impl<'a> RenderContext<'a> {
         config: &'a Config,
         current_page_permalink: &'a str,
         permalinks: &'a HashMap<String, String>,
+        base_path: &'a Path,
         insert_anchor: InsertAnchor,
     ) -> RenderContext<'a> {
         let mut tera_context = Context::new();
@@ -32,6 +35,7 @@ impl<'a> RenderContext<'a> {
             current_page_permalink,
             permalinks,
             insert_anchor,
+            base_path,
             config,
         }
     }

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -97,7 +97,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<(Strin
                     }
 
                     let theme = &THEME_SET.themes[&context.config.highlight_theme];
-                    match get_highlighter(&theme, info, &context.config.extra_syntaxes) {
+                    match get_highlighter(&theme, info, context.base_path, &context.config.extra_syntaxes) {
                         Ok(h) => highlighter = Some(h),
                         Err(err) => {
                             error = Some(format!("Could not load syntax: {}", err).into());

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -97,7 +97,13 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<(Strin
                     }
 
                     let theme = &THEME_SET.themes[&context.config.highlight_theme];
-                    highlighter = Some(get_highlighter(&theme, info));
+                    match get_highlighter(&theme, info, &context.config.extra_syntaxes) {
+                        Ok(h) => highlighter = Some(h),
+                        Err(err) => {
+                            error = Some(format!("Could not load syntax: {}", err).into());
+                            return Event::Html(Owned(String::new()));
+                        }
+                    }
                     let snippet = start_coloured_html_snippet(theme);
                     Event::Html(Owned(snippet))
                 }

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -258,6 +258,7 @@ impl Site {
         let permalinks = &self.permalinks;
         let tera = &self.tera;
         let config = &self.config;
+        let base_path = &self.base_path;
 
         // TODO: avoid the duplication with function above for that part
         // This is needed in the first place because of silly borrow checker
@@ -269,13 +270,13 @@ impl Site {
         self.pages.par_iter_mut()
             .map(|(_, page)| {
                 let insert_anchor = pages_insert_anchors[&page.file.path];
-                page.render_markdown(permalinks, tera, config, insert_anchor)
+                page.render_markdown(permalinks, tera, config, base_path, insert_anchor)
             })
             .fold(|| Ok(()), Result::and)
             .reduce(|| Ok(()), Result::and)?;
 
         self.sections.par_iter_mut()
-            .map(|(_, section)| section.render_markdown(permalinks, tera, config))
+            .map(|(_, section)| section.render_markdown(permalinks, tera, config, base_path))
             .fold(|| Ok(()), Result::and)
             .reduce(|| Ok(()), Result::and)?;
 
@@ -318,7 +319,7 @@ impl Site {
         if render {
             let insert_anchor = self.find_parent_section_insert_anchor(&self.pages[&path].file.parent);
             let page = self.pages.get_mut(&path).unwrap();
-            page.render_markdown(&self.permalinks, &self.tera, &self.config, insert_anchor)?;
+            page.render_markdown(&self.permalinks, &self.tera, &self.config, &self.base_path, insert_anchor)?;
         }
 
         Ok(prev)
@@ -335,7 +336,7 @@ impl Site {
 
         if render {
             let section = self.sections.get_mut(&path).unwrap();
-            section.render_markdown(&self.permalinks, &self.tera, &self.config)?;
+            section.render_markdown(&self.permalinks, &self.tera, &self.config, &self.base_path)?;
         }
 
         Ok(prev)

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -19,7 +19,7 @@ fn can_parse_site() {
     site.load().unwrap();
 
     // Correct number of pages (sections are pages too)
-    assert_eq!(site.pages.len(), 14);
+    assert_eq!(site.pages.len(), 15);
     let posts_path = path.join("content").join("posts");
 
     // Make sure we remove all the pwd + content from the sections
@@ -44,7 +44,7 @@ fn can_parse_site() {
 
     let posts_section = &site.sections[&posts_path.join("_index.md")];
     assert_eq!(posts_section.subsections.len(), 1);
-    assert_eq!(posts_section.pages.len(), 6);
+    assert_eq!(posts_section.pages.len(), 7);
 
     let tutorials_section = &site.sections[&posts_path.join("tutorials").join("_index.md")];
     assert_eq!(tutorials_section.subsections.len(), 2);
@@ -321,22 +321,41 @@ fn can_build_site_with_pagination_for_section() {
         "posts/page/1/index.html",
         "http-equiv=\"refresh\" content=\"0;url=https://replace-this-with-your-url.com/posts/\""
     ));
-    assert!(file_contains!(public, "posts/index.html", "Num pagers: 3"));
+    assert!(file_contains!(public, "posts/index.html", "Num pagers: 4"));
     assert!(file_contains!(public, "posts/index.html", "Page size: 2"));
     assert!(file_contains!(public, "posts/index.html", "Current index: 1"));
+    assert!(!file_contains!(public, "posts/index.html", "has_prev"));
     assert!(file_contains!(public, "posts/index.html", "has_next"));
     assert!(file_contains!(public, "posts/index.html", "First: https://replace-this-with-your-url.com/posts/"));
-    assert!(file_contains!(public, "posts/index.html", "Last: https://replace-this-with-your-url.com/posts/page/3/"));
+    assert!(file_contains!(public, "posts/index.html", "Last: https://replace-this-with-your-url.com/posts/page/4/"));
     assert_eq!(file_contains!(public, "posts/index.html", "has_prev"), false);
 
     assert!(file_exists!(public, "posts/page/2/index.html"));
-    assert!(file_contains!(public, "posts/page/2/index.html", "Num pagers: 3"));
+    assert!(file_contains!(public, "posts/page/2/index.html", "Num pagers: 4"));
     assert!(file_contains!(public, "posts/page/2/index.html", "Page size: 2"));
     assert!(file_contains!(public, "posts/page/2/index.html", "Current index: 2"));
     assert!(file_contains!(public, "posts/page/2/index.html", "has_prev"));
     assert!(file_contains!(public, "posts/page/2/index.html", "has_next"));
     assert!(file_contains!(public, "posts/page/2/index.html", "First: https://replace-this-with-your-url.com/posts/"));
-    assert!(file_contains!(public, "posts/page/2/index.html", "Last: https://replace-this-with-your-url.com/posts/page/3/"));
+    assert!(file_contains!(public, "posts/page/2/index.html", "Last: https://replace-this-with-your-url.com/posts/page/4/"));
+
+    assert!(file_exists!(public, "posts/page/3/index.html"));
+    assert!(file_contains!(public, "posts/page/3/index.html", "Num pagers: 4"));
+    assert!(file_contains!(public, "posts/page/3/index.html", "Page size: 2"));
+    assert!(file_contains!(public, "posts/page/3/index.html", "Current index: 3"));
+    assert!(file_contains!(public, "posts/page/3/index.html", "has_prev"));
+    assert!(file_contains!(public, "posts/page/3/index.html", "has_next"));
+    assert!(file_contains!(public, "posts/page/3/index.html", "First: https://replace-this-with-your-url.com/posts/"));
+    assert!(file_contains!(public, "posts/page/3/index.html", "Last: https://replace-this-with-your-url.com/posts/page/4/"));
+
+    assert!(file_exists!(public, "posts/page/4/index.html"));
+    assert!(file_contains!(public, "posts/page/4/index.html", "Num pagers: 4"));
+    assert!(file_contains!(public, "posts/page/4/index.html", "Page size: 2"));
+    assert!(file_contains!(public, "posts/page/4/index.html", "Current index: 4"));
+    assert!(file_contains!(public, "posts/page/4/index.html", "has_prev"));
+    assert!(!file_contains!(public, "posts/page/4/index.html", "has_next"));
+    assert!(file_contains!(public, "posts/page/4/index.html", "First: https://replace-this-with-your-url.com/posts/"));
+    assert!(file_contains!(public, "posts/page/4/index.html", "Last: https://replace-this-with-your-url.com/posts/page/4/"));
 }
 
 #[test]
@@ -397,10 +416,10 @@ fn can_build_rss_feed() {
 
     assert!(Path::new(&public).exists());
     assert!(file_exists!(public, "rss.xml"));
-    // latest article is posts/simple.md
+    // latest article is posts/extra-syntax.md
+    assert!(file_contains!(public, "rss.xml", "Extra Syntax"));
+    // Next is posts/simple.md
     assert!(file_contains!(public, "rss.xml", "Simple article with shortcodes"));
-    // Next is posts/python.md
-    assert!(file_contains!(public, "rss.xml", "Python in posts"));
 }
 
 
@@ -419,4 +438,21 @@ fn can_build_search_index() {
     assert!(Path::new(&public).exists());
     assert!(file_exists!(public, "elasticlunr.min.js"));
     assert!(file_exists!(public, "search_index.en.js"));
+}
+
+#[test]
+fn can_build_with_extra_syntaxes() {
+    let mut path = env::current_dir().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
+    path.push("test_site");
+    let mut site = Site::new(&path, "config.toml").unwrap();
+    site.load().unwrap();
+    let tmp_dir = tempdir().expect("create temp dir");
+    let public = &tmp_dir.path().join("public");
+    site.set_output_path(&public);
+    site.build().unwrap();
+
+    assert!(&public.exists());
+    assert!(file_exists!(public, "posts/extra-syntax/index.html"));
+    assert!(file_contains!(public, "posts/extra-syntax/index.html",
+        r#"<span style="background-color:#2b303b;color:#d08770;">test</span>"#));
 }

--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -106,3 +106,23 @@ Here is a full list of the supported languages and the short names you can use:
 ```
 
 If you want to highlight a language not on that list, please open an issue or a pull request on the [Gutenberg repo](https://github.com/Keats/gutenberg).
+Alternatively, the `extra_syntaxes` config option can be used to add additional syntax files.
+
+If your site source is laid out as follows:
+
+```
+.
+├── config.toml
+├── content/
+│   └── ...
+├── static/
+│   └── ...
+├── syntaxes/
+│   ├── Sublime-Language1/
+│   │   └── lang1.sublime-syntax
+│   └── lang2.sublime-syntax
+└── templates/
+    └── ...
+```
+
+you would set your `extra_syntaxes` to `["syntaxes", "syntaxes/Sublime-Language1"]` in order to load `lang1.sublime-syntax` and `lang2.sublime-syntax`.

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -70,6 +70,9 @@ check_external_links = false
 #     ignored_content = ["*.{graphml,xlsx}", "temp.*"]
 ignored_content = []
 
+# A list of directories to search for additional `.sublime-syntax` files in.
+extra_syntaxes = []
+
 # Optional translation object. The key if present should be a language code
 [translations]
 

--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -10,5 +10,7 @@ taxonomies = [
     {name = "categories", rss = true},
 ]
 
+extra_syntaxes = ["syntaxes"]
+
 [extra.author]
 name = "Vincent Prouillet"

--- a/test_site/content/posts/extra_syntax.md
+++ b/test_site/content/posts/extra_syntax.md
@@ -1,0 +1,9 @@
++++
+title = "Extra Syntax"
+description = ""
+date = 2018-08-14
++++
+
+```test-syntax
+This is a test code snippet.
+```

--- a/test_site/syntaxes/test.sublime-syntax
+++ b/test_site/syntaxes/test.sublime-syntax
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+file_extensions:
+  - test-syntax
+scope: source.test
+
+contexts:
+  main:
+    - match: "test"
+      scope: constant.language.test


### PR DESCRIPTION
Resolves #262.

I'm less-than-100% sure that https://github.com/remexre/gutenberg/blob/64fa890aa96a2aea351ed3ebe3257ed4b6d5dde5/components/rendering/src/markdown.rs#L104 is an appropriate course of action, but other than that, I've tested this on my own project and it works.