### PR TITLE
Implement an opportunistic watcher for all optional directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod cmd;
 mod console;
 mod cli;
 mod prompt;
+mod opportunistic_watcher;
 
 
 fn main() {

--- a/src/opportunistic_watcher.rs
+++ b/src/opportunistic_watcher.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::Sender;
+use std::time::Duration;
+
+use errors::{Result, ResultExt};
+
+use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::DebouncedEvent::{Create, Rename};
+
+pub struct OpportunisticWatcher {
+    watcher: RecommendedWatcher,
+    watches: HashMap<PathBuf, RecursiveMode>,
+}
+
+impl OpportunisticWatcher {
+    pub fn new(tx: Sender<DebouncedEvent>, delay: Duration) -> Result<Self> {
+        let watcher = RecommendedWatcher::new(tx, delay).unwrap();
+        let opportunistic_watcher = OpportunisticWatcher {
+            watcher,
+            watches: HashMap::new(),
+        };
+        Ok(opportunistic_watcher)
+    }
+
+    pub fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watches.insert(path.as_ref().to_path_buf(), recursive_mode);
+        self.watcher.watch(path.as_ref().clone(), recursive_mode)
+            .chain_err(|| format!("Failed to watch `{}`", path.as_ref().display()))
+    }
+
+    pub fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        self.watches.remove(path.as_ref());
+        self.watcher.unwatch(path.as_ref().clone())
+            .chain_err(|| format!("Failed to unwatch `{}`", path.as_ref().display()))
+    }
+
+    pub fn watches(&self) -> &HashMap<PathBuf, RecursiveMode> {
+        &self.watches
+    }
+
+    pub fn update(&mut self, event: &DebouncedEvent) -> Result<()> {
+        match &event {
+            Create(path) |
+            Rename(_, path) => {
+                match self.watches.get(path) {
+                    Some(recursive_mode) => {
+                        self.watcher.watch(&path, *recursive_mode)
+                            .chain_err(|| format!("Failed to watch `{}`", path.display()))
+                    },
+                    None => Ok(()),
+                }
+            },
+            _ => Ok(()),
+        }
+    }
+}


### PR DESCRIPTION
This allows Gutenberg to start with just a config file.  All other directories
 will be picked up once they are created.  Directories which are not necessary
 will thus not cause errors.

Closes: https://github.com/Keats/gutenberg/issues/445

I expect that this will require quite some work (and documentation, which is currently completely missing) until it can be accepted, because this is one of my first pieces of Rust code. Please do not hesitate to provide feedback!