### PR TITLE
Simplify yes/ehh/no links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,31 +10,31 @@ in the `docs/content` folder of the repository and the community can use [its fo
 
 ## Comparisons with other static site generators
 
-|                                 | Zola                 | Cobalt               | Hugo                 | Pelican              |
-|:--------------------------------|:--------------------:|:--------------------:|:--------------------:|:--------------------:|
-| Single binary                   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![no](./is-no.svg)   |
-| Language                        | Rust                 | Rust                 | Go                   | Python               |
-| Syntax highlighting             | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Sass compilation                | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Assets co-location              | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Multilingual site               | ![ehh](./is-ehh.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Image processing                | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Sane & powerful template engine | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![ehh](./is-ehh.svg) | ![yes](./is-yes.svg) |
-| Themes                          | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Shortcodes                      | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Internal links                  | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Link checker                    | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![no](./is-no.svg)   | ![yes](./is-yes.svg) |
-| Table of contents               | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Automatic header anchors        | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Aliases                         | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Pagination                      | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Custom taxonomies               | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![no](./is-no.svg)   |
-| Search                          | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![no](./is-no.svg)   | ![yes](./is-yes.svg) |
-| Data files                      | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) | ![no](./is-no.svg)   |
-| LiveReload                      | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![yes](./is-yes.svg) |
-| Netlify support                 | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![no](./is-no.svg)   |
-| Breadcrumbs                     | ![yes](./is-yes.svg) | ![no](./is-no.svg)   | ![no](./is-no.svg)   | ![yes](./is-yes.svg) |
-| Custom output formats           | ![no](./is-no.svg)   | ![no](./is-no.svg)   | ![yes](./is-yes.svg) | ![no](./is-no.svg)   |
+|                                 | Zola   | Cobalt | Hugo   | Pelican |
+|:--------------------------------|:------:|:------:|:------:|:-------:|
+| Single binary                   | ![yes] | ![yes] | ![yes] | ![no]   |
+| Language                        | Rust   | Rust   | Go     | Python  |
+| Syntax highlighting             | ![yes] | ![yes] | ![yes] | ![yes]  |
+| Sass compilation                | ![yes] | ![yes] | ![yes] | ![yes]  |
+| Assets co-location              | ![yes] | ![yes] | ![yes] | ![yes]  |
+| Multilingual site               | ![ehh] | ![no]  | ![yes] | ![yes]  |
+| Image processing                | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Sane & powerful template engine | ![yes] | ![yes] | ![ehh] | ![yes]  |
+| Themes                          | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Shortcodes                      | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Internal links                  | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Link checker                    | ![yes] | ![no]  | ![no]  | ![yes]  |
+| Table of contents               | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Automatic header anchors        | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Aliases                         | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Pagination                      | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Custom taxonomies               | ![yes] | ![no]  | ![yes] | ![no]   |
+| Search                          | ![yes] | ![no]  | ![no]  | ![yes]  |
+| Data files                      | ![yes] | ![yes] | ![yes] | ![no]   |
+| LiveReload                      | ![yes] | ![no]  | ![yes] | ![yes]  |
+| Netlify support                 | ![yes] | ![no]  | ![yes] | ![no]   |
+| Breadcrumbs                     | ![yes] | ![no]  | ![no]  | ![yes]  |
+| Custom output formats           | ![no]  | ![no]  | ![yes] | ![no]   |
 
 ### Supported content formats
 
@@ -43,12 +43,16 @@ in the `docs/content` folder of the repository and the community can use [its fo
 - Hugo: markdown, asciidoc, org-mode
 - Pelican: reStructuredText, markdown, asciidoc, org-mode, whatever-you-want
 
-### ![ehh](./is-ehh.svg) explanations
+### ![ehh] explanations
 
-Hugo gets ![ehh](./is-ehh.svg) for the template engine because while it is probably the most powerful template engine in the list, after Jinja2, it personally drives me insane, to the point of writing my own template engine and static site generator. Yes, this is a bit biased.
+Hugo gets ![ehh] for the template engine because while it is probably the most powerful template engine in the list, after Jinja2, it personally drives me insane, to the point of writing my own template engine and static site generator. Yes, this is a bit biased.
 
-Zola gets ![ehh](./is-ehh.svg) for the multi-language support as it only has a basic support and does not offer (yet) things like i18n in templates.
+Zola gets ![ehh] for the multi-language support as it only has a basic support and does not offer (yet) things like i18n in templates.
 
 ### Pelican notes
 
 Many features of Pelican are coming from plugins, which might be tricky to use because of version mismatch or lacking documentation. Netlify supports Python and Pipenv but you still need to install your dependencies manually.
+
+[yes]: ./is-yes.svg
+[ehh]: ./is-ehh.svg
+[no]:  ./is-no.svg


### PR DESCRIPTION
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

----

Came across this project and figured I'd make a small quality-of-life improvement. 😄

This makes it such that you only need to type `![yes]` to get ![yes](https://raw.githubusercontent.com/getzola/zola/master/is-yes.svg?sanitize=true), and likewise for "ehh" and "no".