### PR TITLE
Add current_path and current_url in 404.html

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -691,8 +691,12 @@ impl Site {
     /// Renders 404.html
     pub fn render_404(&self) -> Result<()> {
         ensure_directory_exists(&self.output_path)?;
+        let current_path = "404.html";
+        let current_url = self.config.base_url.clone() + "/" + current_path;
         let mut context = Context::new();
         context.insert("config", &self.config);
+        context.insert("current_path", &current_path);
+        context.insert("current_url", &current_url);
         let output = render_template("404.html", &self.tera, &context, &self.config.theme)?;
         create_file(&self.output_path.join("404.html"), &self.inject_livereload(output))
     }


### PR DESCRIPTION
Only config variable was available in the context
for 404.html templates

This uses `base_url/404.html` as the url for all 404's. This is similar to what's done by Jekyll for it's 404 page.

fixes #586

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## Code changes
* [x] Are you doing the PR on the `next` branch?
