### PR TITLE
Properly escape `&` in injected live-reload script tag

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -633,7 +633,7 @@ impl Site {
             return html.replace(
                 "</body>",
                 &format!(
-                    r#"<script src="/livereload.js?port={}&mindelay=10"></script></body>"#,
+                    r#"<script src="/livereload.js?port={}&amp;mindelay=10"></script></body>"#,
                     port
                 ),
             );

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -161,7 +161,7 @@ fn can_build_site_without_live_reload() {
     assert!(file_exists!(public, "nested_sass/scss.css"));
 
     // no live reload code
-    assert_eq!(file_contains!(public, "index.html", "/livereload.js?port=1112&mindelay=10"), false);
+    assert_eq!(file_contains!(public, "index.html", "/livereload.js?port=1112&amp;mindelay=10"), false);
 
     // Both pages and sections are in the sitemap
     assert!(file_contains!(


### PR DESCRIPTION
Unescaped [Ampersands](https://en.wikipedia.org/wiki/Ampersand) used as query string separators in an URL must be escaped when that URL is used as value for an HTML (or XML, for that matter) attribute.

> […] `&` normally indicates the start of a character entity reference or numeric character reference; writing it as `&amp;` […] allows `&` to be included in the content of an element or in the value of an attribute.

From: https://en.wikipedia.org/wiki/HTML#Character_and_entity_references

And here's a screenshot (as seen in #824) in which the red coloring added by Firefox's source code viewer indicates an issue with the markup:
![port1024](https://user-images.githubusercontent.com/95277/67529535-b3a91d00-f6bc-11e9-8482-9e1140ef8199.png)