### PR TITLE
Add --open flag to serve command, to open URL in default browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "open"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3172,6 +3180,7 @@ dependencies = [
  "front_matter 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "open 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rebuild 0.1.0",
  "site 0.1.0",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3345,6 +3354,7 @@ dependencies = [
 "checksum onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a646989adad8a19f49be2090374712931c3a59835cb5277b4530f48b417f26e7"
 "checksum onig_sys 69.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388410bf5fa341f10e58e6db3975f4bea1ac30247dd79d37a9e5ced3cb4cc3b0"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
+"checksum open 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "02bbc4c56e3254b7717562db189ef6a327e29842d79402123a018c1fde065dfc"
 "checksum openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)" = "97c140cbb82f3b3468193dd14c1b88def39f341f68257f8a7fe8ed9ed3f628a5"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ actix-web = { version = "1.0", default-features = false, features = [] }
 notify = "4"
 ws = "0.8"
 ctrlc = "3"
+open = "1.2"
 
 site = { path = "components/site" }
 errors = { path = "components/errors" }

--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -56,6 +56,9 @@ the interface/port combination to use if you want something different than the d
 You can also specify different addresses for the interface and base_url using `-u`/`--base-url`, for example
 if you are running zola in a Docker container.
 
+Use the `--open` flag to automatically open the locally hosted instance in your
+web browser.
+
 In the event you don't want zola to run a local webserver, you can use the `--watch-only` flag.
 
 Before starting, it will delete the public directory to ensure it starts from a clean slate.
@@ -68,6 +71,7 @@ $ zola serve --interface 0.0.0.0 --port 2000
 $ zola serve --interface 0.0.0.0 --base-url 127.0.0.1
 $ zola serve --interface 0.0.0.0 --port 2000 --output-dir www/public
 $ zola serve --watch-only
+$ zola serve --open
 ```
 
 The serve command will watch all your content and will provide live reload, without

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,7 +65,12 @@ pub fn build_cli() -> App<'static, 'static> {
                     Arg::with_name("watch_only")
                         .long("watch-only")
                         .takes_value(false)
-                        .help("Do not start a server, just re-build project on changes")
+                        .help("Do not start a server, just re-build project on changes"),
+                    Arg::with_name("open")
+                        .short("O")
+                        .long("open")
+                        .takes_value(false)
+                        .help("Open site in the default browser"),
                 ]),
             SubCommand::with_name("check")
                 .about("Try building the project without rendering it. Checks links")

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -42,6 +42,7 @@ use site::Site;
 use utils::fs::copy_file;
 
 use console;
+use open;
 use rebuild;
 
 #[derive(Debug, PartialEq)]
@@ -146,6 +147,7 @@ pub fn serve(
     base_url: &str,
     config_file: &str,
     watch_only: bool,
+    open: bool,
 ) -> Result<()> {
     let start = Instant::now();
     let (mut site, address) = create_new_site(interface, port, output_dir, base_url, config_file)?;
@@ -211,6 +213,11 @@ pub fn serve(
             .expect("Can't start the webserver")
             .shutdown_timeout(20);
             println!("Web server is available at http://{}\n", &address);
+            if open {
+                if let Err(err) = open::that(format!("http://{}", &address)) {
+                    eprintln!("Failed to open URL in your browser: {}", err);
+                }
+            }
             s.run()
         });
         // The websocket for livereload

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ extern crate site;
 #[macro_use]
 extern crate errors;
 extern crate front_matter;
+extern crate open;
 extern crate rebuild;
 extern crate utils;
 
@@ -65,6 +66,7 @@ fn main() {
                 }
             };
             let watch_only = matches.is_present("watch_only");
+            let open = matches.is_present("open");
 
             // Default one
             if port != 1111 && !watch_only && !port_is_available(port) {
@@ -83,7 +85,7 @@ fn main() {
             let output_dir = matches.value_of("output_dir").unwrap();
             let base_url = matches.value_of("base_url").unwrap();
             console::info("Building site...");
-            match cmd::serve(interface, port, output_dir, base_url, config_file, watch_only) {
+            match cmd::serve(interface, port, output_dir, base_url, config_file, watch_only, open) {
                 Ok(()) => (),
                 Err(e) => {
                     console::unravel_errors("", &e);


### PR DESCRIPTION
> **IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**
>
> The place to discuss new features is the forum: <https://zola.discourse.group/>
> If you want to add a new feature, please open a thread there first in the feature requests section.

I noticed this message after adding this feature. Since it's quite small I decided to initiate the PR anyway. Please tell me if a discussion for this is still desired. In that case I'll be sure to follow up to that.

This PR adds an `--open` flag to the `serve` command, to open the URL the page is locally hosted at in the default browser of the user. While working with `zola` I commonly wanted to have such functionality  built-in, thus I decided to add this.

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



