### PR TITLE
Improve init command

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -17,7 +17,7 @@
 | [Tinkering](https://tinkering.xyz)                                 |                                                      |
 | [Daniel Sockwell's codesections.com](https://www.codesections.com) | https://gitlab.com/codesections/codesections-website |
 | [Jens Getreu's blog](https://blog.getreu.net)                      |                                                      |
-| [Matthias Endler](https://matthias-endler.de)                      | https://github.com/mre/mre.github.io                 |
+| [Matthias Endler](https://endler.dev)                              | https://github.com/mre/mre.github.io                 |
 | [Michael Plotke](https://michael.plotke.me)                        | https://gitlab.com/bdjnk/michael                     |
 | [shaleenjain.com](https://shaleenjain.com)                         | https://github.com/shalzz/shalzz.github.io           |
 | [Hello, Rust!](https://hello-rust.show)                            | https://github.com/hello-rust/hello-rust.github.io   |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ in the `docs/content` folder of the repository and the community can use [its fo
 | Data files                      | ![yes] | ![yes] | ![yes] | ![no]   |
 | LiveReload                      | ![yes] | ![no]  | ![yes] | ![yes]  |
 | Netlify support                 | ![yes] | ![no]  | ![yes] | ![no]   |
+| ZEIT Now support                | ![yes] | ![no]  | ![yes] | ![yes]  |
 | Breadcrumbs                     | ![yes] | ![no]  | ![no]  | ![yes]  |
 | Custom output formats           | ![no]  | ![no]  | ![yes] | ![no]   |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,7 +19,6 @@ pub fn build_cli() -> App<'static, 'static> {
                 .about("Create a new Zola project")
                 .arg(
                     Arg::with_name("name")
-                        .default_value(".")
                         .help("Name of the project. Will create a new directory with that name in the current directory")
                 ),
             SubCommand::with_name("build")

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,16 @@ fn main() {
 
     match matches.subcommand() {
         ("init", Some(matches)) => {
-            match cmd::create_new_project(matches.value_of("name").unwrap()) {
+            let name = matches.value_of("name");
+
+            if name.is_none() {
+                println!("You have to provide folder name as an argument to init.");
+                ::std::process::exit(1);
+            }
+
+            let name = name.unwrap();
+
+            match cmd::create_new_project(name) {
                 Ok(()) => (),
                 Err(e) => {
                     console::unravel_errors("Failed to create the project", &e);


### PR DESCRIPTION
Command `zola init` fails if you don't provide folder name with non specific message "file exists". This adds message that should hopefully be little more helpful in what is missing.

