### PR TITLE
Write files using `create_new` option to avoid accidental overwrites

### DIFF
--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -1,4 +1,4 @@
-use std::fs::{copy, create_dir_all, read_dir, File};
+use std::fs::{copy, create_dir_all, read_dir, File, OpenOptions};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -19,8 +19,7 @@ pub fn is_path_in_directory(parent: &Path, path: &Path) -> Result<bool> {
 
 /// Create a file with the content given
 pub fn create_file(path: &Path, content: &str) -> Result<()> {
-    let mut file =
-        File::create(&path).map_err(|e| Error::chain(format!("Failed to create {:?}", path), e))?;
+    let mut file = OpenOptions::new().write(true).create_new(true).open(&path).map_err(|e| Error::chain(format!("Failed to create {:?}", path), e))?;
     file.write_all(content.as_bytes())?;
     Ok(())
 }


### PR DESCRIPTION
The previously used `File::create` silently overwrites existing files, which causes problems e.g. when two pages accidentally specify the same `path`. By opening all files with the `create_new` option, we can ensure that no files are overwritten.

Fixes #366 


