### PR TITLE
Feat: inject config in robots.txt context

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -670,9 +670,11 @@ impl Site {
     /// Renders robots.txt
     pub fn render_robots(&self) -> Result<()> {
         ensure_directory_exists(&self.output_path)?;
+        let mut context = Context::new();
+        context.insert("config", &self.config);
         create_file(
             &self.output_path.join("robots.txt"),
-            &render_template("robots.txt", &self.tera, &Context::new(), &self.config.theme)?,
+            &render_template("robots.txt", &self.tera, &context, &self.config.theme)?,
         )
     }
 

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -168,6 +168,7 @@ fn can_build_site_without_live_reload() {
 
     // robots.txt has been rendered from the template
     assert!(file_contains!(public, "robots.txt", "User-agent: gutenberg"));
+    assert!(file_contains!(public, "robots.txt", "Sitemap: https://replace-this-with-your-url.com/sitemap.xml"));
 }
 
 #[test]

--- a/docs/content/documentation/templates/robots.md
+++ b/docs/content/documentation/templates/robots.md
@@ -6,8 +6,8 @@ weight = 70
 Gutenberg will look for a `robots.txt` file in the `templates` directory or 
 use the built-in one.
 
-Robots.txt is the simplest of all templates: it doesn't take any variables
-and the default is what most site want.
+Robots.txt is the simplest of all templates: it only gets the config
+and the default is what most site want:
 
 ```jinja2
 User-agent: *

--- a/test_site/templates/robots.txt
+++ b/test_site/templates/robots.txt
@@ -1,2 +1,3 @@
 User-agent: gutenberg
 Allow: /
+Sitemap: {{config.base_url}}/sitemap.xml


### PR DESCRIPTION
### Use case

Creating a robots.txt referencing a sitemap:

```
User-agent: *
Sitemap: https://mydomain.tld/sitemap.xml
```

To achieve this, one could hardcode the base URL, but it feels kind of dirty.
A cleaner way would be to use the `config.base_url` value.

### Introduced change

The config object is now passed in the template context, allowing to write a template like this:

```
Sitemap: {{config.base_url}}/sitemap.xml
```

The documentation has been updated to reflect this change. Also a test case checks that the produced file does contains the configured base_url.

Let me now if there is something to change.