### PR TITLE
chore: Update toml to 0.5 everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,7 @@ dependencies = [
  "slug 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 1.0.0-beta.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
 ]
 
@@ -2774,14 +2774,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "toml"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2978,7 +2970,7 @@ dependencies = [
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 1.0.0-beta.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3183,7 +3175,7 @@ dependencies = [
  "rebuild 0.1.0",
  "site 0.1.0",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
  "ws 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3464,7 +3456,6 @@ dependencies = [
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 "checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
-"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum trust-dns-proto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5559ebdf6c2368ddd11e20b11d6bbaf9e46deb803acd7815e93f5a7b4a6d2901"
 "checksum trust-dns-resolver 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c9992e58dba365798803c0b91018ff6c8d3fc77e06977c4539af2a6bfe0a039"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ atty = "0.2.11"
 clap = "2"
 chrono = "0.4"
 lazy_static = "1.1.0"
-toml = "0.4"
+toml = "0.5"
 termcolor = "1.0.4"
 # Used in init to ensure the url given as base_url is a valid one
 url = "1.5"

--- a/components/library/Cargo.toml
+++ b/components/library/Cargo.toml
@@ -22,5 +22,5 @@ errors = { path = "../errors" }
 
 [dev-dependencies]
 tempfile = "3"
-toml = "0.4"
+toml = "0.5"
 globset = "0.4"

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -8,7 +8,7 @@ errors = { path = "../errors" }
 tera = "1.0.0-beta.10"
 unicode-segmentation = "1.2"
 walkdir = "2"
-toml = "0.4"
+toml = "0.5"
 serde = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Seems it was missed in last dependency update. Not sure if intentionally though.