### PR TITLE
Improve summary handling

### DIFF
--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -185,19 +185,12 @@ impl Page {
 
         context.tera_context.add("page", self);
 
-        let res = render_content(
-            &self.raw_content.replacen("<!-- more -->", "<a name=\"continue-reading\"></a>", 1),
-            &context,
-        ).chain_err(|| format!("Failed to render content of {}", self.file.path.display()))?;
-        self.content = res.0;
-        self.toc = res.1;
-        if self.raw_content.contains("<!-- more -->") {
-            self.summary = Some({
-                let summary = self.raw_content.splitn(2, "<!-- more -->").collect::<Vec<&str>>()[0];
-                render_content(summary, &context)
-                    .chain_err(|| format!("Failed to render content of {}", self.file.path.display()))?.0
-            })
-        }
+        let res = render_content(&self.raw_content, &context)
+            .chain_err(|| format!("Failed to render content of {}", self.file.path.display()))?;
+
+        self.summary = res.summary_len.map(|l| res.body[0..l].to_owned());
+        self.content = res.body;
+        self.toc = res.toc;
 
         Ok(())
     }

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -137,8 +137,8 @@ impl Section {
 
         let res = render_content(&self.raw_content, &context)
             .chain_err(|| format!("Failed to render content of {}", self.file.path.display()))?;
-        self.content = res.0;
-        self.toc = res.1;
+        self.content = res.body;
+        self.toc = res.toc;
         Ok(())
     }
 

--- a/components/rendering/src/lib.rs
+++ b/components/rendering/src/lib.rs
@@ -32,7 +32,7 @@ pub use table_of_contents::Header;
 pub use shortcode::render_shortcodes;
 pub use context::RenderContext;
 
-pub fn render_content(content: &str, context: &RenderContext) -> Result<(String, Vec<Header>)> {
+pub fn render_content(content: &str, context: &RenderContext) -> Result<markdown::Rendered> {
     // Don't do anything if there is nothing like a shortcode in the content
     if content.contains("{{") || content.contains("{%") {
         let rendered = render_shortcodes(content, context)?;

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -76,7 +76,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                     if in_header {
                         if header_created {
                             temp_header.push(&text);
-                            return Event::Html(Owned(String::new()));
+                            return Event::Html(Borrowed(""));
                         }
                         let id = find_anchor(&anchors, slugify(&text), 0);
                         anchors.push(id.clone());
@@ -86,7 +86,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                         // += as we might have some <code> or other things already there
                         temp_header.title += &text;
                         header_created = true;
-                        return Event::Html(Owned(String::new()));
+                        return Event::Html(Borrowed(""));
                     }
 
                     // if we are in the middle of a code block
@@ -101,7 +101,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                 }
                 Event::Start(Tag::CodeBlock(ref info)) => {
                     if !context.config.highlight_code {
-                        return Event::Html(Owned("<pre><code>".to_string()));
+                        return Event::Html(Borrowed("<pre><code>"));
                     }
 
                     let theme = &THEME_SET.themes[&context.config.highlight_theme];
@@ -109,7 +109,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                         Ok(h) => highlighter = Some(h),
                         Err(err) => {
                             error = Some(format!("Could not load syntax: {}", err).into());
-                            return Event::Html(Owned(String::new()));
+                            return Event::Html(Borrowed(""));
                         }
                     }
                     let snippet = start_coloured_html_snippet(theme);
@@ -117,11 +117,11 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                 }
                 Event::End(Tag::CodeBlock(_)) => {
                     if !context.config.highlight_code {
-                        return Event::Html(Owned("</code></pre>\n".to_string()));
+                        return Event::Html(Borrowed("</code></pre>\n"));
                     }
                     // reset highlight and close the code block
                     highlighter = None;
-                    Event::Html(Owned("</pre>".to_string()))
+                    Event::Html(Borrowed("</pre>"))
                 }
                 Event::Start(Tag::Image(src, title)) => {
                     if is_colocated_asset_link(&src) {
@@ -147,7 +147,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                             Ok(url) => url,
                             Err(_) => {
                                 error = Some(format!("Relative link {} not found.", link).into());
-                                return Event::Html(Owned(String::new()));
+                                return Event::Html(Borrowed(""));
                             }
                         }
                     } else if is_colocated_asset_link(&link) {
@@ -175,7 +175,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                             format!("<a href=\"{}\" title=\"{}\">", fixed_link, title)
                         };
                         temp_header.push(&html);
-                        return Event::Html(Owned(String::new()));
+                        return Event::Html(Borrowed(""));
                     }
 
                     Event::Start(Tag::Link(Owned(fixed_link), title))
