### PR TITLE
Update snap installation instructions

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -21,7 +21,7 @@ $ yay -S zola-bin
 Zola is available on snapcraft:
 
 ```bash
-$ snap install --edge zola
+$ snap install --edge --classic zola
 ```
 
 ## Windows


### PR DESCRIPTION
If you don't install with classic confinement, you'll get permission errors trying to create sites with `zola init`.