### PR TITLE
Update links to Tera documentation

### DIFF
--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -9,7 +9,7 @@ HTML to add some styling for example.
 To solve this, Zola borrows the concept of [shortcodes](https://codex.wordpress.org/Shortcode_API)
 from WordPress.
 In our case, the shortcode corresponds to a template that is defined in the `templates/shortcodes` directory or a built-in one that can
-be used in a Markdown file. If you want to use something similar to shortcodes in your templates, try [Tera macros](https://tera.netlify.com/docs/templates/#macros).
+be used in a Markdown file. If you want to use something similar to shortcodes in your templates, try [Tera macros](https://tera.netlify.com/docs#macros).
 
 ## Writing a shortcode
 Let's write a shortcode to embed YouTube videos as an example.

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -7,7 +7,7 @@ Zola uses the [Tera](https://tera.netlify.com) template engine and is very simil
 to Jinja2, Liquid or Twig.
 
 As this documentation will only talk about how templates work in Zola, please read
-the [Tera template documentation](https://tera.netlify.com/docs/templates/) if you want
+the [Tera template documentation](https://tera.netlify.com/docs#templates) if you want
 to learn more about it first.
 
 All templates live in the `templates` directory.  If you are not sure what variables are available in a template, you can just stick `{{ __tera_context }}` in it
@@ -58,7 +58,7 @@ Custom templates are not required to live at the root of your `templates` direct
 For example, `product_pages/with_pictures.html` is a valid template.
 
 ## Built-in filters
-Zola adds a few filters, in addition of the ones [ones already present](https://tera.netlify.com/docs/templates/#built-in-filters) in Tera.
+Zola adds a few filters, in addition of the ones [ones already present](https://tera.netlify.com/docs#built-in-filters) in Tera.
 
 ### markdown
 Converts the given variable to HTML using Markdown. This doesn't apply any of the
@@ -80,7 +80,7 @@ Decode the variable from base64.
 
 ## Built-in global functions
 
-Zola adds a few global functions to [those in Tera](https://tera.netlify.com/docs/templates/#built-in-functions) in order to make it easier to develop complex sites.
+Zola adds a few global functions to [those in Tera](https://tera.netlify.com/docs#built-in-functions) in order to make it easier to develop complex sites.
 
 
 ### `get_page`

--- a/docs/content/documentation/themes/creating-a-theme.md
+++ b/docs/content/documentation/themes/creating-a-theme.md
@@ -4,7 +4,7 @@ weight = 30
 +++
 
 Creating a theme is exactly like creating a normal site with Zola, except you
-will want to use many [Tera blocks](https://tera.netlify.com/docs/templates/#inheritance) to
+will want to use many [Tera blocks](https://tera.netlify.com/docs#inheritance) to
 allow users to easily modify it.
 
 ## Getting started
@@ -53,8 +53,8 @@ to be able to build the theme from your repository.
 
 ### Caveat
 
-Please note that [include paths](https://tera.netlify.com/docs/templates/#include) can only be used in normal templates.
-Theme templates should use [macros](https://tera.netlify.com/docs/templates/#macros) instead.
+Please note that [include paths](https://tera.netlify.com/docs#include) can only be used in normal templates.
+Theme templates should use [macros](https://tera.netlify.com/docs#macros) instead.
 
 ## Submitting a theme to the gallery
 


### PR DESCRIPTION
I noticed that the links to the Tera docs are a bit different at the moment, probably since version 1.0 came out. This PR should make them work again.