### PR TITLE
Updated install instructions

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -6,12 +6,36 @@ weight = 1
 Zola provides pre-built binaries for MacOS, Linux and Windows on the
 [GitHub release page](https://github.com/getzola/zola/releases).
 
+## Linux
+
 ## Arch Linux
 
 Use your favourite AUR helper to install the `zola-bin` package.
 
 ```bash
 $ yaourt -S zola-bin
+```
+
+### Snapcraft
+
+Zola is available on snapcraft:
+
+```bash
+$ snap install --edge zola
+```
+
+## Windows
+
+Zola is available on [Scoop](http://scoop.sh):
+
+```bash
+$ scoop install zola
+```
+
+And [Chocolatey](https://chocolatey.org/):
+
+```bash
+$ choco install zola
 ```
 
 ## From source

--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -8,7 +8,7 @@ Zola provides pre-built binaries for MacOS, Linux and Windows on the
 
 ## Linux
 
-## Arch Linux
+### Arch Linux
 
 Use your favourite AUR helper to install the `zola-bin` package.
 


### PR DESCRIPTION
I updated the install instructions (snap, scoop, chocolatey) and added the ones where Gutenberg already got renamed to Zola also to the top of the document.

Should yaourt be replaced by one of the other aur-helpers (pikaur, yay,...) as the development for it is stalled/discontinued for quite some time now although it is still working?

Scoop: https://github.com/lukesampson/scoop/blob/master/bucket/zola.json
Chocolatey: https://chocolatey.org/packages/zola
Snap: https://snapcraft.io/zola