### PR TITLE
docs(examples): Remove dead links in Zola example sites listing

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,8 +2,6 @@
 
 | Site                                                               |                   Source Code                        |
 |:-------------------------------------------------------------------|:----------------------------------------------------:|
-| [vincent.is](https://vincent.is)                                   | https://gitlab.com/Keats/vincent.is                  |
-| [code<future](http://www.codelessfuture.com/)                      |                                                      |
 | [t-rex.tileserver.ch](https://t-rex.tileserver.ch)                 | https://github.com/t-rex-tileserver/t-rex-website/   |
 | [Philipp Oppermann's blog](https://os.phil-opp.com/)               | https://github.com/phil-opp/blog_os/tree/master/blog |
 | [seventeencups](https://www.seventeencups.net)                     | https://github.com/17cupsofcoffee/seventeencups.net  |


### PR DESCRIPTION
The first 2 links in the example doc are dead, I guess they should be removed?