### PR TITLE
Fix crash of trans() function called on absent translation key

### DIFF
--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -8,6 +8,7 @@ use toml;
 use toml::Value as Toml;
 
 use errors::Result;
+use errors::Error;
 use highlighting::THEME_SET;
 use theme::Theme;
 use utils::fs::read_file_with_error;
@@ -83,6 +84,8 @@ impl Default for Taxonomy {
     }
 }
 
+type TranslateTerm  = HashMap<String, String>;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -100,8 +103,12 @@ pub struct Config {
     pub default_language: String,
     /// The list of supported languages outside of the default one
     pub languages: Vec<Language>,
+
     /// Languages list and translated strings
-    pub translations: HashMap<String, Toml>,
+    ///
+    /// The `String` key of `HashMap` is a language name, the value should be toml crate `Table`
+    /// with String key representing term and value another `String` representing its translation.
+    pub translations: HashMap<String, TranslateTerm>,
 
     /// Whether to highlight all code blocks found in markdown files. Defaults to false
     pub highlight_code: bool,
@@ -299,6 +306,16 @@ impl Config {
         // and this operation can be expensive.
         self.highlight_code = false;
     }
+
+    pub fn get_translation<S: AsRef<str>>(&self, lang: S, key: S) -> Result<String> {
+        let terms = self.translations.get(lang.as_ref()).ok_or_else(|| {
+            Error::msg(format!("Translation for language '{}' is missing", lang.as_ref()))
+        })?;
+
+        terms.get(key.as_ref()).ok_or_else(|| {
+            Error::msg(format!("Translation key '{}' for language '{}' is missing", key.as_ref(), lang.as_ref()))
+        }).map(|term| term.to_string())
+    }
 }
 
 impl Default for Config {
@@ -447,9 +464,7 @@ a_value = 10
         assert_eq!(extra["a_value"].as_integer().unwrap(), 10);
     }
 
-    #[test]
-    fn can_use_language_configuration() {
-        let config = r#"
+    const CONFIG_TRANSLATION: &str = r#"
 base_url = "https://remplace-par-ton-url.fr"
 default_language = "fr"
 
@@ -459,14 +474,38 @@ title = "Un titre"
 
 [translations.en]
 title = "A title"
-
         "#;
 
-        let config = Config::parse(config);
+    #[test]
+    fn can_use_language_configuration() {
+        let config = Config::parse(CONFIG_TRANSLATION);
         assert!(config.is_ok());
         let translations = config.unwrap().translations;
-        assert_eq!(translations["fr"]["title"].as_str().unwrap(), "Un titre");
-        assert_eq!(translations["en"]["title"].as_str().unwrap(), "A title");
+        assert_eq!(translations["fr"]["title"].as_str(), "Un titre");
+        assert_eq!(translations["en"]["title"].as_str(), "A title");
+    }
+
+    #[test]
+    fn can_use_present_translation() {
+        let config = Config::parse(CONFIG_TRANSLATION).unwrap();
+        assert_eq!(config.get_translation("fr", "title").unwrap(), "Un titre");
+        assert_eq!(config.get_translation("en", "title").unwrap(), "A title");
+    }
+
+    #[test]
+    fn error_on_absent_translation_lang() {
+        let config = Config::parse(CONFIG_TRANSLATION).unwrap();
+        let error = config.get_translation("absent", "key").unwrap_err();
+
+        assert_eq!("Translation for language 'absent' is missing", format!("{}", error));
+    }
+
+    #[test]
+    fn error_on_absent_translation_key() {
+        let config = Config::parse(CONFIG_TRANSLATION).unwrap();
+        let error = config.get_translation("en", "absent").unwrap_err();
+
+        assert_eq!("Translation key 'absent' for language 'en' is missing", format!("{}", error));
     }
 
     #[test]


### PR DESCRIPTION
## Description

The `trans()` Tera function used by Zola crashes when attempting to translate key that does not exist in `config.toml` file. The crash does not even contain information *which* key is missing from config, making fixing config impossible.

The root cause of the crash was un-handled error path when retrieving translations and keys from Config struct. 

The PR adds new method for `Config` struct for translation retrieval. The reason for addition to `Config` is mainly encapsulation of the config data access and reusability by other parts of Zola code.

Then updates implementation of `Trans::call()` function that provides `trans()` Tera function to use new way for translation retrieval and chain any errors with additional error message for better readability.

I have not removed existing unit tests nor `pub` from `Config::translation` field. It is something that 'might' be desirable, to ensure that nobody will try to mess with `Config struct` internals without proper error checks again.

## Sanity check

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
  * no documentation to update as I was fixing crash



