### PR TITLE
Ensure root output directory exists explicitly.

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -565,6 +565,7 @@ impl Site {
     }
 
     pub fn render_aliases(&self) -> Result<()> {
+        ensure_directory_exists(&self.output_path)?;
         for (_, page) in self.library.pages() {
             for alias in &page.meta.aliases {
                 let mut output_path = self.output_path.to_path_buf();

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -19,7 +19,7 @@ fn can_parse_site() {
     site.load().unwrap();
 
     // Correct number of pages (sections are pages too)
-    assert_eq!(site.library.pages().len(), 15);
+    assert_eq!(site.library.pages().len(), 16);
     let posts_path = path.join("content").join("posts");
 
     // Make sure the page with a url doesn't have any sections
@@ -41,7 +41,7 @@ fn can_parse_site() {
 
     let posts_section = site.library.get_section(&posts_path.join("_index.md")).unwrap();
     assert_eq!(posts_section.subsections.len(), 1);
-    assert_eq!(posts_section.pages.len(), 7);
+    assert_eq!(posts_section.pages.len(), 8);
     assert_eq!(posts_section.ancestors, vec![*site.library.get_section_key(&index_section.file.path).unwrap()]);
 
     // Make sure we remove all the pwd + content from the sections

--- a/test_site/content/posts/top-level-alias.md
+++ b/test_site/content/posts/top-level-alias.md
@@ -1,0 +1,8 @@
++++
+title = "Top level alias"
+description = ""
+date = 2017-01-01
+aliases = ["top-level.html"]
++++
+
+Simple page


### PR DESCRIPTION
This PR obsoletes #492.

Aliases that have no directory nesting sneakily avoid the code path that ensures the directories exist. A way to fix this is to call ensure_directory_exists explicitly. This is implemented in this pull request.

Test data has been updated so if the implementation change is not applied, tests will fail.

However, tests currently fail to build with the following unrelated error message:

```
error[E0061]: this function takes 1 parameter but 0 parameters were supplied
   --> components/site/tests/site.rs:205:10
    |
205 |     site.enable_live_reload();
    |          ^^^^^^^^^^^^^^^^^^ expected 1 parameter
```
