### PR TITLE
add watch command

### DIFF
--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -56,6 +56,8 @@ the interface/port combination to use if you want something different than the d
 You can also specify different addresses for the interface and base_url using `-u`/`--base-url`, for example
 if you are running zola in a Docker container.
 
+In the event you don't want zola to run a local webserver, you can use the `--watch-only` flag.
+
 ```bash
 $ zola serve
 $ zola serve --port 2000
@@ -63,6 +65,7 @@ $ zola serve --interface 0.0.0.0
 $ zola serve --interface 0.0.0.0 --port 2000
 $ zola serve --interface 0.0.0.0 --base-url 127.0.0.1
 $ zola serve --interface 0.0.0.0 --port 2000 --output-dir www/public
+$ zola serve --watch-only
 ```
 
 The serve command will watch all your content and will provide live reload, without

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,10 @@ pub fn build_cli() -> App<'static, 'static> {
                         .default_value("127.0.0.1")
                         .takes_value(true)
                         .help("Changes the base_url"),
+                    Arg::with_name("watch_only")
+                        .long("watch-only")
+                        .takes_value(false)
+                        .help("Do not start a server, just re-build project on changes")
                 ]),
         ])
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,6 @@ fn main() {
             let watch_only = matches.is_present("watch_only");
             let output_dir = matches.value_of("output_dir").unwrap();
             let base_url = matches.value_of("base_url").unwrap();
-            println!("watch_only: {}", watch_only);
             console::info("Building site...");
             match cmd::serve(interface, port, output_dir, base_url, config_file, watch_only) {
                 Ok(()) => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,11 +77,12 @@ fn main() {
                     ::std::process::exit(1);
                 }
             }
-
+            let watch_only = matches.is_present("watch_only");
             let output_dir = matches.value_of("output_dir").unwrap();
             let base_url = matches.value_of("base_url").unwrap();
+            println!("watch_only: {}", watch_only);
             console::info("Building site...");
-            match cmd::serve(interface, port, output_dir, base_url, config_file) {
+            match cmd::serve(interface, port, output_dir, base_url, config_file, watch_only) {
                 Ok(()) => (),
                 Err(e) => {
                     console::unravel_errors("", &e);


### PR DESCRIPTION
In an effort to address #213 this pull request breaks the watch functionality out from the `serve` sub-command into its own sub-command. 

This would allow someone include `gutenbreg` in their development workflow when utilizing another server. While this doesn't add proxy functionality it does solve the problem that prompted the issue.