### PR TITLE
zola init works inside existing directories (closes #406)

### DIFF
--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -13,11 +13,17 @@ the command help by running `zola <cmd> --help`.
 Creates the directory structure used by Zola at the given directory.
 
 ```bash
-$ zola init my_site
+$ zola init [my_site]
 ```
 
-will create a new folder named `my_site` and the files/folders needed by
-zola.
+If the `my_site` folder already exists, Zola will only populate it if it does not contain non-hidden files (dotfiles are ignored). If no `my_site` argument is passed, Zola will try to populate the current directory.
+
+You can initialize a git repository and a Zola site directly from within a new folder:
+
+```bash
+$ git init
+$ zola init
+```
 
 ## build
 

--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -13,7 +13,8 @@ the command help by running `zola <cmd> --help`.
 Creates the directory structure used by Zola at the given directory.
 
 ```bash
-$ zola init [my_site]
+$ zola init my_site
+$ zola init
 ```
 
 If the `my_site` folder already exists, Zola will only populate it if it does not contain non-hidden files (dotfiles are ignored). If no `my_site` argument is passed, Zola will try to populate the current directory.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,7 +19,7 @@ pub fn build_cli() -> App<'static, 'static> {
                 .about("Create a new Zola project")
                 .arg(
                     Arg::with_name("name")
-                        .required(true)
+                        .default_value(".")
                         .help("Name of the project. Will create a new directory with that name in the current directory")
                 ),
             SubCommand::with_name("build")

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -93,3 +93,57 @@ pub fn create_new_project(name: &str) -> Result<()> {
     println!("Visit https://www.getzola.org for the full documentation.");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::env::temp_dir;
+    use std::fs::{create_dir,remove_dir,remove_dir_all};
+    use super::*;
+
+    #[test]
+    fn init_empty_directory() {
+        let mut dir = temp_dir();
+        dir.push("test_empty_dir");
+        if dir.exists() {
+            remove_dir_all(&dir).expect("Could not free test directory");
+        }
+        create_dir(&dir).expect("Could not create test directory");
+        let allowed = is_directory_quasi_empty(&dir).expect("An error happened reading the directory's contents");
+        remove_dir(&dir).unwrap();
+        assert_eq!(true, allowed);
+    }
+
+    #[test]
+    fn init_non_empty_directory() {
+        let mut dir = temp_dir();
+        dir.push("test_non_empty_dir");
+        if dir.exists() {
+            remove_dir_all(&dir).expect("Could not free test directory");
+        }
+        create_dir(&dir).expect("Could not create test directory");
+        let mut content = dir.clone();
+        content.push("content");
+        create_dir(&content).unwrap();
+        let allowed = is_directory_quasi_empty(&dir).expect("An error happened reading the directory's contents");
+        remove_dir(&content).unwrap();
+        remove_dir(&dir).unwrap();
+        assert_eq!(false, allowed);
+    }
+
+    #[test]
+    fn init_quasi_empty_directory() {
+        let mut dir = temp_dir();
+        dir.push("test_quasi_empty_dir");
+        if dir.exists() {
+            remove_dir_all(&dir).expect("Could not free test directory");
+        }
+        create_dir(&dir).expect("Could not create test directory");
+        let mut git = dir.clone();
+        git.push(".git");
+        create_dir(&git).unwrap();
+        let allowed = is_directory_quasi_empty(&dir).expect("An error happened reading the directory's contents");
+        remove_dir(&git).unwrap();
+        remove_dir(&dir).unwrap();
+        assert_eq!(true, allowed);
+    }
+}


### PR DESCRIPTION
I've just had the problem described in #406 when trying to git init then zola init in a directory.

I think this patch respects the decision taken on that thread:
- non-empty folders raise an error (hidden files are ignored)
- zola init works without argument, taking the current directory instead

I've updated the docs about CLI usage.

I should probably write some tests before this gets merged, i just wanted to get your feedback before to see if this is ok