### PR TITLE
add rendering for 404.html when running zola serve

### DIFF
--- a/components/rebuild/src/lib.rs
+++ b/components/rebuild/src/lib.rs
@@ -352,6 +352,7 @@ pub fn after_template_change(site: &mut Site, path: &Path) -> Result<()> {
             site.render_orphan_pages()
         }
         "section.html" => site.render_sections(),
+        "404.html" => site.render_404(),
         // Either the index or some unknown template changed
         // We can't really know what this change affects so rebuild all
         // the things

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -627,9 +627,10 @@ impl Site {
         ensure_directory_exists(&self.output_path)?;
         let mut context = Context::new();
         context.insert("config", &self.config);
+        let output = render_template("404.html", &self.tera, &context, &self.config.theme)?;
         create_file(
             &self.output_path.join("404.html"),
-            &render_template("404.html", &self.tera, &context, &self.config.theme)?,
+            &self.inject_livereload(output),
         )
     }
 


### PR DESCRIPTION
Sanity check:

* [ ✔ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## Code changes

* [ ✔ ] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ~ ] Have you created/updated the relevant documentation page(s)?
The documentation already outlines the expected behavior.

## Notes
Modifying `templates/404.html` when running `zola serve` previously did nothing. It now re-renders the file, as suggested by the documentation.

Note that this only re-renders the previous version of `404.html` on a new save, e.g. it takes *two* saves to show a single change. I tried browsing through the code to find where that caching occurs, but I couldn't find it. I'd be happy to add on to this admittedly tiny PR if you have any clues as to where the issue might be hiding.