### PR TITLE
Update page variable list for custom taxonomies

### DIFF
--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -25,8 +25,7 @@ draft: Bool;
 components: Array<String>;
 permalink: String;
 summary: String?;
-tags: Array<String>;
-category: String?;
+taxonomies: HashMap<String, Array<String>>;
 extra: HashMap<String, Any>;
 // Naive word count, will not work for languages without whitespace
 word_count: Number;


### PR DESCRIPTION
I love the new support for custom taxonomies! I got a little thrown off when updating my site, though, as the docs didn't specify how the page would expose the taxonomies to the template. Wasn't too hard to figure it out, but I figured I'd save the next person who tries it the effort :)