### PR TITLE
Allow inclusion of all items in RSS feeds.

### DIFF
--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -5,13 +5,13 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use globset::{Glob, GlobSet, GlobSetBuilder};
+use syntect::parsing::{SyntaxSet, SyntaxSetBuilder};
 use toml;
 use toml::Value as Toml;
-use syntect::parsing::{SyntaxSet, SyntaxSetBuilder};
 
-use theme::Theme;
-use highlighting::THEME_SET;
 use errors::{Result, ResultExt};
+use highlighting::THEME_SET;
+use theme::Theme;
 
 // We want a default base url for tests
 static DEFAULT_BASE_URL: &'static str = "http://a-website.com";
@@ -76,8 +76,8 @@ pub struct Config {
 
     /// Whether to generate RSS. Defaults to false
     pub generate_rss: bool,
-    /// The number of articles to include in the RSS feed. Defaults to 10_000
-    pub rss_limit: usize,
+    /// The number of articles to include in the RSS feed. Defaults to including all items.
+    pub rss_limit: Option<usize>,
 
     pub taxonomies: Vec<Taxonomy>,
 
@@ -251,7 +251,7 @@ impl Default for Config {
             highlight_theme: "base16-ocean-dark".to_string(),
             default_language: "en".to_string(),
             generate_rss: false,
-            rss_limit: 10_000,
+            rss_limit: None,
             taxonomies: Vec::new(),
             compile_sass: false,
             check_external_links: false,

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -732,10 +732,11 @@ impl Site {
         pages.par_sort_unstable_by(sort_actual_pages_by_date);
 
         context.insert("last_build_date", &pages[0].meta.date.clone().map(|d| d.to_string()));
-        // limit to the last n elements
+        // limit to the last n elements if the limit is set; otherwise use all.
+        let num_entries = self.config.rss_limit.unwrap_or(pages.len());
         let p = pages
             .iter()
-            .take(self.config.rss_limit)
+            .take(num_entries)
             .map(|x| x.to_serialized_basic())
             .collect::<Vec<_>>();
 

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -37,8 +37,9 @@ highlight_theme = "base16-ocean-dark"
 # Whether to generate a RSS feed automatically
 generate_rss = false
 
-# The number of articles to include in the RSS feed
-rss_limit = 20
+# The number of articles to include in the RSS feed. Will include all items if
+# not set (the default).
+# rss_limit = 20
 
 # The taxonomies to be rendered for that site and their configuration
 # Example:


### PR DESCRIPTION
Switch to an `Option<usize>` for the serialized value of `rss_items`. This lets us just set a blank value in the configuration and thereby include *all* items.

This is a backwards-compatible change; it does not affect the behavior of existing configurations.

- Fixes #468.
- Closes #471. This alternative approach covers the same territory as that documentation change but in a better way in my view.