### PR TITLE
Update reqwest to 0.9

### DIFF
--- a/components/link_checker/Cargo.toml
+++ b/components/link_checker/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
 
 [dependencies]
-reqwest = "0.8"
+reqwest = "0.9"
 lazy_static = "1"
+mime = "0.3"

--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -1,9 +1,10 @@
+extern crate mime;
 extern crate reqwest;
 #[macro_use]
 extern crate lazy_static;
 
-use reqwest::header::{qitem, Accept, Headers};
-use reqwest::{mime, StatusCode};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT};
+use reqwest::StatusCode;
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::{Arc, RwLock};
@@ -54,8 +55,15 @@ pub fn check_url(url: &str) -> LinkResult {
         }
     }
 
-    let mut headers = Headers::new();
-    headers.set(Accept(vec![qitem(mime::TEXT_HTML), qitem(mime::STAR_STAR)]));
+    let mut headers = HeaderMap::new();
+    headers.append(
+        ACCEPT,
+        HeaderValue::from_str(&mime::TEXT_HTML.to_string()).unwrap(),
+    );
+    headers.append(
+        ACCEPT,
+        HeaderValue::from_str(&mime::STAR_STAR.to_string()).unwrap(),
+    );
 
     let client = reqwest::Client::new();
 


### PR DESCRIPTION
Because reqwest 0.8 uses the openssl 0.9 crate which does not work with OpenSSL 1.1.x.