### PR TITLE
Remove pub visibility from Config::translations hash

### DIFF
--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -110,7 +110,10 @@ pub struct Config {
     ///
     /// The `String` key of `HashMap` is a language name, the value should be toml crate `Table`
     /// with String key representing term and value another `String` representing its translation.
-    pub translations: HashMap<String, TranslateTerm>,
+    ///
+    /// The attribute is intentionally not public, use `get_translation()` method for translating
+    /// key into different language.
+    translations: HashMap<String, TranslateTerm>,
 
     /// Whether to highlight all code blocks found in markdown files. Defaults to false
     pub highlight_code: bool,
@@ -477,15 +480,6 @@ title = "Un titre"
 [translations.en]
 title = "A title"
         "#;
-
-    #[test]
-    fn can_use_language_configuration() {
-        let config = Config::parse(CONFIG_TRANSLATION);
-        assert!(config.is_ok());
-        let translations = config.unwrap().translations;
-        assert_eq!(translations["fr"]["title"].as_str(), "Un titre");
-        assert_eq!(translations["en"]["title"].as_str(), "A title");
-    }
 
     #[test]
     fn can_use_present_translation() {


### PR DESCRIPTION
I have cleaned up the `Config` struct as discussed in pull request  #793.

I've aimed for as minimal change as possible (since I'm new to the codebase), but I have few questions which might result in PR rework:

Would it be good idea to move tests for public api of `Config` struct from module into `tests` directory?

Advantages:
* less clutter in `config.rs`
* better distinction of test for public vs private api
* step in good direction *if* we wan't to provide api methods on `Config` and remove `pub` access to attributes in long term

Disadvantages
* currently whole `Config` struct is public, splitting tests will result into two places to look at
* step in wrong direction if we want to keep attributes public in long term

I think encapsulating `translations` field and providing api method for it is good move, but now it looks plain weird - single non public attribute in whole struct :-)

@Keats Let me know if you want to take this further or in different direction. I'd be happy to keep working on the PR or do additional work to make the `Config` api more consistent, but I'd like to hear you opinions before I start making bigger changes.

## Commit message

The access to translations is not straightforward and requires checks if
language and key exists. It is better to forbit direct access to
attribute and provide method - `get_translation()` - that will handle
all details of key translations.

Remove unit tests that use direct access and test only public method.

## Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
  * internal api cleanup, no need for documentation update



