### PR TITLE
Add an option to hard link files from static/ instead of copying.

### DIFF
--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -106,6 +106,8 @@ pub struct Config {
     pub generate_rss: bool,
     /// The number of articles to include in the RSS feed. Defaults to including all items.
     pub rss_limit: Option<usize>,
+    /// If set, files from static/ will be hardlinked instead of copied to the output dir.
+    pub hard_link_static: bool,
 
     pub taxonomies: Vec<Taxonomy>,
 
@@ -280,6 +282,7 @@ impl Default for Config {
             languages: Vec::new(),
             generate_rss: false,
             rss_limit: None,
+            hard_link_static: false,
             taxonomies: Vec::new(),
             compile_sass: false,
             check_external_links: false,

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -597,11 +597,12 @@ impl Site {
             copy_directory(
                 &self.base_path.join("themes").join(theme).join("static"),
                 &self.output_path,
+                false
             )?;
         }
         // We're fine with missing static folders
         if self.static_path.exists() {
-            copy_directory(&self.static_path, &self.output_path)?;
+            copy_directory(&self.static_path, &self.output_path, self.config.hard_link_static)?;
         }
 
         Ok(())

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -111,7 +111,7 @@ pub fn copy_file(src: &Path, dest: &PathBuf, base_path: &PathBuf, hard_link: boo
     Ok(())
 }
 
-pub fn copy_directory(src: &PathBuf, dest: &PathBuf, hardlink: bool) -> Result<()> {
+pub fn copy_directory(src: &PathBuf, dest: &PathBuf, hard_link: bool) -> Result<()> {
     for entry in WalkDir::new(src).into_iter().filter_map(std::result::Result::ok) {
         let relative_path = entry.path().strip_prefix(src).unwrap();
         let target_path = dest.join(relative_path);
@@ -121,7 +121,7 @@ pub fn copy_directory(src: &PathBuf, dest: &PathBuf, hardlink: bool) -> Result<(
                 create_directory(&target_path)?;
             }
         } else {
-            copy_file(entry.path(), dest, src, hardlink)?;
+            copy_file(entry.path(), dest, src, hard_link)?;
         }
     }
     Ok(())

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -111,7 +111,7 @@ pub fn copy_file(src: &Path, dest: &PathBuf, base_path: &PathBuf, hardlink: bool
     Ok(())
 }
 
-pub fn copy_directory(src: &PathBuf, dest: &PathBuf) -> Result<()> {
+pub fn copy_directory(src: &PathBuf, dest: &PathBuf, hardlink: bool) -> Result<()> {
     for entry in WalkDir::new(src).into_iter().filter_map(std::result::Result::ok) {
         let relative_path = entry.path().strip_prefix(src).unwrap();
         let target_path = dest.join(relative_path);
@@ -121,7 +121,7 @@ pub fn copy_directory(src: &PathBuf, dest: &PathBuf) -> Result<()> {
                 create_directory(&target_path)?;
             }
         } else {
-            copy_file(entry.path(), dest, src, false)?;
+            copy_file(entry.path(), dest, src, hardlink)?;
         }
     }
     Ok(())

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -1,4 +1,4 @@
-use std::fs::{copy, create_dir_all, read_dir, File};
+use std::fs::{copy, create_dir_all, hard_link, read_dir, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -95,7 +95,7 @@ pub fn find_related_assets(path: &Path) -> Vec<PathBuf> {
 
 /// Copy a file but takes into account where to start the copy as
 /// there might be folders we need to create on the way
-pub fn copy_file(src: &Path, dest: &PathBuf, base_path: &PathBuf) -> Result<()> {
+pub fn copy_file(src: &Path, dest: &PathBuf, base_path: &PathBuf, hardlink: bool) -> Result<()> {
     let relative_path = src.strip_prefix(base_path).unwrap();
     let target_path = dest.join(relative_path);
 
@@ -103,7 +103,11 @@ pub fn copy_file(src: &Path, dest: &PathBuf, base_path: &PathBuf) -> Result<()> 
         create_dir_all(parent_directory)?;
     }
 
-    copy(src, target_path)?;
+    if hardlink {
+        hard_link(src, target_path)?
+    } else {
+        copy(src, target_path)?;
+    }
     Ok(())
 }
 
@@ -117,7 +121,7 @@ pub fn copy_directory(src: &PathBuf, dest: &PathBuf) -> Result<()> {
                 create_directory(&target_path)?;
             }
         } else {
-            copy_file(entry.path(), dest, src)?;
+            copy_file(entry.path(), dest, src, false)?;
         }
     }
     Ok(())

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -1,4 +1,4 @@
-use std::fs::{copy, create_dir_all, hard_link, read_dir, File};
+use std::fs::{copy, create_dir_all, read_dir, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -95,7 +95,7 @@ pub fn find_related_assets(path: &Path) -> Vec<PathBuf> {
 
 /// Copy a file but takes into account where to start the copy as
 /// there might be folders we need to create on the way
-pub fn copy_file(src: &Path, dest: &PathBuf, base_path: &PathBuf, hardlink: bool) -> Result<()> {
+pub fn copy_file(src: &Path, dest: &PathBuf, base_path: &PathBuf, hard_link: bool) -> Result<()> {
     let relative_path = src.strip_prefix(base_path).unwrap();
     let target_path = dest.join(relative_path);
 
@@ -103,8 +103,8 @@ pub fn copy_file(src: &Path, dest: &PathBuf, base_path: &PathBuf, hardlink: bool
         create_dir_all(parent_directory)?;
     }
 
-    if hardlink {
-        hard_link(src, target_path)?
+    if hard_link {
+        std::fs::hard_link(src, target_path)?
     } else {
         copy(src, target_path)?;
     }

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -41,9 +41,9 @@ generate_rss = false
 # not set (the default).
 # rss_limit = 20
 
-# Whether to copy or hardlink files in `static/` directory. Useful for sites
-# whose static files are large. Note that for this to work, both `static/` and
-# output directory need to be on the same filesystem. Also, theme's `static/`
+# Whether to copy or hardlink files in static/ directory. Useful for sites
+# whose static files are large. Note that for this to work, both static/ and
+# output directory need to be on the same filesystem. Also, theme's static/
 # files are always copies, regardles of this setting. False by default.
 # hard_link_static = true
 

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -45,7 +45,7 @@ generate_rss = false
 # whose static files are large. Note that for this to work, both static/ and
 # output directory need to be on the same filesystem. Also, theme's static/
 # files are always copies, regardles of this setting. False by default.
-# hard_link_static = true
+# hard_link_static = false
 
 # The taxonomies to be rendered for that site and their configuration
 # Example:

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -41,6 +41,12 @@ generate_rss = false
 # not set (the default).
 # rss_limit = 20
 
+# Whether to copy or hardlink files in `static/` directory. Useful for sites
+# whose static files are large. Note that for this to work, both `static/` and
+# output directory need to be on the same filesystem. Also, theme's `static/`
+# files are always copies, regardles of this setting. False by default.
+# hard_link_static = true
+
 # The taxonomies to be rendered for that site and their configuration
 # Example:
 #     taxonomies = [

--- a/docs/content/documentation/getting-started/directory-structure.md
+++ b/docs/content/documentation/getting-started/directory-structure.md
@@ -38,6 +38,8 @@ The directory structure of the `sass` folder will be preserved when copying over
 
 ## `static`
 Contains any kind of files. All the files/folders in the `static` folder will be copied as-is in the output directory.
+If your static files are large you can configure Zola to [hard link](https://en.wikipedia.org/wiki/Hard_link) them
+instead of copying by setting `hard_link_static = true` in the config file.
 
 ## `templates`
 Contains all the [Tera](https://tera.netlify.com) templates that will be used to render this site.

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -321,7 +321,7 @@ pub fn serve(
         } else {
             rebuild_done_handling(
                 &broadcaster,
-                copy_file(&path, &site.output_path, &site.static_path),
+                copy_file(&path, &site.output_path, &site.static_path, false),
                 &partial_path.to_string_lossy(),
             );
         }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -321,7 +321,7 @@ pub fn serve(
         } else {
             rebuild_done_handling(
                 &broadcaster,
-                copy_file(&path, &site.output_path, &site.static_path, false),
+                copy_file(&path, &site.output_path, &site.static_path, site.config.hard_link_static),
                 &partial_path.to_string_lossy(),
             );
         }


### PR DESCRIPTION
As discussed in https://github.com/getzola/zola/issues/710, I've tried to add an optional hardlink for static files. Worked for me 

The way I've tested this:
```
$ cd test_site
$ dd if=/dev/zero of=static/foo bs=100m count=6
$ cargo run -- build; ls -l static/foo public/foo
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
     Running `/Users/yacoob/workarea/zola/target/debug/zola build`
Building site...
-> Creating 22 pages (1 orphan), 10 sections, and processing 0 images
Done in 1.6s.

-rw-r-----  1 yacoob  staff  629145600 24 Jun 23:17 public/foo
-rw-r-----  1 yacoob  staff  629145600 24 Jun 23:17 static/foo
$ # added hard_link_static = true to config.toml
$ cargo run -- build; ls -l static/foo public/foo
   Compiling zola v0.8.0 (/Users/yacoob/workarea/zola)
    Finished dev [unoptimized + debuginfo] target(s) in 9.42s
     Running `/Users/yacoob/workarea/zola/target/debug/zola build`
Building site...
-> Creating 22 pages (1 orphan), 10 sections, and processing 0 images
Done in 723ms.

-rw-r-----  2 yacoob  staff  629145600 24 Jun 23:17 public/foo
-rw-r-----  2 yacoob  staff  629145600 24 Jun 23:17 static/foo
```
With `hard_link_static = true` the build was faster as expected, and the hardlink count in `ls` output has increased. 

I don't have a good idea how to add a meaningful test here. If you do, I'm all ears. Maybe just enable it for the `test_site`, to make sure the codepath gets executed during integration test?

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



