### PR TITLE
Fix ToC generation for heading levels > 3 (bugfix)

### DIFF
--- a/components/rendering/src/table_of_contents.rs
+++ b/components/rendering/src/table_of_contents.rs
@@ -45,14 +45,13 @@ fn insert_into_parent(potential_parent: Option<&mut Header>, header: &Header) ->
                 // We have a direct child of the parent
                 parent.children.push(header.clone());
                 return true;
-            } else {
-                // We need to go deeper
-                if !insert_into_parent(parent.children.iter_mut().last(), header) {
-                    // No, we need to insert it here
-                    parent.children.push(header.clone());
-                }
-                return true;
             }
+            // We need to go deeper
+            if !insert_into_parent(parent.children.iter_mut().last(), header) {
+                // No, we need to insert it here
+                parent.children.push(header.clone());
+            }
+            return true;
         }
     }
 }

--- a/components/rendering/src/table_of_contents.rs
+++ b/components/rendering/src/table_of_contents.rs
@@ -40,25 +40,18 @@ fn insert_into_parent(potential_parent: Option<&mut Header>, header: &Header) ->
             if diff <= 0 {
                 // Heading is same level or higher so we don't insert here
                 return false;
+            } 
+            if diff == 1 {
+                // We have a direct child of the parent
+                parent.children.push(header.clone());
+                return true;
             } else {
-                if diff == 1 {
-                    // We have a direct child of the parent
+                // We need to go deeper
+                if !insert_into_parent(parent.children.iter_mut().last(), header) {
+                    // No, we need to insert it here
                     parent.children.push(header.clone());
-                    return true;
-                } else {
-                    // We need to go deeper
-                    match insert_into_parent(parent.children.iter_mut().last(), header) {
-                        true => {
-                            // Element was succesfully inserted deeper in the recursion
-                            return true;
-                        },
-                        false => {
-                            // No, we need to insert it here
-                            parent.children.push(header.clone());
-                            return true;
-                        }
-                    }
                 }
+                return true;
             }
         }
     }
@@ -122,6 +115,49 @@ mod tests {
         assert_eq!(toc[1].children.len(), 1);
         assert_eq!(toc[0].children[1].children.len(), 1);
         assert_eq!(toc[1].children[0].children.len(), 2);
+    }
+
+    #[test]
+    fn can_make_deep_toc() {
+        let input = vec![
+            Header::new(1),
+            Header::new(2),
+            Header::new(3),
+            Header::new(4),
+            Header::new(5),
+            Header::new(4),
+        ];
+        let toc = make_table_of_contents(input);
+        assert_eq!(toc.len(), 1);
+        assert_eq!(toc[0].children.len(), 1);
+        assert_eq!(toc[0].children[0].children.len(), 1);
+        assert_eq!(toc[0].children[0].children[0].children.len(), 2);
+        assert_eq!(toc[0].children[0].children[0].children[0].children.len(), 1);
+    }
+
+    #[test]
+    fn can_make_deep_messy_toc() {
+        let input = vec![
+            Header::new(2), // toc[0]
+            Header::new(3),
+            Header::new(4),
+            Header::new(5),
+            Header::new(4),
+            Header::new(2), // toc[1]
+            Header::new(1), // toc[2]
+            Header::new(2),
+            Header::new(3),
+            Header::new(4),
+        ];
+        let toc = make_table_of_contents(input);
+        assert_eq!(toc.len(), 3);
+        assert_eq!(toc[0].children.len(), 1);
+        assert_eq!(toc[0].children[0].children.len(), 2);
+        assert_eq!(toc[0].children[0].children[0].children.len(), 1);
+        assert_eq!(toc[1].children.len(), 0);
+        assert_eq!(toc[2].children.len(), 1);
+        assert_eq!(toc[2].children[0].children.len(), 1);
+        assert_eq!(toc[2].children[0].children[0].children.len(), 1);
     }
 
     #[test]

--- a/components/rendering/src/table_of_contents.rs
+++ b/components/rendering/src/table_of_contents.rs
@@ -87,6 +87,7 @@ pub fn make_table_of_contents(headers: Vec<Header>) -> Vec<Header> {
                 continue;
             }
         }
+    }
 
     toc
 }


### PR DESCRIPTION
Previously, 4-level headers were inserted as children of the last 2nd level header because the code didn't go peek deep enough into the children of children (etc).

I wrote a simple recursive helper function that conveniently takes an Option<Header> to potentially insert a new Header into.

The documentation doesn't need to be edited.

TODO: i need to write some tests