@@ -183,28 +183,28 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                 Event::End(Tag::Link(_, _)) => {
                     if in_header {
                         temp_header.push("</a>");
-                        return Event::Html(Owned(String::new()));
+                        return Event::Html(Borrowed(""));
                     }
                     event
                 }
                 Event::Start(Tag::Code) => {
                     if in_header {
                         temp_header.push("<code>");
-                        return Event::Html(Owned(String::new()));
+                        return Event::Html(Borrowed(""));
                     }
                     event
                 }
                 Event::End(Tag::Code) => {
                     if in_header {
                         temp_header.push("</code>");
-                        return Event::Html(Owned(String::new()));
+                        return Event::Html(Borrowed(""));
                     }
                     event
                 }
                 Event::Start(Tag::Header(num)) => {
                     in_header = true;
                     temp_header = TempHeader::new(num);
-                    Event::Html(Owned(String::new()))
+                    Event::Html(Borrowed(""))
                 }
                 Event::End(Tag::Header(_)) => {
                     // End of a header, reset all the things and return the stringified

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -16,6 +16,7 @@ use context::RenderContext;
 
 const CONTINUE_READING: &str = "<p><a name=\"continue-reading\"></a></p>\n";
 
+#[derive(Debug)]
 pub struct Rendered {
     pub body: String,
     pub summary_len: Option<usize>,

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -22,7 +22,7 @@ fn can_do_render_content_simple() {
     let config = Config::default();
     let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("hello", &context).unwrap();
-    assert_eq!(res.0, "<p>hello</p>\n");
+    assert_eq!(res.body, "<p>hello</p>\n");
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn doesnt_highlight_code_block_with_highlighting_off() {
     let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("```\n$ gutenberg server\n```", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<pre><code>$ gutenberg server\n</code></pre>\n"
     );
 }
@@ -47,7 +47,7 @@ fn can_highlight_code_block_no_lang() {
     let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("```\n$ gutenberg server\n$ ping\n```", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<pre style=\"background-color:#2b303b\">\n<span style=\"background-color:#2b303b;color:#c0c5ce;\">$ gutenberg server\n</span><span style=\"background-color:#2b303b;color:#c0c5ce;\">$ ping\n</span></pre>"
     );
 }
@@ -60,7 +60,7 @@ fn can_highlight_code_block_with_lang() {
     let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("```python\nlist.append(1)\n```", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<pre style=\"background-color:#2b303b\">\n<span style=\"background-color:#2b303b;color:#c0c5ce;\">list.</span><span style=\"background-color:#2b303b;color:#bf616a;\">append</span><span style=\"background-color:#2b303b;color:#c0c5ce;\">(</span><span style=\"background-color:#2b303b;color:#d08770;\">1</span><span style=\"background-color:#2b303b;color:#c0c5ce;\">)\n</span></pre>"
     );
 }
@@ -74,7 +74,7 @@ fn can_higlight_code_block_with_unknown_lang() {
     let res = render_content("```yolo\nlist.append(1)\n```", &context).unwrap();
     // defaults to plain text
     assert_eq!(
-        res.0,
+        res.body,
         "<pre style=\"background-color:#2b303b\">\n<span style=\"background-color:#2b303b;color:#c0c5ce;\">list.append(1)\n</span></pre>"
     );
 }
@@ -89,8 +89,8 @@ Hello
 
 {{ youtube(id="ub36ffWAqgQ") }}
     "#, &context).unwrap();
-    assert!(res.0.contains("<p>Hello</p>\n<div >"));
-    assert!(res.0.contains(r#"<iframe src="https://www.youtube.com/embed/ub36ffWAqgQ""#));
+    assert!(res.body.contains("<p>Hello</p>\n<div >"));
+    assert!(res.body.contains(r#"<iframe src="https://www.youtube.com/embed/ub36ffWAqgQ""#));
 }
 
 #[test]
@@ -106,7 +106,7 @@ fn can_render_shortcode_with_markdown_char_in_args_name() {
     ];
     for i in input {
         let res = render_content(&format!("{{{{ youtube(id=\"hey\", {}=1) }}}}", i), &context).unwrap();
-        assert!(res.0.contains(r#"<iframe src="https://www.youtube.com/embed/hey""#));
+        assert!(res.body.contains(r#"<iframe src="https://www.youtube.com/embed/hey""#));
     }
 }
 
@@ -124,7 +124,7 @@ fn can_render_shortcode_with_markdown_char_in_args_value() {
     ];
     for i in input {
         let res = render_content(&format!("{{{{ youtube(id=\"{}\") }}}}", i), &context).unwrap();
-        assert!(res.0.contains(&format!(r#"<iframe src="https://www.youtube.com/embed/{}""#, i)));
+        assert!(res.body.contains(&format!(r#"<iframe src="https://www.youtube.com/embed/{}""#, i)));
     }
 }
 
@@ -145,7 +145,7 @@ fn can_render_body_shortcode_with_markdown_char_in_name() {
 
         let res = render_content(&format!("{{% {}(author=\"Bob\") %}}\nhey\n{{% end %}}", i), &context).unwrap();
         println!("{:?}", res);
-        assert!(res.0.contains("<blockquote>hey - Bob</blockquote>"));
+        assert!(res.body.contains("<blockquote>hey - Bob</blockquote>"));
     }
 }
 
@@ -174,7 +174,7 @@ Here is another paragraph.
 
     let res = render_content(markdown_string, &context).unwrap();
     println!("{:?}", res);
-    assert_eq!(res.0, expected);
+    assert_eq!(res.body, expected);
 }
 
 #[test]
@@ -207,7 +207,7 @@ Here is another paragraph.
 
     let res = render_content(markdown_string, &context).unwrap();
     println!("{:?}", res);
-    assert_eq!(res.0, expected);
+    assert_eq!(res.body, expected);
 }
 
 #[test]
@@ -229,11 +229,11 @@ Hello
 {{ gist(url="https://gist.github.com/Keats/32d26f699dcc13ebd41b") }}
 
     "#, &context).unwrap();
-    assert!(res.0.contains("<p>Hello</p>\n<div >"));
-    assert!(res.0.contains(r#"<iframe src="https://www.youtube.com/embed/ub36ffWAqgQ""#));
-    assert!(res.0.contains(r#"<iframe src="https://www.youtube.com/embed/ub36ffWAqgQ?autoplay=1""#));
-    assert!(res.0.contains(r#"<iframe src="https://www.streamable.com/e/c0ic""#));
-    assert!(res.0.contains(r#"//player.vimeo.com/video/210073083""#));
+    assert!(res.body.contains("<p>Hello</p>\n<div >"));
+    assert!(res.body.contains(r#"<iframe src="https://www.youtube.com/embed/ub36ffWAqgQ""#));
+    assert!(res.body.contains(r#"<iframe src="https://www.youtube.com/embed/ub36ffWAqgQ?autoplay=1""#));
+    assert!(res.body.contains(r#"<iframe src="https://www.streamable.com/e/c0ic""#));
+    assert!(res.body.contains(r#"//player.vimeo.com/video/210073083""#));
 }
 
 #[test]
@@ -243,7 +243,7 @@ fn doesnt_render_ignored_shortcodes() {
     config.highlight_code = false;
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content(r#"```{{/* youtube(id="w7Ft2ymGmfc") */}}```"#, &context).unwrap();
-    assert_eq!(res.0, "<p><code>{{ youtube(id=&quot;w7Ft2ymGmfc&quot;) }}</code></p>\n");
+    assert_eq!(res.body, "<p><code>{{ youtube(id=&quot;w7Ft2ymGmfc&quot;) }}</code></p>\n");
 }
 
 #[test]
@@ -261,7 +261,7 @@ Hello
 A quote
 {% end %}
     "#, &context).unwrap();
-    assert_eq!(res.0, "<p>Hello</p>\n<blockquote>A quote - Keats</blockquote>\n");
+    assert_eq!(res.body, "<p>Hello</p>\n<blockquote>A quote - Keats</blockquote>\n");
 }
 
 #[test]
@@ -287,7 +287,7 @@ fn can_make_valid_relative_link() {
     ).unwrap();
 
     assert!(
-        res.0.contains(r#"<p><a href="https://vincent.is/about">rel link</a>, <a href="https://vincent.is/about">abs link</a></p>"#)
+        res.body.contains(r#"<p><a href="https://vincent.is/about">rel link</a>, <a href="https://vincent.is/about">abs link</a></p>"#)
     );
 }
 
@@ -301,7 +301,7 @@ fn can_make_relative_links_with_anchors() {
     let res = render_content(r#"[rel link](./pages/about.md#cv)"#, &context).unwrap();
 
     assert!(
-        res.0.contains(r#"<p><a href="https://vincent.is/about#cv">rel link</a></p>"#)
+        res.body.contains(r#"<p><a href="https://vincent.is/about#cv">rel link</a></p>"#)
     );
 }
 
@@ -322,7 +322,7 @@ fn can_add_id_to_headers() {
     let config = Config::default();
     let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content(r#"# Hello"#, &context).unwrap();
-    assert_eq!(res.0, "<h1 id=\"hello\">Hello</h1>\n");
+    assert_eq!(res.body, "<h1 id=\"hello\">Hello</h1>\n");
 }
 
 #[test]
@@ -332,7 +332,7 @@ fn can_add_id_to_headers_same_slug() {
     let config = Config::default();
     let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("# Hello\n# Hello", &context).unwrap();
-    assert_eq!(res.0, "<h1 id=\"hello\">Hello</h1>\n<h1 id=\"hello-1\">Hello</h1>\n");
+    assert_eq!(res.body, "<h1 id=\"hello\">Hello</h1>\n<h1 id=\"hello-1\">Hello</h1>\n");
 }
 
 #[test]
@@ -342,7 +342,7 @@ fn can_insert_anchor_left() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::Left);
     let res = render_content("# Hello", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<h1 id=\"hello\"><a class=\"gutenberg-anchor\" href=\"#hello\" aria-label=\"Anchor link for: hello\">🔗</a>\nHello</h1>\n"
     );
 }
@@ -354,7 +354,7 @@ fn can_insert_anchor_right() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::Right);
     let res = render_content("# Hello", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<h1 id=\"hello\">Hello<a class=\"gutenberg-anchor\" href=\"#hello\" aria-label=\"Anchor link for: hello\">🔗</a>\n</h1>\n"
     );
 }
@@ -367,7 +367,7 @@ fn can_insert_anchor_with_exclamation_mark() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::Left);
     let res = render_content("# Hello!", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<h1 id=\"hello\"><a class=\"gutenberg-anchor\" href=\"#hello\" aria-label=\"Anchor link for: hello\">🔗</a>\nHello!</h1>\n"
     );
 }
@@ -380,7 +380,7 @@ fn can_insert_anchor_with_link() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::Left);
     let res = render_content("## [Rust](https://rust-lang.org)", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<h2 id=\"rust\"><a class=\"gutenberg-anchor\" href=\"#rust\" aria-label=\"Anchor link for: rust\">🔗</a>\n<a href=\"https://rust-lang.org\">Rust</a></h2>\n"
     );
 }
@@ -392,7 +392,7 @@ fn can_insert_anchor_with_other_special_chars() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::Left);
     let res = render_content("# Hello*_()", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<h1 id=\"hello\"><a class=\"gutenberg-anchor\" href=\"#hello\" aria-label=\"Anchor link for: hello\">🔗</a>\nHello*_()</h1>\n"
     );
 }
@@ -420,7 +420,7 @@ fn can_make_toc() {
 ### Last one
     "#, &context).unwrap();
 
-    let toc = res.1;
+    let toc = res.toc;
     assert_eq!(toc.len(), 1);
     assert_eq!(toc[0].children.len(), 2);
     assert_eq!(toc[0].children[1].children.len(), 1);
@@ -433,7 +433,7 @@ fn can_understand_backtick_in_titles() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("# `Hello`", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<h1 id=\"hello\"><code>Hello</code></h1>\n"
     );
 }
@@ -445,7 +445,7 @@ fn can_understand_backtick_in_paragraphs() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("Hello `world`", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<p>Hello <code>world</code></p>\n"
     );
 }
@@ -458,7 +458,7 @@ fn can_understand_links_in_header() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("# [Rust](https://rust-lang.org)", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<h1 id=\"rust\"><a href=\"https://rust-lang.org\">Rust</a></h1>\n"
     );
 }
@@ -470,7 +470,7 @@ fn can_understand_link_with_title_in_header() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("# [Rust](https://rust-lang.org \"Rust homepage\")", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<h1 id=\"rust\"><a href=\"https://rust-lang.org\" title=\"Rust homepage\">Rust</a></h1>\n"
     );
 }
@@ -488,7 +488,7 @@ fn can_make_valid_relative_link_in_header() {
     ).unwrap();
 
     assert_eq!(
-        res.0,
+        res.body,
         "<h1 id=\"rel-link\"><a href=\"https://vincent.is/about/\">rel link</a></h1>\n"
     );
 }
@@ -500,7 +500,7 @@ fn can_make_permalinks_with_colocated_assets_for_link() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "https://vincent.is/about/", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("[an image](image.jpg)", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<p><a href=\"https://vincent.is/about/image.jpg\">an image</a></p>\n"
     );
 }
@@ -512,7 +512,7 @@ fn can_make_permalinks_with_colocated_assets_for_image() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "https://vincent.is/about/", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("![alt text](image.jpg)", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<p><img src=\"https://vincent.is/about/image.jpg\" alt=\"alt text\" /></p>\n"
     );
 }
@@ -534,7 +534,7 @@ Some text
 </div>
     "#, &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<p>Some text</p>\n<h1>Helo</h1>\n<div>\n<a href=\"mobx-flow.png\">\n        <img src=\"mobx-flow.png\" alt=\"MobX flow\">\n    </a>\n</div>\n"
     );
 }
@@ -547,7 +547,7 @@ fn can_validate_valid_external_links() {
     let context = RenderContext::new(&GUTENBERG_TERA, &config, "https://vincent.is/about/", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
     let res = render_content("[a link](http://google.com)", &context).unwrap();
     assert_eq!(
-        res.0,
+        res.body,
         "<p><a href=\"http://google.com\">a link</a></p>\n"
     );
 }

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -563,3 +563,20 @@ fn can_show_error_message_for_invalid_external_links() {
     let err = res.unwrap_err();
     assert!(err.description().contains("Link http://google.comy is not valid"));
 }
+
+#[test]
+fn can_handle_summaries() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let config = Config::default();
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, Path::new("something"), InsertAnchor::None);
+    let res = render_content("Hello [world]\n\n<!-- more -->\n\nBla bla\n\n[world]: https://vincent.is/about/", &context).unwrap();
+    assert_eq!(
+        res.body,
+        "<p>Hello <a href=\"https://vincent.is/about/\">world</a></p>\n<p><a name=\"continue-reading\"></a></p>\n<p>Bla bla</p>\n"
+    );
+    assert_eq!(
+        res.summary_len,
+        Some("<p>Hello <a href=\"https://vincent.is/about/\">world</a></p>\n".len())
+    );
+}


### PR DESCRIPTION
As per #376, this moves `<!-- more -->` handling into the Markdown parser.

In addition to fixing reference-style links and being a bit tidier, it should also be a bit faster, reducing the amount of unnecessary string searching and only rendering the document once.

While I'm here, swap over a lot of Owned() to Borrowed() to reduce unnecessary String allocations.