### PR TITLE
Mark required Rust version as 1.29

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -47,7 +47,7 @@ $ choco install zola
 ```
 
 ## From source
-To build it from source, you will need to have Git, [Rust (at least 1.28) and Cargo](https://www.rust-lang.org/)
+To build it from source, you will need to have Git, [Rust (at least 1.29) and Cargo](https://www.rust-lang.org/)
 installed. You will also need additional dependencies to compile [libsass](https://github.com/sass/libsass):
 
 - OSX, Linux and other Unix: `make` (`gmake` on BSDs), `g++`, `libssl-dev`


### PR DESCRIPTION
690b3f923511c1a updated the required version in Cargo.lock and in the CI config files, but not in the installation instructions.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?



