### PR TITLE
prevent html tags from appearing in the toc

### DIFF
--- a/components/rendering/src/table_of_contents.rs
+++ b/components/rendering/src/table_of_contents.rs
@@ -31,6 +31,7 @@ pub struct TempHeader {
     pub id: String,
     pub permalink: String,
     pub title: String,
+    pub html: String,
 }
 
 impl TempHeader {
@@ -40,10 +41,16 @@ impl TempHeader {
             id: String::new(),
             permalink: String::new(),
             title: String::new(),
+            html: String::new(),
         }
     }
 
-    pub fn push(&mut self, val: &str) {
+    pub fn add_html(&mut self, val: &str) {
+        self.html += val;
+    }
+
+    pub fn add_text(&mut self, val: &str) {
+        self.html += val;
         self.title += val;
     }
 
@@ -58,9 +65,9 @@ impl TempHeader {
         };
 
         match insert_anchor {
-            InsertAnchor::None => format!("<h{lvl} id=\"{id}\">{t}</h{lvl}>\n", lvl = self.level, t = self.title, id = self.id),
-            InsertAnchor::Left => format!("<h{lvl} id=\"{id}\">{a}{t}</h{lvl}>\n", lvl = self.level, a = anchor_link, t = self.title, id = self.id),
-            InsertAnchor::Right => format!("<h{lvl} id=\"{id}\">{t}{a}</h{lvl}>\n", lvl = self.level, a = anchor_link, t = self.title, id = self.id),
+            InsertAnchor::None => format!("<h{lvl} id=\"{id}\">{t}</h{lvl}>\n", lvl = self.level, t = self.html, id = self.id),
+            InsertAnchor::Left => format!("<h{lvl} id=\"{id}\">{a}{t}</h{lvl}>\n", lvl = self.level, a = anchor_link, t = self.html, id = self.id),
+            InsertAnchor::Right => format!("<h{lvl} id=\"{id}\">{t}{a}</h{lvl}>\n", lvl = self.level, a = anchor_link, t = self.html, id = self.id),
         }
     }
 }

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -428,6 +428,38 @@ fn can_make_toc() {
 }
 
 #[test]
+fn can_ignore_tags_in_toc() {
+    let permalinks_ctx = HashMap::new();
+    let config = Config::default();
+    let context = RenderContext::new(
+        &GUTENBERG_TERA,
+        &config,
+        "https://mysite.com/something",
+        &permalinks_ctx,
+        InsertAnchor::Left,
+    );
+
+    let res = render_content(r#"
+## header with `code`
+
+## [anchor](https://duckduckgo.com/) in header
+
+## **bold** and *italics*
+    "#, &context).unwrap();
+
+    let toc = res.toc;
+
+    assert_eq!(toc[0].id, "header-with-code");
+    assert_eq!(toc[0].title, "header with code");
+
+    assert_eq!(toc[1].id, "anchor-in-header");
+    assert_eq!(toc[1].title, "anchor in header");
+
+    assert_eq!(toc[2].id, "bold-and-italics");
+    assert_eq!(toc[2].title, "bold and italics");
+}
+
+#[test]
 fn can_understand_backtick_in_titles() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();


### PR DESCRIPTION
This resolves #487 by not including html tags while building header information for the table of contents.

It retains html tags in headers for the regular markdown output, as previously.