### PR TITLE
CSV and TOML loading global functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,23 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "csv"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,12 +2159,15 @@ dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.1.0",
  "content 0.1.0",
+ "csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "errors 0.1.0",
  "imageproc 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "taxonomies 0.1.0",
  "tera 0.11.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
 ]
 
@@ -2783,6 +2803,8 @@ dependencies = [
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
+"checksum csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71903184af9960c555e7f3b32ff17390d20ecaaf17d4f18c4a0993f2df8a49e3"
+"checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
 "checksum ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)" = "32c8120d981901a9970a3a1c97cf8b630e0fa8c3ca31e75b6fd6fd5f9f427b31"

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -306,6 +306,8 @@ impl Site {
             "get_taxonomy_url",
             global_fns::make_get_taxonomy_url(self.taxonomies.clone()),
         );
+        self.tera.register_global_function("load_toml", global_fns::make_load_toml(self.content_path.clone()));
+        self.tera.register_global_function("load_csv", global_fns::make_load_csv(self.content_path.clone()));
     }
 
     /// Add a page to the site

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -8,6 +8,9 @@ tera = "0.11"
 base64 = "0.9"
 lazy_static = "1"
 pulldown-cmark = "0"
+toml = "0.4"
+csv = "1"
+serde_json = "1.0"
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -4,6 +4,9 @@ extern crate lazy_static;
 extern crate tera;
 extern crate base64;
 extern crate pulldown_cmark;
+extern crate csv;
+#[macro_use]
+extern crate serde_json;
 
 extern crate errors;
 extern crate utils;

--- a/components/utils/test-files/test.csv
+++ b/components/utils/test-files/test.csv
@@ -1,0 +1,3 @@
+File,Description
+"Hello.png","a very special file"
+"goodbye.jpg","a not so special file"

--- a/components/utils/test-files/test.toml
+++ b/components/utils/test-files/test.toml
@@ -1,0 +1,2 @@
+[category]
+key = "value"

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -25,8 +25,7 @@ draft: Bool;
 components: Array<String>;
 permalink: String;
 summary: String?;
-tags: Array<String>;
-category: String?;
+taxonomies: HashMap<String, Array<String>>;
 extra: HashMap<String, Any>;
 // Naive word count, will not work for languages without whitespace
 word_count: Number;


### PR DESCRIPTION
This pull request adds the ability to load TOML files and CSV files into templates using these global functions: `load_csv` and `load_toml`

In the future it would also be cool to add:

 - More options for the CSV parser
 - Markdown table shortcode/filter/function which can load from CSV file.
