### PR TITLE
Allow manual specification of header IDs

### DIFF
--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -352,6 +352,46 @@ fn can_add_id_to_headers_same_slug() {
 }
 
 #[test]
+fn can_handle_manual_ids_on_headers() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let config = Config::default();
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    // Tested things: manual IDs; whitespace flexibility; that automatic IDs avoid collision with
+    // manual IDs; that duplicates are in fact permitted among manual IDs; that any non-plain-text
+    // in the middle of `{#…}` will disrupt it from being acknowledged as a manual ID (that last
+    // one could reasonably be considered a bug rather than a feature, but test it either way); one
+    // workaround for the improbable case where you actually want `{#…}` at the end of a header.
+    let res = render_content("\
+        # Hello\n\
+        # Hello{#hello}\n\
+        # Hello {#hello}\n\
+        # Hello     {#Something_else} \n\
+        # Workaround for literal {#…&#125;\n\
+        # Hello\n\
+        # Auto {#*matic*}", &context).unwrap();
+    assert_eq!(res.body, "\
+        <h1 id=\"hello-1\">Hello</h1>\n\
+        <h1 id=\"hello\">Hello</h1>\n\
+        <h1 id=\"hello\">Hello</h1>\n\
+        <h1 id=\"Something_else\">Hello</h1>\n\
+        <h1 id=\"workaround-for-literal\">Workaround for literal {#…}</h1>\n\
+        <h1 id=\"hello-2\">Hello</h1>\n\
+        <h1 id=\"auto-matic\">Auto {#<em>matic</em>}</h1>\n\
+        ");
+}
+
+#[test]
+fn blank_headers() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let config = Config::default();
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content("# \n#\n# {#hmm} \n# {#}", &context).unwrap();
+    assert_eq!(res.body, "<h1 id=\"-1\"></h1>\n<h1 id=\"-2\"></h1>\n<h1 id=\"hmm\"></h1>\n<h1 id=\"\"></h1>\n");
+}
+
+#[test]
 fn can_insert_anchor_left() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();

--- a/docs/content/documentation/content/linking.md
+++ b/docs/content/documentation/content/linking.md
@@ -16,6 +16,14 @@ if the slug already exists for that article. For example:
 ## Example code <- example-code-1
 ```
 
+You can also manually specify an id with a `{#…}` suffix on the header line:
+
+```md
+# Something manual! {#manual}
+```
+
+This is useful for making deep links robust, either proactively (so that you can later change the text of a header without breaking links to it) or retroactively (keeping the slug of the old header text, when changing the text). It can also be useful for migration of existing sites with different header id schemes, so that you can keep deep links working.
+
 ## Anchor insertion
 It is possible to have Zola automatically insert anchor links next to the header, as you can see on the site you are currently
 reading if you hover a title.


### PR DESCRIPTION
Justification for this feature is added in the docs.

Precedent for the precise syntax: Hugo.

Hugo puts this syntax behind a preference named headerIds, and automatic header ID generation behind a preference named autoHeaderIds, with both enabled by default. I have not implemented a switch to disable this.

My suggestion for a workaround for the improbable case of desiring a literal “{#…}” at the end of a header is to replace `}` with `&#125;`.

The algorithm I have used is not identical to [that which Hugo uses][0], because Hugo’s looks to work at the source level, whereas here we work at the pulldown-cmark event level, which is generally more sane, but potentially limiting for extremely esoteric IDs.

Practical differences in implementation from Hugo (based purely on reading [blackfriday’s implementation][0], not actually trying it):

- I believe Hugo would treat `# Foo {#*bar*}` as a heading with text “Foo” and ID `*bar*`, since it is working at the source level; whereas this code turns it into a heading with HTML `Foo {#<em>bar</em>}`, as it works at the pulldown-cmark event level and doesn’t go out of its way to make that work (I’m not familiar with pulldown-cmark, but I get the impression that you could make it work Hugo’s way on this point). The difference should be negligible: only *very* esoteric hashes would include magic Markdown characters.

- Hugo will automatically generate an ID for `{#}`, whereas what I’ve coded here will yield a blank ID instead (which feels more correct to me—`None` versus `Some("")`, and all that).

In practice the results should be identical.

Fixes #433.

[0]: https://github.com/russross/blackfriday/blob/a477dd1646916742841ed20379f941cfa6c5bb6f/block.go#L218-L234