### PR TITLE
Fix broken links on the "Sections and Pages" documentation page

### DIFF
--- a/docs/content/documentation/templates/pagination.md
+++ b/docs/content/documentation/templates/pagination.md
@@ -6,7 +6,7 @@ weight = 30
 Two things can get paginated: a section and a taxonomy term.
 
 A paginated section gets the same `section` variable as a normal
-[section page](./documentation/templates/pages-sections.md#section-variables) minus its pages
+[section page](@/documentation/templates/pages-sections.md#section-variables) minus its pages
 while both a paginated taxonomy page and a paginated section page gets a
 `paginator` variable of the `Pager` type:
 
@@ -35,7 +35,7 @@ current_index: Number;
 ## Section
 
 A paginated section gets the same `section` variable as a normal
-[section page](./documentation/templates/pages-sections.md#section-variables)
+[section page](@/documentation/templates/pages-sections.md#section-variables)
 minus its pages. The pages are instead in `paginator.pages`.
 
 ## Taxonomy term


### PR DESCRIPTION
It looks like two links on this page didn't get updated with the change from `./` to `@/` in ec61a57, resulting in broken links. This PR fixes that.

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?


