### PR TITLE
Section extra -> SitemapEntry

### DIFF
--- a/components/library/src/content/ser.rs
+++ b/components/library/src/content/ser.rs
@@ -206,7 +206,7 @@ pub struct SerializingSection<'a> {
     ancestors: Vec<String>,
     title: &'a Option<String>,
     description: &'a Option<String>,
-    extra: &'a HashMap<String, Value>,
+    extra: &'a Map<String, Value>,
     path: &'a str,
     components: &'a [String],
     toc: &'a [Heading],

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -20,7 +20,7 @@ extern crate utils;
 #[cfg(test)]
 extern crate tempfile;
 
-mod sitemap;
+pub mod sitemap;
 
 use std::collections::HashMap;
 use std::fs::{copy, create_dir_all, remove_dir_all};

--- a/components/site/src/sitemap.rs
+++ b/components/site/src/sitemap.rs
@@ -11,9 +11,9 @@ use tera::{Map, Value};
 /// for examples so we trim down all entries to only that
 #[derive(Debug, Serialize)]
 pub struct SitemapEntry<'a> {
-    permalink: Cow<'a, str>,
-    date: Option<String>,
-    extra: Option<&'a Map<String, Value>>,
+    pub permalink: Cow<'a, str>,
+    pub date: Option<String>,
+    pub extra: Option<&'a Map<String, Value>>,
 }
 
 // Hash/Eq is not implemented for tera::Map but in our case we only care about the permalink
@@ -77,7 +77,11 @@ pub fn find_entries<'a>(
         .sections_values()
         .iter()
         .filter(|s| s.meta.render)
-        .map(|s| SitemapEntry::new(Cow::Borrowed(&s.permalink), None))
+        .map(|s| {
+            let mut entry = SitemapEntry::new(Cow::Borrowed(&s.permalink), None);
+            entry.add_extra(&s.meta.extra);
+            entry
+        })
         .collect::<Vec<_>>();
 
     for section in library.sections_values().iter().filter(|s| s.meta.paginate_by.is_some()) {

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use common::{build_site, build_site_with_setup};
 use config::Taxonomy;
+use site::sitemap;
 use site::Site;
 
 #[test]
@@ -87,6 +88,19 @@ fn can_parse_site() {
         .unwrap();
     assert_eq!(prog_section.subsections.len(), 0);
     assert_eq!(prog_section.pages.len(), 2);
+
+    // Testing extra variables in sections & sitemaps
+    // Regression test for #https://github.com/getzola/zola/issues/842
+    assert_eq!(
+        prog_section.meta.extra.get("we_have_extra").and_then(|s| s.as_str()),
+        Some("variables")
+    );
+    let sitemap_entries = sitemap::find_entries(&library, &site.taxonomies[..], &site.config);
+    let sitemap_entry = sitemap_entries
+        .iter()
+        .find(|e| e.permalink.ends_with("tutorials/programming/"))
+        .expect("expected to find programming section in sitemap");
+    assert_eq!(Some(&prog_section.meta.extra), sitemap_entry.extra);
 }
 
 #[test]
@@ -161,7 +175,10 @@ fn can_build_site_without_live_reload() {
     assert!(file_exists!(public, "nested_sass/scss.css"));
 
     // no live reload code
-    assert_eq!(file_contains!(public, "index.html", "/livereload.js?port=1112&amp;mindelay=10"), false);
+    assert_eq!(
+        file_contains!(public, "index.html", "/livereload.js?port=1112&amp;mindelay=10"),
+        false
+    );
 
     // Both pages and sections are in the sitemap
     assert!(file_contains!(
@@ -470,11 +487,7 @@ fn can_build_site_with_pagination_for_index() {
         "page/1/index.html",
         "http-equiv=\"refresh\" content=\"0;url=https://replace-this-with-your-url.com/\""
     ));
-    assert!(file_contains!(
-        public,
-        "page/1/index.html",
-        "<title>Redirect</title>"
-    ));
+    assert!(file_contains!(public, "page/1/index.html", "<title>Redirect</title>"));
     assert!(file_contains!(
         public,
         "page/1/index.html",

--- a/test_site/content/posts/tutorials/programming/_index.md
+++ b/test_site/content/posts/tutorials/programming/_index.md
@@ -2,4 +2,7 @@
 title = "Programming"
 sort_by = "weight"
 weight = 1
+
+[extra]
+we_have_extra = "variables"
 +++


### PR DESCRIPTION
## General summary:

- Fixes #842 
- `Section` has parity with `Page` extra (using a `tera::Map` instead of `std::collections::Map`)
- `SitemapEntry` gets passed the `section.meta.extra`
- Added regression tests to make sure that the sitemap has the extra of the section
- unrelated formatting changes are because I ran `cargo fmt` on the project
- Question: There are some changes in modules structure (making `sitemap` `pub`) in order to make it easy to do a regression test there. Is there a better place for this?

## Code changes

* [x] Are you doing the PR on the `next` branch?


