### PR TITLE
Fix populate_sections when using nested subsections

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -368,6 +368,7 @@ impl Site {
             section.ignored_pages = vec![];
         }
 
+        // Put pages into the 'pages' field of their section
         for page in self.pages.values() {
             let parent_section_path = page.file.parent.join("_index.md");
             if self.sections.contains_key(&parent_section_path) {
@@ -378,18 +379,31 @@ impl Site {
         }
 
         self.sort_sections_pages(None);
-        // TODO: remove this clone
-        let sections = self.sections.clone();
 
-        for section in self.sections.values_mut() {
-            if let Some(paths) = grandparent_paths.get(&section.file.parent) {
-                section.subsections = paths
+        // Recursively adds the subsections of the given section to its 'subsections' field
+        fn set_subsections(section: &mut Section,
+                           grandparent_paths: &HashMap<PathBuf, Vec<PathBuf>>,
+                           sections: &HashMap<PathBuf, Section>) {
+            if let Some(subsection_indices) = grandparent_paths.get(&section.file.parent) {
+                section.subsections = subsection_indices
                     .iter()
-                    .map(|p| sections[p].clone())
-                    .collect::<Vec<_>>();
+                    .map(|index_file| sections[index_file].clone())
+                    .collect();
+
                 section.subsections
                     .sort_by(|a, b| a.meta.weight.cmp(&b.meta.weight));
+
+                for mut subsection in section.subsections.iter_mut() {
+                    set_subsections(&mut subsection, grandparent_paths, sections);
+                }
             }
+        }
+
+        // TODO: avoid unnecessary copying
+        let sections_cloned = self.sections.clone();
+
+        for mut section in self.sections.values_mut() {
+            set_subsections(&mut section, &grandparent_paths, &sections_cloned);
         }
     }
 

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -3,7 +3,7 @@ title = "Image processing"
 weight = 120
 +++
 
-Gutengerb provides support for automatic image resizing through the built-in function `resize_image`,
+Gutenberg provides support for automatic image resizing through the built-in function `resize_image`,
 which is available in template code as well as in shortcodes.
 
 The function usage is as follows:

--- a/docs/content/documentation/templates/rss.md
+++ b/docs/content/documentation/templates/rss.md
@@ -7,8 +7,6 @@ If the site `config.toml` file sets `generate_rss = true`, then Gutenberg will
 generate an `rss.xml` page for the site, which will live at `base_url/rss.xml`. To
 generate the `rss.xml` page, Gutenberg will look for a `rss.xml` file in the `templates`
 directory or, if one does not exist, will use the use the built-in rss template.
-Currently it is only possible to have one RSS feed for the whole site; you cannot
-create a RSS feed per section or taxonomy.
 
 **Only pages with a date and that are not draft will be available.**
 


### PR DESCRIPTION
Until now, `Site.sections` was incorrect when nested subsections were used. This PR fixes this behavior, together with #446.