### PR TITLE
Do not attempt to serve on "well-known" ports

### DIFF
--- a/components/utils/src/net.rs
+++ b/components/utils/src/net.rs
@@ -1,7 +1,9 @@
 use std::net::TcpListener;
 
 pub fn get_available_port(avoid: u16) -> Option<u16> {
-    (1000..9000).find(|port| *port != avoid && port_is_available(*port))
+    // Start after "well-known" ports (0–1023) as they require superuser
+    // privileges on UNIX-like operating systems.
+    (1024..9000).find(|port| *port != avoid && port_is_available(*port))
 }
 
 pub fn port_is_available(port: u16) -> bool {


### PR DESCRIPTION
`zola serve` tries to find a port in the range 1000 and up.

Ports 0–1023 are known as [well-known ports](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports) and require root privileges on at Linux and likely macOS to bind a socket to them.

This (an excerpt from HTML served by `zola serve`) using port 1024 might be no coincidence:
![port1024](https://user-images.githubusercontent.com/95277/67528567-0f25db80-f6ba-11e9-859a-d73d7da1a183.png)

Thus, just ignore those and start right after them (in the "registered ports" range).