### PR TITLE
update zola version on deployment docs

### DIFF
--- a/docs/content/documentation/deployment/github-pages.md
+++ b/docs/content/documentation/deployment/github-pages.md
@@ -51,7 +51,7 @@ language: minimal
 before_script:
   # Download and unzip the zola executable
   # Replace the version numbers in the URL by the version you want to use
-  - curl -s -L https://github.com/getzola/zola/releases/download/v0.5.0/zola-v0.5.0-x86_64-unknown-linux-gnu.tar.gz | sudo tar xvzf - -C /usr/local/bin
+  - curl -s -L https://github.com/getzola/zola/releases/download/v0.6.0/zola-v0.6.0-x86_64-unknown-linux-gnu.tar.gz | sudo tar xvzf - -C /usr/local/bin
 
 script:
   - zola build

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -41,7 +41,7 @@ variables:
   # This variable will ensure that the CI runner pulls in your theme from the submodule
   GIT_SUBMODULE_STRATEGY: recursive  
   # Specify the zola version you want to use here
-  ZOLA_VERSION: "v0.5.0"
+  ZOLA_VERSION: "v0.6.0"
 
 pages:
   script:

--- a/docs/content/documentation/deployment/netlify.md
+++ b/docs/content/documentation/deployment/netlify.md
@@ -55,7 +55,7 @@ command = "gutenberg build --base-url $DEPLOY_PRIME_URL"
 Since Netlify doesn't support Zola currently, you will need to download the archive directly from GitHub, replacing the version in the URL with the one you want:
 
 ```
-command = "curl -sL https://github.com/getzola/zola/releases/download/v0.5.0/zola-v0.5.0-x86_64-unknown-linux-gnu.tar.gz | tar zxv && ./zola build"
+command = "curl -sL https://github.com/getzola/zola/releases/download/v0.6.0/zola-v0.6.0-x86_64-unknown-linux-gnu.tar.gz | tar zxv && ./zola build"
 ```
 
 ## Manual Deploys


### PR DESCRIPTION
This PR updates the version of zola on the  deployment documentation to v0.6.0
as discussed in Issue #653 

