### PR TITLE
Skip anchor checking for URL with prefix in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,7 @@ dependencies = [
 name = "link_checker"
 version = "0.1.0"
 dependencies = [
+ "config 0.1.0",
  "errors 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -86,7 +86,7 @@ impl Default for Taxonomy {
     }
 }
 
-type TranslateTerm  = HashMap<String, String>;
+type TranslateTerm = HashMap<String, String>;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -317,9 +317,16 @@ impl Config {
             Error::msg(format!("Translation for language '{}' is missing", lang.as_ref()))
         })?;
 
-        terms.get(key.as_ref()).ok_or_else(|| {
-            Error::msg(format!("Translation key '{}' for language '{}' is missing", key.as_ref(), lang.as_ref()))
-        }).map(|term| term.to_string())
+        terms
+            .get(key.as_ref())
+            .ok_or_else(|| {
+                Error::msg(format!(
+                    "Translation key '{}' for language '{}' is missing",
+                    key.as_ref(),
+                    lang.as_ref()
+                ))
+            })
+            .map(|term| term.to_string())
     }
 }
 

--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -7,8 +7,8 @@ use syntect::parsing::{SyntaxSet, SyntaxSetBuilder};
 use toml;
 use toml::Value as Toml;
 
-use errors::Result;
 use errors::Error;
+use errors::Result;
 use highlighting::THEME_SET;
 use theme::Theme;
 use utils::fs::read_file_with_error;
