### PR TITLE
Ensure root output directory exists explicitly

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -623,6 +623,7 @@ impl Site {
     }
 
     pub fn render_aliases(&self) -> Result<()> {
+        ensure_directory_exists(&self.output_path)?;
         for page in self.pages.values() {
             for alias in &page.meta.aliases {
                 let mut output_path = self.output_path.to_path_buf();

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -19,7 +19,7 @@ fn can_parse_site() {
     site.load().unwrap();
 
     // Correct number of pages (sections are pages too)
-    assert_eq!(site.pages.len(), 15);
+    assert_eq!(site.pages.len(), 16);
     let posts_path = path.join("content").join("posts");
 
     // Make sure we remove all the pwd + content from the sections
@@ -44,7 +44,7 @@ fn can_parse_site() {
 
     let posts_section = &site.sections[&posts_path.join("_index.md")];
     assert_eq!(posts_section.subsections.len(), 1);
-    assert_eq!(posts_section.pages.len(), 7);
+    assert_eq!(posts_section.pages.len(), 8);
 
     let tutorials_section = &site.sections[&posts_path.join("tutorials").join("_index.md")];
     assert_eq!(tutorials_section.subsections.len(), 2);

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -3,7 +3,7 @@ title = "Image processing"
 weight = 120
 +++
 
-Gutengerb provides support for automatic image resizing through the built-in function `resize_image`,
+Gutenberg provides support for automatic image resizing through the built-in function `resize_image`,
 which is available in template code as well as in shortcodes.
 
 The function usage is as follows:

--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -36,7 +36,7 @@ $ gutenberg build --base-url $DEPLOY_URL
 This is useful for example when you want to deploy previews of a site to a dynamic URL, such as Netlify
 deploy previews.
 
-+You can override the default output directory 'public' by passing a other value to the `output-dir` flag.
+You can override the default output directory 'public' by passing a other value to the `output-dir` flag.
 
 ```bash
 $ gutenberg build --output-dir $DOCUMENT_ROOT

--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -3,10 +3,10 @@ title = "Installation"
 weight = 1
 +++
 
-Gutenberg provides pre-built binaries for MacOS, Linux and Windows on the
+Gutenberg provides pre-built binaries for macOS, Linux and Windows on the
 [GitHub release page](https://github.com/Keats/gutenberg/releases).
 
-## Mac OS
+## macOS
 
 Gutenberg is available on [Brew](https://brew.sh):
 

--- a/docs/content/documentation/templates/rss.md
+++ b/docs/content/documentation/templates/rss.md
@@ -7,8 +7,6 @@ If the site `config.toml` file sets `generate_rss = true`, then Gutenberg will
 generate an `rss.xml` page for the site, which will live at `base_url/rss.xml`. To
 generate the `rss.xml` page, Gutenberg will look for a `rss.xml` file in the `templates`
 directory or, if one does not exist, will use the use the built-in rss template.
-Currently it is only possible to have one RSS feed for the whole site; you cannot
-create a RSS feed per section or taxonomy.
 
 **Only pages with a date and that are not draft will be available.**
 

--- a/docs/content/documentation/themes/installing-and-using-themes.md
+++ b/docs/content/documentation/themes/installing-and-using-themes.md
@@ -40,7 +40,7 @@ templates/macros.html -> replace themes/simple-blog/templates/macros.html
 static/js/site.js -> replace themes/simple-blog/static/js/site.js
 ```
 
-You can also choose to only parts of a page if a theme define some blocks by extending it. If we wanted
+You can also choose to only override parts of a page if a theme define some blocks by extending it. If we wanted
 to only change a single block from the `post.html` page in the example above, we could do the following:
 
 ```

--- a/docs/content/documentation/themes/installing-and-using-themes.md
+++ b/docs/content/documentation/themes/installing-and-using-themes.md
@@ -18,6 +18,8 @@ Cloning the repository using Git or another VCS will allow you to easily
 update it but you can also simply download the files manually and paste
 them in a folder.
 
+You can find a list of themes [on this very website](./themes/_index.md).
+
 ## Using a theme
 
 Now that you have the theme in your `themes` directory, you only need to tell

--- a/docs/content/documentation/themes/overview.md
+++ b/docs/content/documentation/themes/overview.md
@@ -8,3 +8,5 @@ but still easy to update if needed.
 
 All themes can use the full power of Gutenberg, from shortcodes to Sass compilation.
 
+A list of themes is available [on this very website](./themes/_index.md).
+

--- a/test_site/content/posts/top-level-alias.md
+++ b/test_site/content/posts/top-level-alias.md
@@ -1,0 +1,8 @@
++++
+title = "Top level alias"
+description = ""
+date = 2017-01-01
+aliases = ["top-level.html"]
++++
+
+Simple page


### PR DESCRIPTION
Aliases that have no directory nesting sneakily avoid the code path that ensures the directories exist. A way to fix this is to call `ensure_directory_exists` explicitly. This is implemented in this pull request.

Test data has been updated so if the implementation change is not applied, tests will fail.