### PR TITLE
Reset color after writing message in colorize

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -42,8 +42,9 @@ pub fn error(message: &str) {
 fn colorize(message: &str, color: &ColorSpec) {
     let mut stdout = StandardStream::stdout(*COLOR_CHOICE);
     stdout.set_color(color).unwrap();
-    writeln!(&mut stdout, "{}", message).unwrap();
+    write!(&mut stdout, "{}", message).unwrap();
     stdout.set_color(&ColorSpec::new()).unwrap();
+    writeln!(&mut stdout).unwrap();
 }
 
 /// Display in the console the number of pages/sections in the site, and number of images to process


### PR DESCRIPTION
Presently when you `^C` in `zola serve` it is painted with the same
color as the previous message. This PR always ensures to reset the color
in colorize, before writing the newline.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



