### PR TITLE
Add `get_json` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "imageproc 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "taxonomies 0.1.0",
  "tera 0.11.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -311,6 +311,7 @@ impl Site {
             "get_taxonomy_url",
             global_fns::make_get_taxonomy_url(self.taxonomies.clone()),
         );
+        self.tera.register_function("get_json", global_fns::make_get_json());
     }
 
     /// Add a page to the site

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -8,6 +8,7 @@ tera = "0.11"
 base64 = "0.9"
 lazy_static = "1"
 pulldown-cmark = "0"
+reqwest = "0.9.2"
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -8,7 +8,7 @@ tera = "0.11"
 base64 = "0.9"
 lazy_static = "1"
 pulldown-cmark = "0"
-reqwest = "0.9.2"
+reqwest = "0.9"
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -4,6 +4,7 @@ extern crate lazy_static;
 extern crate tera;
 extern crate base64;
 extern crate pulldown_cmark;
+extern crate reqwest;
 
 extern crate errors;
 extern crate utils;

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -147,3 +147,11 @@ Gets the translation of the given `key`, for the `default_language` or the `lang
 ### `resize_image`
 Resizes an image file.
 Pease refer to [_Content / Image Processing_](./documentation/content/image-processing/index.md) for complete documentation.
+
+### `get_json`
+Returns JSON requested from a remote endpoint.
+
+```jinja2
+{% set response = get_json(url="https://api.github.com/repos/Keats/gutenberg") %}
+{{ response.id }}
+```

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -14,10 +14,11 @@
 
         <header>
             <nav class="{% block extra_nav_class %}container{% endblock extra_nav_class %}">
+                {% set gh_response = get_json(url="https://api.github.com/repos/Keats/gutenberg") %}
                 <a class="header__logo white" href="{{ config.base_url }}">Gutenberg</a>
                 <a class="white" href="{{ get_url(path="./documentation/_index.md") }}" class="nav-link">Docs</a>
                 <a class="white" href="{{ get_url(path="./themes/_index.md") }}" class="nav-link">Themes</a>
-                <a class="white" href="https://github.com/Keats/gutenberg" class="nav-link">GitHub</a>
+                <a class="white" href="{{ gh_response.html_url }}" class="nav-link">GitHub</a>
 
                 <div class="search-container">
                     <input id="search" type="search" placeholder="🔎 Search the docs">


### PR DESCRIPTION
Add a template function to request JSON data from remote endpoints. This is currently a very minimal implementation, which doesn't cache anything between runs (the cache lives purely in-memory). Future iterations may include a filesystem cache, and support for other datatypes (eg CSV). I added a fairly naive example to the docs site which tests both the response, and whether the response is correctly cached. 

Adding support for remote content like this is a controvertial feature in static site generators, because it both adds an external dependency on the upstream API value, but also means the site requires an active internet connection to build. I personally use it quite a lot to fetch fairly fixed metadata, or to build custom widgets for things which expose an API, but have fairly terrible embed support. If you don't actually use the function, then no requests are actually made.