### PR TITLE
Replace trim_{left, right} with trim_{start, end}

### DIFF
--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -153,7 +153,7 @@ impl Page {
         };
 
         if let Some(ref p) = page.meta.path {
-            page.path = p.trim().trim_left_matches('/').to_string();
+            page.path = p.trim().trim_start_matches('/').to_string();
         } else {
             let mut path = if page.file.components.is_empty() {
                 page.slug.clone()

--- a/components/rendering/src/shortcode.rs
+++ b/components/rendering/src/shortcode.rs
@@ -108,7 +108,7 @@ fn render_shortcode(
     }
     if let Some(ref b) = body {
         // Trimming right to avoid most shortcodes with bodies ending up with a HTML new line
-        tera_context.insert("body", b.trim_right());
+        tera_context.insert("body", b.trim_end());
     }
     tera_context.extend(context.tera_context.clone());
 

--- a/components/templates/src/filters.rs
+++ b/components/templates/src/filters.rs
@@ -21,9 +21,9 @@ pub fn markdown(value: &Value, args: &HashMap<String, Value>) -> TeraResult<Valu
 
     if inline {
         html = html
-            .trim_left_matches("<p>")
+            .trim_start_matches("<p>")
             // pulldown_cmark finishes a paragraph with `</p>\n`
-            .trim_right_matches("</p>\n")
+            .trim_end_matches("</p>\n")
             .to_string();
     }
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -41,7 +41,7 @@ pub fn create_new_project(name: &str) -> Result<()> {
     let search = ask_bool("> Do you want to build a search index of the content?", false)?;
 
     let config = CONFIG
-        .trim_left()
+        .trim_start()
         .replace("%BASE_URL%", &base_url)
         .replace("%COMPILE_SASS%", &format!("{}", compile_sass))
         .replace("%SEARCH%", &format!("{}", search))


### PR DESCRIPTION
trim_{start, end} is introduced in rust 1.30.0 and trim_{left, right} is deprecated since 1.33.0.

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Code changes

* [x] Are you doing the PR on the `next` branch?
