### PR TITLE
Add maxdeviant.com to examples

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -20,3 +20,4 @@
 | [Jens Getreu's blog](https://blog.getreu.net)                      |                                                      |
 | [Matthias Endler](https://matthias-endler.de)                      | https://github.com/mre/mre.github.io                 |
 | [Hello, Rust!](https://hello-rust.show)                            | https://github.com/hello-rust/hello-rust.github.io   |
+| [maxdeviant.com](https://maxdeviant.com/)                          |                                                      |


### PR DESCRIPTION
Added my personal site [maxdeviant.com](https://maxdeviant.com/) to the examples page.

The repo is not currently open source, but I might consider open sourcing it in the near future :wink: