### PR TITLE
Skip link checking for URL with prefix in config

### DIFF
--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -91,13 +91,15 @@ type TranslateTerm = HashMap<String, String>;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LinkChecker {
+    /// Skip link checking for these URL prefixes
+    pub skip_prefixes: Vec<String>,
     /// Skip anchor checking for these URL prefixes
     pub skip_anchor_prefixes: Vec<String>,
 }
 
 impl Default for LinkChecker {
     fn default() -> LinkChecker {
-        LinkChecker { skip_anchor_prefixes: Vec::new() }
+        LinkChecker { skip_prefixes: Vec::new(), skip_anchor_prefixes: Vec::new() }
     }
 }
 
@@ -589,10 +591,29 @@ skip_anchor_prefixes = [
         "#;
 
         let config = Config::parse(config_str).unwrap();
-        let v = config.link_checker.skip_anchor_prefixes;
         assert_eq!(
-            v,
+            config.link_checker.skip_anchor_prefixes,
             vec!["https://caniuse.com/#feat=", "https://github.com/rust-lang/rust/blob/"]
+        );
+    }
+
+    #[test]
+    fn link_checker_skip_prefixes() {
+        let config_str = r#"
+title = "My site"
+base_url = "example.com"
+
+[link_checker]
+skip_prefixes = [
+    "http://[2001:db8::]/",
+    "https://www.example.com/path",
+]
+        "#;
+
+        let config = Config::parse(config_str).unwrap();
+        assert_eq!(
+            config.link_checker.skip_prefixes,
+            vec!["http://[2001:db8::]/", "https://www.example.com/path",]
         );
     }
 }

--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -198,6 +198,7 @@ mod tests {
     #[test]
     fn skip_anchor_prefixes() {
         let config = LinkChecker {
+            skip_prefixes: vec![],
             skip_anchor_prefixes: vec!["https://github.com/rust-lang/rust/blob/".to_owned()],
         };
 

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -399,6 +399,15 @@ impl Site {
             all_links
                 .par_iter()
                 .filter_map(|(page_path, link)| {
+                    if self
+                        .config
+                        .link_checker
+                        .skip_prefixes
+                        .iter()
+                        .any(|prefix| link.starts_with(prefix))
+                    {
+                        return None;
+                    }
                     let res = check_url(&link, &self.config.link_checker);
                     if res.is_valid() {
                         None

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -161,7 +161,10 @@ fn can_build_site_without_live_reload() {
     assert!(file_exists!(public, "nested_sass/scss.css"));
 
     // no live reload code
-    assert_eq!(file_contains!(public, "index.html", "/livereload.js?port=1112&amp;mindelay=10"), false);
+    assert_eq!(
+        file_contains!(public, "index.html", "/livereload.js?port=1112&amp;mindelay=10"),
+        false
+    );
 
     // Both pages and sections are in the sitemap
     assert!(file_contains!(
@@ -470,11 +473,7 @@ fn can_build_site_with_pagination_for_index() {
         "page/1/index.html",
         "http-equiv=\"refresh\" content=\"0;url=https://replace-this-with-your-url.com/\""
     ));
-    assert!(file_contains!(
-        public,
-        "page/1/index.html",
-        "<title>Redirect</title>"
-    ));
+    assert!(file_contains!(public, "page/1/index.html", "<title>Redirect</title>"));
     assert!(file_contains!(
         public,
         "page/1/index.html",
@@ -677,8 +676,11 @@ fn can_ignore_markdown_content() {
 fn check_site() {
     let (mut site, _tmp_dir, _public) = build_site("test_site");
 
-    let prefixes = &site.config.link_checker.skip_anchor_prefixes;
-    assert_eq!(prefixes, &vec!["https://github.com/rust-lang/rust/blob/"]);
+    assert_eq!(
+        site.config.link_checker.skip_anchor_prefixes,
+        vec!["https://github.com/rust-lang/rust/blob/"]
+    );
+    assert_eq!(site.config.link_checker.skip_prefixes, vec!["http://[2001:db8::]/"]);
 
     site.config.enable_check_mode();
     site.load().expect("link check test_site");

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -87,6 +87,11 @@ extra_syntaxes = []
 
 # Configure the link checker
 [link_checker]
+# Skip link checking for external URLs that start with these prefixes
+skip_prefixes = [
+    "http://[2001:db8::]/",
+]
+
 # Skip anchor checking for external URLs that start with these prefixes
 skip_anchor_prefixes = [
     "https://caniuse.com/",

--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -14,6 +14,10 @@ extra_syntaxes = ["syntaxes"]
 ignored_content = ["*/ignored.md"]
 
 [link_checker]
+skip_prefixes = [
+    "http://[2001:db8::]/",
+]
+
 skip_anchor_prefixes = [
     "https://github.com/rust-lang/rust/blob/",
 ]

--- a/test_site/content/posts/tutorials/programming/rust.md
+++ b/test_site/content/posts/tutorials/programming/rust.md
@@ -10,4 +10,6 @@ A simple page
 
 Link to some rust-lang [source code][permalink].
 
+Internal web server <http://[2001:db8::]/path>.
+
 [permalink]: https://github.com/rust-lang/rust/blob/c772948b687488a087356cb91432425662e034b9/src/librustc_back/target/mod.rs#L194-L214


### PR DESCRIPTION
Adds a configuration option to exclude certain URLs to be link checked, in addition to `skip_anchor_prefixes` #812.

Use case: Links to internal web servers.

```toml
# Configure the link checker
[link_checker]
# Skip link checking for external URLs that start with these prefixes
skip_prefixes = [
    "http://[2001:db8::]/",
]
```

## Prior art

[mdBook linkcheck](https://github.com/Michael-F-Bryan/mdbook-linkcheck#configuration)

```toml
# If necessary, you can exclude one or more web links from being checked with
# a list of regular expressions
exclude = [ "google\\.com" ]
```

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



