### PR TITLE
Allow relative paths in new_file()/new_section()

### DIFF
--- a/components/library/src/content/file_info.rs
+++ b/components/library/src/content/file_info.rs
@@ -57,7 +57,7 @@ impl FileInfo {
         let mut parent = file_path.parent().expect("Get parent of page").to_path_buf();
         let name = path.file_stem().unwrap().to_string_lossy().to_string();
         let mut components = find_content_components(
-            &file_path.strip_prefix(base_path).expect("Strip base path prefix for page"),
+            &file_path.strip_prefix(base_path).unwrap_or(&file_path),
         );
         let relative = if !components.is_empty() {
             format!("{}/{}.md", components.join("/"), name)
@@ -92,7 +92,7 @@ impl FileInfo {
         let parent = path.parent().expect("Get parent of section").to_path_buf();
         let name = path.file_stem().unwrap().to_string_lossy().to_string();
         let components = find_content_components(
-            &file_path.strip_prefix(base_path).expect("Strip base path prefix for section"),
+            &file_path.strip_prefix(base_path).unwrap_or(&file_path),
         );
         let relative = if !components.is_empty() {
             format!("{}/{}.md", components.join("/"), name)


### PR DESCRIPTION
These functions expect that file_path can have base_path stripped from it, but during reloading they can be given relative paths.  Maybe this behaviour varies between the notify backends?

This fixes two `zola serve` panics on FreeBSD (poll backend).