### PR TITLE
Footnote is now supported in headers

### DIFF
--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -28,6 +28,7 @@ pub struct Rendered {
     pub toc: Vec<Header>,
 }
 
+#[derive(Debug)]
 struct HeaderIndex {
     start: usize,
     end: usize,

--- a/components/rendering/src/table_of_contents.rs
+++ b/components/rendering/src/table_of_contents.rs
@@ -1,6 +1,3 @@
-use front_matter::InsertAnchor;
-use tera::{Context as TeraContext, Tera};
-
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct Header {
     #[serde(skip_serializing)]
@@ -30,7 +27,6 @@ pub struct TempHeader {
     pub id: String,
     pub permalink: String,
     pub title: String,
-    pub html: String,
 }
 
 impl TempHeader {
@@ -40,50 +36,6 @@ impl TempHeader {
             id: String::new(),
             permalink: String::new(),
             title: String::new(),
-            html: String::new(),
-        }
-    }
-
-    pub fn add_html(&mut self, val: &str) {
-        self.html += val;
-    }
-
-    pub fn add_text(&mut self, val: &str) {
-        self.html += val;
-        self.title += val;
-    }
-
-    /// Transform all the information we have about this header into the HTML string for it
-    pub fn to_string(&self, tera: &Tera, insert_anchor: InsertAnchor) -> String {
-        let anchor_link = if insert_anchor != InsertAnchor::None {
-            let mut c = TeraContext::new();
-            c.insert("id", &self.id);
-            tera.render("anchor-link.html", &c).unwrap()
-        } else {
-            String::new()
-        };
-
-        match insert_anchor {
-            InsertAnchor::None => format!(
-                "<h{lvl} id=\"{id}\">{t}</h{lvl}>\n",
-                lvl = self.level,
-                t = self.html,
-                id = self.id
-            ),
-            InsertAnchor::Left => format!(
-                "<h{lvl} id=\"{id}\">{a}{t}</h{lvl}>\n",
-                lvl = self.level,
-                a = anchor_link,
-                t = self.html,
-                id = self.id
-            ),
-            InsertAnchor::Right => format!(
-                "<h{lvl} id=\"{id}\">{t}{a}</h{lvl}>\n",
-                lvl = self.level,
-                a = anchor_link,
-                t = self.html,
-                id = self.id
-            ),
         }
     }
 }

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -375,6 +375,19 @@ fn can_insert_anchor_right() {
     );
 }
 
+#[test]
+fn can_insert_anchor_for_multi_header() {
+    let permalinks_ctx = HashMap::new();
+    let config = Config::default();
+    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Right);
+    let res = render_content("# Hello\n# World", &context).unwrap();
+    assert_eq!(
+        res.body,
+        "<h1 id=\"hello\">Hello<a class=\"zola-anchor\" href=\"#hello\" aria-label=\"Anchor link for: hello\">🔗</a>\n</h1>\n\
+<h1 id=\"world\">World<a class=\"zola-anchor\" href=\"#world\" aria-label=\"Anchor link for: world\">🔗</a>\n</h1>\n"
+    );
+}
+
 // See https://github.com/Keats/gutenberg/issues/42
 #[test]
 fn can_insert_anchor_with_exclamation_mark() {
@@ -528,7 +541,7 @@ fn can_understand_emphasis_in_header() {
     let config = Config::default();
     let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
     let res = render_content("# *Emphasis* text", &context).unwrap();
-    assert_eq!(res.body, "<h1 id=\"emphasis-text\"><em>Emphasis</em> text</h1>\n")
+    assert_eq!(res.body, "<h1 id=\"emphasis-text\"><em>Emphasis</em> text</h1>\n");
 }
 
 #[test]
@@ -537,7 +550,7 @@ fn can_understand_strong_in_header() {
     let config = Config::default();
     let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
     let res = render_content("# **Strong** text", &context).unwrap();
-    assert_eq!(res.body, "<h1 id=\"strong-text\"><strong>Strong</strong> text</h1>\n")
+    assert_eq!(res.body, "<h1 id=\"strong-text\"><strong>Strong</strong> text</h1>\n");
 }
 
 #[test]
@@ -546,7 +559,21 @@ fn can_understand_code_in_header() {
     let config = Config::default();
     let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
     let res = render_content("# `Code` text", &context).unwrap();
-    assert_eq!(res.body, "<h1 id=\"code-text\"><code>Code</code> text</h1>\n")
+    assert_eq!(res.body, "<h1 id=\"code-text\"><code>Code</code> text</h1>\n");
+}
+
+// See https://github.com/getzola/zola/issues/569
+#[test]
+fn can_understand_footnote_in_header() {
+    let permalinks_ctx = HashMap::new();
+    let config = Config::default();
+    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content("# text [^1] there\n[^1]: footnote", &context).unwrap();
+    assert_eq!(res.body, r##"<h1 id="text-there">text <sup class="footnote-reference"><a href="#1">1</a></sup> there</h1>
+<div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup>
+<p>footnote</p>
+</div>
+"##);
 }
 
 #[test]
@@ -641,8 +668,8 @@ fn can_validate_valid_external_links() {
         &permalinks_ctx,
         InsertAnchor::None,
     );
-    let res = render_content("[a link](http://google.com)", &context).unwrap();
-    assert_eq!(res.body, "<p><a href=\"http://google.com\">a link</a></p>\n");
+    let res = render_content("[a link](http://bing.com)", &context).unwrap();
+    assert_eq!(res.body, "<p><a href=\"http://bing.com\">a link</a></p>\n");
 }
 
 #[test]

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -668,8 +668,8 @@ fn can_validate_valid_external_links() {
         &permalinks_ctx,
         InsertAnchor::None,
     );
-    let res = render_content("[a link](http://bing.com)", &context).unwrap();
-    assert_eq!(res.body, "<p><a href=\"http://bing.com\">a link</a></p>\n");
+    let res = render_content("[a link](http://google.com)", &context).unwrap();
+    assert_eq!(res.body, "<p><a href=\"http://google.com\">a link</a></p>\n");
 }
 
 #[test]

