### PR TITLE
Add links to tera documentation for filters and functions

### DIFF
--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -55,7 +55,7 @@ Custom templates are not required to live at the root of your `templates` direct
 For example, `product_pages/with_pictures.html` is a valid template.
 
 ## Built-in filters
-Gutenberg adds a few filters, in addition of the ones already present in Tera.
+Gutenberg adds a few filters, in addition of the [ones already present](https://tera.netlify.com/docs/templates/#built-in-filters) in Tera.
 
 ### markdown
 Converts the given variable to HTML using Markdown. This doesn't apply any of the
@@ -76,7 +76,7 @@ Decode the variable from base64.
 
 
 ## Built-in global functions
-Gutenberg adds a few global functions to Tera in order to make it easier to develop complex sites.
+Gutenberg adds a few global functions to [those in Tera](https://tera.netlify.com/docs/templates/#built-in-functions) in order to make it easier to develop complex sites.
 
 ### `get_page`
 Takes a path to a `.md` file and returns the associated page


### PR DESCRIPTION
Fixes https://github.com/Keats/gutenberg/issues/510. Well, should help with it.

I opened this against `master` as it's not necessarily related to changes from `next`. I can change the base if necessary.