### PR TITLE
Add trailing slash to multilingual section path

### DIFF
--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -113,7 +113,11 @@ impl Section {
         section.reading_time = Some(reading_time);
         let path = section.file.components.join("/");
         if section.lang != config.default_language {
-            section.path = format!("{}/{}", section.lang, path);
+            if path.is_empty() {
+                section.path = format!("{}/", section.lang);
+            } else {
+                section.path = format!("{}/{}/", section.lang, path);
+            }
         } else {
             section.path = format!("{}/", path);
         }
@@ -380,5 +384,22 @@ Bonjour le monde"#
         let section = res.unwrap();
         assert_eq!(section.lang, "fr".to_string());
         assert_eq!(section.permalink, "http://a-website.com/fr/");
+    }
+
+    #[test]
+    fn can_make_links_to_translated_subsections_with_trailing_slash() {
+        let mut config = Config::default();
+        config.languages.push(Language { code: String::from("fr"), rss: false });
+        let content = r#"
++++
++++
+Bonjour le monde"#
+            .to_string();
+        let res =
+            Section::parse(Path::new("content/subcontent/_index.fr.md"), &content, &config, &PathBuf::new());
+        assert!(res.is_ok());
+        let section = res.unwrap();
+        assert_eq!(section.lang, "fr".to_string());
+        assert_eq!(section.permalink, "http://a-website.com/fr/subcontent/");
     }
 }


### PR DESCRIPTION
Other than the default language that is set at `config.toml`, `section.path` ends without a trailing slash in multilingual sites.
This behaviour seems to have been introduced with [this commit](https://github.com/getzola/zola/commit/260c413de406dd176605eb1db3a75d17c5418e64#diff-0ba0bdecfa60be201d2919df49632079L95-R95).
I think it would be reasonable for `section.path` to end with a slash, regardless of the language settings.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



