### PR TITLE
Handle csv parsing error when encountering rows with different lengths

### DIFF
--- a/components/utils/test-files/uneven_rows.csv
+++ b/components/utils/test-files/uneven_rows.csv
@@ -1,0 +1,4 @@
+Number,Title
+1,Gutenberg
+2,Printing
+3,Typewriter,ExtraBadColumn


### PR DESCRIPTION
Current code is calling unwrap on each row that results from csv crate parsing logic. This has been changed to match and map an error result into the expected Teraform error with chaining. Associated unit test has been added.