--- a/components/utils/src/lib.rs
+++ b/components/utils/src/lib.rs
@@ -14,3 +14,4 @@ pub mod fs;
 pub mod net;
 pub mod site;
 pub mod templates;
+pub mod vec;

--- a/components/utils/src/vec.rs
+++ b/components/utils/src/vec.rs
@@ -7,7 +7,7 @@ impl<T> InsertMany for Vec<T> {
     type Element = T;
 
     /// Efficiently insert multiple element in their specified index.
-    /// The index should be sorted in ascending order.
+    /// The elements should sorted in ascending order by their index.
     ///
     /// This is done in O(n) time.
     fn insert_many(&mut self, elem_to_insert: Vec<(usize, T)>) {

--- a/components/utils/src/vec.rs
+++ b/components/utils/src/vec.rs
@@ -1,0 +1,44 @@
+pub trait InsertMany {
+    type Element;
+    fn insert_many(&mut self, elem_to_insert: Vec<(usize, Self::Element)>);
+}
+
+impl<T> InsertMany for Vec<T> {
+    type Element = T;
+
+    /// Efficiently insert multiple element in their specified index.
+    /// The index should be sorted in ascending order.
+    ///
+    /// This is done in O(n) time.
+    fn insert_many(&mut self, elem_to_insert: Vec<(usize, T)>) {
+        let mut inserted = vec![];
+        let mut last_idx = 0;
+
+        for (idx, elem) in elem_to_insert.into_iter() {
+            let head_len = idx - last_idx;
+            inserted.extend(self.splice(0 .. head_len, std::iter::empty()));
+            inserted.push(elem);
+            last_idx = idx;
+        }
+        let len = self.len();
+        inserted.extend(self.drain(0..len));
+
+        *self = inserted;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::InsertMany;
+
+    #[test]
+    fn insert_many_works() {
+        let mut v = vec![1, 2, 3, 4, 5];
+        v.insert_many(vec![(0, 0), (2, -1), (5, 6)]);
+        assert_eq!(v, &[0, 1, 2, -1, 3, 4, 5, 6]);
+
+        let mut v2 = vec![1, 2, 3, 4, 5];
+        v2.insert_many(vec![(0, 0), (2, -1)]);
+        assert_eq!(v2, &[0, 1, 2, -1, 3, 4, 5]);
+    }
+}


### PR DESCRIPTION

This fixes #569 .
    
`markdown_to_html` is heavily refactored, header-related things is
handled in a second pass.

<details>
  <summary>Sanity check:</summary>

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

</details>



