### PR TITLE
Add path to `TranslatedContent`

### DIFF
--- a/components/library/src/content/ser.rs
+++ b/components/library/src/content/ser.rs
@@ -1,5 +1,6 @@
 //! What we are sending to the templates when rendering them
 use std::collections::HashMap;
+use std::path::Path;
 
 use tera::{Map, Value};
 
@@ -12,6 +13,9 @@ pub struct TranslatedContent<'a> {
     lang: &'a str,
     permalink: &'a str,
     title: &'a Option<String>,
+    /// The path to the markdown file; useful for retrieving the full page through
+    /// the `get_page` function.
+    path: &'a Path,
 }
 
 impl<'a> TranslatedContent<'a> {
@@ -25,6 +29,7 @@ impl<'a> TranslatedContent<'a> {
                 lang: &other.lang,
                 permalink: &other.permalink,
                 title: &other.meta.title,
+                path: &other.file.path,
             });
         }
 
@@ -40,6 +45,7 @@ impl<'a> TranslatedContent<'a> {
                 lang: &other.lang,
                 permalink: &other.permalink,
                 title: &other.meta.title,
+                path: &other.file.path,
             });
         }
 

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -132,5 +132,8 @@ lang: String?;
 title: String?;
 // A permalink to that content
 permalink: String;
+// The path to the markdown file; useful for retrieving the full page through
+// the `get_page` function.
+path: String;
 ```
 

--- a/test_site_i18n/templates/page.html
+++ b/test_site_i18n/templates/page.html
@@ -4,6 +4,12 @@ Language: {{lang}}
 
 {% for t in page.translations %}
 Translated in {{t.lang|default(value=config.default_language)}}: {{t.title}} {{t.permalink|safe}}
+
+<br><br>
+
+{% set translated_page = get_page(path = t.path) %}
+{{ translated_page.content | safe }}
+
 {% endfor %}
 
 {% for taxo_kind, items in page.taxonomies %}


### PR DESCRIPTION
This makes it possible to retrieve the translated page through the `get_page` function.

Fixes #859 
