### PR TITLE
[WIP] Add a prototype of transparent sections

### DIFF
--- a/components/front_matter/src/section.rs
+++ b/components/front_matter/src/section.rs
@@ -51,6 +51,11 @@ pub struct SectionFrontMatter {
     /// Defaults to `true` but is only used if search if explicitly enabled in the config.
     #[serde(skip_serializing)]
     pub in_search_index: bool,
+    /// Whether the section should pass its pages on to the parent section. Defaults to `false`.
+    /// Useful when the section shouldn't split up the parent section, like
+    /// sections for each year under a posts section.
+    #[serde(skip_serializing)]
+    pub transparent: bool,
     /// Any extra parameter present in the front matter
     pub extra: HashMap<String, Value>,
 }
@@ -88,6 +93,7 @@ impl Default for SectionFrontMatter {
             redirect_to: None,
             insert_anchor_links: InsertAnchor::None,
             in_search_index: true,
+            transparent: false,
             extra: HashMap::new(),
         }
     }

--- a/components/rebuild/src/lib.rs
+++ b/components/rebuild/src/lib.rs
@@ -44,6 +44,8 @@ pub enum SectionChangesNeeded {
     RenderWithPages,
     /// Setting `render` to false
     Delete,
+    /// Changing `transparent`
+    Transparent,
 }
 
 /// Evaluates all the params in the front matter that changed so we can do the smallest
@@ -54,6 +56,10 @@ fn find_section_front_matter_changes(current: &SectionFrontMatter, new: &Section
 
     if current.sort_by != new.sort_by {
         changes_needed.push(SectionChangesNeeded::Sort);
+    }
+
+    if current.transparent != new.transparent {
+        changes_needed.push(SectionChangesNeeded::Transparent);
     }
 
     // We want to hide the section
@@ -158,7 +164,8 @@ fn handle_section_editing(site: &mut Site, path: &Path) -> Result<()> {
                     SectionChangesNeeded::Render => site.render_section(&site.sections[path], false)?,
                     SectionChangesNeeded::RenderWithPages => site.render_section(&site.sections[path], true)?,
                     // not a common enough operation to make it worth optimizing
-                    SectionChangesNeeded::Delete => {
+                    SectionChangesNeeded::Transparent
+                    | SectionChangesNeeded::Delete => {
                         site.populate_sections();
                         site.build()?;
                     }


### PR DESCRIPTION
This implements "transparent" sections, which copy their pages into the parent
section's page list. This is useful for implementing sections that shouldn't
influence pagination, for instance, year sections underneath a posts section on
a blog.