### PR TITLE
Add title and body to alias page

### DIFF
--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -470,6 +470,16 @@ fn can_build_site_with_pagination_for_index() {
         "page/1/index.html",
         "http-equiv=\"refresh\" content=\"0;url=https://replace-this-with-your-url.com/\""
     ));
+    assert!(file_contains!(
+        public,
+        "page/1/index.html",
+        "<title>Redirect</title>"
+    ));
+    assert!(file_contains!(
+        public,
+        "page/1/index.html",
+        "<a href=\"https://replace-this-with-your-url.com/\">Click here</a>"
+    ));
     assert!(file_contains!(public, "index.html", "Num pages: 1"));
     assert!(file_contains!(public, "index.html", "Current index: 1"));
     assert!(file_contains!(public, "index.html", "First: https://replace-this-with-your-url.com/"));

--- a/components/templates/src/builtins/internal/alias.html
+++ b/components/templates/src/builtins/internal/alias.html
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <title>Redirect</title>
         <link rel="canonical" href="{{ url | safe }}" />
         <meta http-equiv="content-type" content="text/html; charset=utf-8" />
         <meta http-equiv="refresh" content="0;url={{ url | safe }}" />
     </head>
+    <body>
+        <p><a href="{{ url | safe }}">Click here</a> to be redirected.</p>
+    </body>
 </html>


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

This ensure the redirect page have a title and a body with a link in case the browser does not handle refresh redirects