### PR TITLE
ADD: reload when themes change

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -568,6 +568,11 @@ mod tests {
                 Path::new("/home/vincent/site/templates/hello.html"),
             ),
             (
+                (ChangeKind::Themes, PathBuf::from("/themes/hello.html")),
+                Path::new("/home/vincent/site"),
+                Path::new("/home/vincent/site/themes/hello.html"),
+            ),
+            (
                 (ChangeKind::StaticFiles, PathBuf::from("/static/site.css")),
                 Path::new("/home/vincent/site"),
                 Path::new("/home/vincent/site/static/site.css"),


### PR DESCRIPTION
Add a feature that, when `zola serve`, reload site if themes change. As issue #713.

This implementation rebuild the entire site instead of rebuilding the pages that affected.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?
Not yet



