### PR TITLE
add id to continue reading p tag

### DIFF
--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -16,7 +16,7 @@ use utils::site::resolve_internal_link;
 use context::RenderContext;
 use table_of_contents::{make_table_of_contents, Header, TempHeader};
 
-const CONTINUE_READING: &str = "<p><a name=\"continue-reading\"></a></p>\n";
+const CONTINUE_READING: &str = "<p id=\"zola-continue-reading\"><a name=\"continue-reading\"></a></p>\n";
 
 #[derive(Debug)]
 pub struct Rendered {

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -681,7 +681,7 @@ fn can_handle_summaries() {
     .unwrap();
     assert_eq!(
         res.body,
-        "<p>Hello <a href=\"https://vincent.is/about/\">world</a></p>\n<p><a name=\"continue-reading\"></a></p>\n<p>Bla bla</p>\n"
+        "<p>Hello <a href=\"https://vincent.is/about/\">world</a></p>\n<p id=\"zola-continue-reading\"><a name=\"continue-reading\"></a></p>\n<p>Bla bla</p>\n"
     );
     assert_eq!(
         res.summary_len,

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -104,4 +104,4 @@ available separately in the
 
 An anchor link to this position named `continue-reading` is created so you can link
 directly to it if needed for example:
-`<p  id="zola-continue-reading"><a href="{{ page.permalink }}#continue-reading">Continue Reading</a></p>`
+`<a href="{{ page.permalink }}#continue-reading">Continue Reading</a>`

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -104,4 +104,4 @@ available separately in the
 
 An anchor link to this position named `continue-reading` is created so you can link
 directly to it if needed for example:
-`<a href="{{ page.permalink }}#continue-reading">Continue Reading</a>`
+`<p  id="zola-continue-reading"><a href="{{ page.permalink }}#continue-reading">Continue Reading</a></p>`


### PR DESCRIPTION
`page.content` includes the `<p><a></a></p>` html which shows up as extra white space. This adds an id to the `p` tag which will allow one to hide the p tag via css.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



