### PR TITLE
Add ZEIT Now support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ in the `docs/content` folder of the repository and the community can use [its fo
 | Data files                      | ![yes] | ![yes] | ![yes] | ![no]   |
 | LiveReload                      | ![yes] | ![no]  | ![yes] | ![yes]  |
 | Netlify support                 | ![yes] | ![no]  | ![yes] | ![no]   |
+| ZEIT Now support                | ![yes] | ![no]  | ![yes] | ![yes]  |
 | Breadcrumbs                     | ![yes] | ![no]  | ![no]  | ![yes]  |
 | Custom output formats           | ![no]  | ![no]  | ![yes] | ![no]   |
 


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

I think that [ZEIT Now](https://zeit.co) is one of the few web hosts that supports building and deploying Zola with [one click](https://zeit.co/new/zola).

Please consider adding it to the documentation or merge this PR. Thanks!