### PR TITLE
Revert "Update snap installation instructions"

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -27,7 +27,7 @@ $ yay -S zola-bin
 Zola is available on snapcraft:
 
 ```bash
-$ snap install --edge --classic zola
+$ snap install --edge zola
 ```
 
 ## Windows


### PR DESCRIPTION
This reverts commit 5fd7bf7e61c87320b1c5a9f358df2d82525ea465.

Apparently it is not just no longer necessary to use classic
confinement, but actually impossible, i.e. snap emits an error that the
zola snap is not compatible with `--classic`.

Snap version: 2.37.1 (Debian 9)

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