@@ -88,6 +88,19 @@ impl Default for Taxonomy {
 
 type TranslateTerm = HashMap<String, String>;
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LinkChecker {
+    /// Skip anchor checking for these URL prefixes
+    pub skip_anchor_prefixes: Vec<String>,
+}
+
+impl Default for LinkChecker {
+    fn default() -> LinkChecker {
+        LinkChecker { skip_anchor_prefixes: Vec::new() }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -151,6 +164,8 @@ pub struct Config {
     /// The compiled extra syntaxes into a syntax set
     #[serde(skip_serializing, skip_deserializing)] // not a typo, 2 are need
     pub extra_syntax_set: Option<SyntaxSet>,
+
+    pub link_checker: LinkChecker,
 
     /// All user params set in [extra] in the config
     pub extra: HashMap<String, Toml>,
@@ -353,6 +368,7 @@ impl Default for Config {
             translations: HashMap::new(),
             extra_syntaxes: Vec::new(),
             extra_syntax_set: None,
+            link_checker: LinkChecker::default(),
             extra: HashMap::new(),
             build_timestamp: Some(1),
         }
@@ -557,5 +573,26 @@ ignored_content = ["*.{graphml,iso}", "*.py?"]
         assert!(g.is_match("foo.py2"));
         assert!(g.is_match("foo.py3"));
         assert!(!g.is_match("foo.py"));
+    }
+
+    #[test]
+    fn link_checker_skip_anchor_prefixes() {
+        let config_str = r#"
+title = "My site"
+base_url = "example.com"
+
+[link_checker]
+skip_anchor_prefixes = [
+    "https://caniuse.com/#feat=",
+    "https://github.com/rust-lang/rust/blob/",
+]
+        "#;
+
+        let config = Config::parse(config_str).unwrap();
+        let v = config.link_checker.skip_anchor_prefixes;
+        assert_eq!(
+            v,
+            vec!["https://caniuse.com/#feat=", "https://github.com/rust-lang/rust/blob/"]
+        );
     }
 }

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -14,7 +14,7 @@ extern crate utils;
 mod config;
 pub mod highlighting;
 mod theme;
-pub use config::{Config, Language, Taxonomy};
+pub use config::{Config, Language, LinkChecker, Taxonomy};
 
 use std::path::Path;
 

--- a/components/imageproc/src/lib.rs
+++ b/components/imageproc/src/lib.rs
@@ -272,7 +272,7 @@ impl ImageOp {
                 } else {
                     img
                 }
-            },
+            }
             Fill(w, h) => {
                 let factor_w = img_w as f32 / w as f32;
                 let factor_h = img_h as f32 / h as f32;

--- a/components/library/src/library.rs
+++ b/components/library/src/library.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use slotmap::{DenseSlotMap, DefaultKey};
+use slotmap::{DefaultKey, DenseSlotMap};
 
 use front_matter::SortBy;
 

--- a/components/library/src/sorting.rs
+++ b/components/library/src/sorting.rs
@@ -21,7 +21,9 @@ pub fn sort_actual_pages_by_date(a: &&Page, b: &&Page) -> Ordering {
 /// Takes a list of (page key, date, permalink) and sort them by dates if possible
 /// Pages without date will be put in the unsortable bucket
 /// The permalink is used to break ties
-pub fn sort_pages_by_date(pages: Vec<(&DefaultKey, Option<NaiveDateTime>, &str)>) -> (Vec<DefaultKey>, Vec<DefaultKey>) {
+pub fn sort_pages_by_date(
+    pages: Vec<(&DefaultKey, Option<NaiveDateTime>, &str)>,
+) -> (Vec<DefaultKey>, Vec<DefaultKey>) {
     let (mut can_be_sorted, cannot_be_sorted): (Vec<_>, Vec<_>) =
         pages.into_par_iter().partition(|page| page.1.is_some());
 
@@ -40,7 +42,9 @@ pub fn sort_pages_by_date(pages: Vec<(&DefaultKey, Option<NaiveDateTime>, &str)>
 /// Takes a list of (page key, weight, permalink) and sort them by weight if possible
 /// Pages without weight will be put in the unsortable bucket
 /// The permalink is used to break ties
-pub fn sort_pages_by_weight(pages: Vec<(&DefaultKey, Option<usize>, &str)>) -> (Vec<DefaultKey>, Vec<DefaultKey>) {
+pub fn sort_pages_by_weight(
+    pages: Vec<(&DefaultKey, Option<usize>, &str)>,
+) -> (Vec<DefaultKey>, Vec<DefaultKey>) {
     let (mut can_be_sorted, cannot_be_sorted): (Vec<_>, Vec<_>) =
         pages.into_par_iter().partition(|page| page.1.is_some());
 
@@ -57,7 +61,9 @@ pub fn sort_pages_by_weight(pages: Vec<(&DefaultKey, Option<usize>, &str)>) -> (
 }
 
 /// Find the lighter/heavier and earlier/later pages for all pages having a date/weight
-pub fn find_siblings(sorted: &[DefaultKey]) -> Vec<(DefaultKey, Option<DefaultKey>, Option<DefaultKey>)> {
+pub fn find_siblings(
+    sorted: &[DefaultKey],
+) -> Vec<(DefaultKey, Option<DefaultKey>, Option<DefaultKey>)> {
     let mut res = Vec::with_capacity(sorted.len());
     let length = sorted.len();
 

--- a/components/link_checker/Cargo.toml
+++ b/components/link_checker/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
 reqwest = "0.9"
 lazy_static = "1"
 
+config = { path = "../config" }
 errors = { path = "../errors" }

--- a/components/rebuild/src/lib.rs
+++ b/components/rebuild/src/lib.rs
@@ -335,7 +335,7 @@ fn is_section(path: &str, languages_codes: &[&str]) -> bool {
         }
     }
 
-    return false;
+    false
 }
 
 /// What happens when a section or a page is created/edited

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -296,8 +296,9 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
             let start_idx = heading_ref.start_idx;
             let end_idx = heading_ref.end_idx;
             let title = get_text(&events[start_idx + 1..end_idx]);
-            let id =
-                heading_ref.id.unwrap_or_else(|| find_anchor(&inserted_anchors, slugify(&title), 0));
+            let id = heading_ref
+                .id
+                .unwrap_or_else(|| find_anchor(&inserted_anchors, slugify(&title), 0));
             inserted_anchors.push(id.clone());
 
             // insert `id` to the tag
@@ -326,7 +327,8 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
 
             // record heading to make table of contents
             let permalink = format!("{}#{}", context.current_page_permalink, id);
-            let h = Heading { level: heading_ref.level, id, permalink, title, children: Vec::new() };
+            let h =
+                Heading { level: heading_ref.level, id, permalink, title, children: Vec::new() };
             headings.push(h);
         }
 

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -399,7 +399,7 @@ impl Site {
             all_links
                 .par_iter()
                 .filter_map(|(page_path, link)| {
-                    let res = check_url(&link);
+                    let res = check_url(&link, &self.config.link_checker);
                     if res.is_valid() {
                         None
                     } else {

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -662,3 +662,14 @@ fn can_ignore_markdown_content() {
     let (_, _tmp_dir, public) = build_site("test_site");
     assert!(!file_exists!(public, "posts/ignored/index.html"));
 }
+
+#[test]
+fn check_site() {
+    let (mut site, _tmp_dir, _public) = build_site("test_site");
+
+    let prefixes = &site.config.link_checker.skip_anchor_prefixes;
+    assert_eq!(prefixes, &vec!["https://github.com/rust-lang/rust/blob/"]);
+
+    site.config.enable_check_mode();
+    site.load().expect("link check test_site");
+}

--- a/components/templates/src/global_fns/mod.rs
+++ b/components/templates/src/global_fns/mod.rs
@@ -34,9 +34,10 @@ impl TeraFn for Trans {
         let lang = optional_arg!(String, args.get("lang"), "`trans`: `lang` must be a string.")
             .unwrap_or_else(|| self.config.default_language.clone());
 
-        let term = self.config.get_translation(lang, key).map_err(|e| {
-            Error::chain("Failed to retreive term translation", e)
-        })?;
+        let term = self
+            .config
+            .get_translation(lang, key)
+            .map_err(|e| Error::chain("Failed to retreive term translation", e))?;
 
         Ok(to_value(term).unwrap())
     }
@@ -508,7 +509,6 @@ mod tests {
         args.insert("name".to_string(), to_value("random").unwrap());
         assert!(static_fn.call(&args).is_err());
     }
-
 
     const TRANS_CONFIG: &str = r#"
 base_url = "https://remplace-par-ton-url.fr"

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -85,6 +85,13 @@ ignored_content = []
 # A list of directories to search for additional `.sublime-syntax` files in.
 extra_syntaxes = []
 
+# Configure the link checker
+[link_checker]
+# Skip anchor checking for external URLs that start with these prefixes
+skip_anchor_prefixes = [
+    "https://caniuse.com/",
+]
+
 # Optional translation object. The key if present should be a language code
 [translations]
 

--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -13,5 +13,10 @@ extra_syntaxes = ["syntaxes"]
 
 ignored_content = ["*/ignored.md"]
 
+[link_checker]
+skip_anchor_prefixes = [
+    "https://github.com/rust-lang/rust/blob/",
+]
+
 [extra.author]
 name = "Vincent Prouillet"

--- a/test_site/content/posts/tutorials/programming/rust.md
+++ b/test_site/content/posts/tutorials/programming/rust.md
@@ -5,3 +5,9 @@ date = 2017-01-01
 +++
 
 A simple page
+
+<!-- more -->
+
+Link to some rust-lang [source code][permalink].
+
+[permalink]: https://github.com/rust-lang/rust/blob/c772948b687488a087356cb91432425662e034b9/src/librustc_back/target/mod.rs#L194-L214


### PR DESCRIPTION
Fixes #805

`zola check`

The anchors of external URLs will not be checked if it starts with one of the configured prefixes.
So false positives can be put on the ignore list, like https://github.com/rust-lang/rust/blob/c772948b687488a087356cb91432425662e034b9/src/librustc_back/target/mod.rs#L194-L214: Anchor `#L194-L214 and https://caniuse.com/#feat=css-filters.

```toml
# Link Checker: skip anchor checking for external URLs that start with these prefixes
link_checker_skip_anchor_prefixes = [
    "https://caniuse.com/",
]
```

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?

