### PR TITLE
Use Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zola"
 version = "0.10.0"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com>"]
+edition = "2018"
 license = "MIT"
 readme = "README.md"
 description = "A fast static site generator with everything built-in"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate clap;
-
 // use clap::Shell;
 
 include!("src/cli.rs");

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -2,6 +2,7 @@
 name = "config"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 toml = "0.5"

--- a/components/config/examples/generate_sublime.rs
+++ b/components/config/examples/generate_sublime.rs
@@ -2,7 +2,6 @@
 //! syntect, not as a helpful example for beginners.
 //! Although it is a valid example for serializing syntaxes, you probably won't need
 //! to do this yourself unless you want to cache your own compiled grammars.
-extern crate syntect;
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -3,14 +3,14 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde_derive::{Deserialize, Serialize};
 use syntect::parsing::{SyntaxSet, SyntaxSetBuilder};
 use toml;
 use toml::Value as Toml;
 
-use errors::Error;
-use errors::Result;
-use highlighting::THEME_SET;
-use theme::Theme;
+use crate::highlighting::THEME_SET;
+use crate::theme::Theme;
+use errors::{bail, Error, Result};
 use utils::fs::read_file_with_error;
 
 // We want a default base url for tests

--- a/components/config/src/highlighting.rs
+++ b/components/config/src/highlighting.rs
@@ -1,9 +1,10 @@
+use lazy_static::lazy_static;
 use syntect::dumps::from_binary;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
 
-use Config;
+use crate::config::Config;
 
 lazy_static! {
     pub static ref SYNTAX_SET: SyntaxSet = {

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -1,20 +1,7 @@
-#[macro_use]
-extern crate serde_derive;
-extern crate chrono;
-extern crate globset;
-extern crate toml;
-#[macro_use]
-extern crate lazy_static;
-extern crate syntect;
-
-#[macro_use]
-extern crate errors;
-extern crate utils;
-
 mod config;
 pub mod highlighting;
 mod theme;
-pub use config::{Config, Language, LinkChecker, Taxonomy};
+pub use crate::config::{Config, Language, LinkChecker, Taxonomy};
 
 use std::path::Path;
 

--- a/components/config/src/theme.rs
+++ b/components/config/src/theme.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use serde_derive::{Deserialize, Serialize};
 use toml::Value as Toml;
 
-use errors::Result;
+use errors::{bail, Result};
 use utils::fs::read_file_with_error;
 
 /// Holds the data from a `theme.toml` file.

--- a/components/errors/Cargo.toml
+++ b/components/errors/Cargo.toml
@@ -2,6 +2,7 @@
 name = "errors"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 tera = "1"

--- a/components/errors/src/lib.rs
+++ b/components/errors/src/lib.rs
@@ -1,8 +1,3 @@
-extern crate image;
-extern crate syntect;
-extern crate tera;
-extern crate toml;
-
 use std::convert::Into;
 use std::error::Error as StdError;
 use std::fmt;

--- a/components/front_matter/Cargo.toml
+++ b/components/front_matter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "front_matter"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 tera = "1"

--- a/components/front_matter/src/lib.rs
+++ b/components/front_matter/src/lib.rs
@@ -1,18 +1,7 @@
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate serde_derive;
-extern crate chrono;
-extern crate regex;
-extern crate serde;
-extern crate tera;
-extern crate toml;
+use lazy_static::lazy_static;
+use serde_derive::{Deserialize, Serialize};
 
-#[macro_use]
-extern crate errors;
-extern crate utils;
-
-use errors::{Error, Result};
+use errors::{bail, Error, Result};
 use regex::Regex;
 use std::path::Path;
 

--- a/components/front_matter/src/page.rs
+++ b/components/front_matter/src/page.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
 use chrono::prelude::*;
+use serde_derive::Deserialize;
 use tera::{Map, Value};
 use toml;
 
-use errors::Result;
+use errors::{bail, Result};
 use utils::de::{fix_toml_dates, from_toml_datetime};
 
 /// The front matter of every page

--- a/components/front_matter/src/section.rs
+++ b/components/front_matter/src/section.rs
@@ -1,8 +1,9 @@
+use serde_derive::{Deserialize, Serialize};
 use tera::{Map, Value};
 use toml;
 
 use super::{InsertAnchor, SortBy};
-use errors::Result;
+use errors::{bail, Result};
 use utils::de::fix_toml_dates;
 
 static DEFAULT_PAGINATE_PATH: &str = "page";

--- a/components/imageproc/Cargo.toml
+++ b/components/imageproc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "imageproc"
 version = "0.1.0"
 authors = ["Vojtěch Král <vojtech@kral.hk>"]
+edition = "2018"
 
 [dependencies]
 lazy_static = "1"

--- a/components/imageproc/src/lib.rs
+++ b/components/imageproc/src/lib.rs
@@ -1,12 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-extern crate image;
-extern crate rayon;
-extern crate regex;
-
-extern crate errors;
-extern crate utils;
-
 use std::collections::hash_map::DefaultHasher;
 use std::collections::hash_map::Entry as HEntry;
 use std::collections::HashMap;
@@ -17,6 +8,7 @@ use std::path::{Path, PathBuf};
 use image::jpeg::JPEGEncoder;
 use image::png::PNGEncoder;
 use image::{FilterType, GenericImageView};
+use lazy_static::lazy_static;
 use rayon::prelude::*;
 use regex::Regex;
 

--- a/components/library/Cargo.toml
+++ b/components/library/Cargo.toml
@@ -2,6 +2,7 @@
 name = "library"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 slotmap = "0.4"

--- a/components/library/src/content/file_info.rs
+++ b/components/library/src/content/file_info.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use config::Config;
-use errors::Result;
+use errors::{bail, Result};
 
 /// Takes a full path to a file and returns only the components after the first `content` directory
 /// Will not return the filename as last component

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -2,22 +2,23 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use lazy_static::lazy_static;
 use regex::Regex;
 use slotmap::DefaultKey;
 use tera::{Context as TeraContext, Tera};
 
+use crate::library::Library;
 use config::Config;
 use errors::{Error, Result};
 use front_matter::{split_page_content, InsertAnchor, PageFrontMatter};
-use library::Library;
 use rendering::{render_content, Heading, RenderContext};
 use utils::fs::{find_related_assets, read_file};
 use utils::site::get_reading_analytics;
 use utils::templates::render_template;
 
-use content::file_info::FileInfo;
-use content::has_anchor;
-use content::ser::SerializingPage;
+use crate::content::file_info::FileInfo;
+use crate::content::has_anchor;
+use crate::content::ser::SerializingPage;
 use utils::slugs::maybe_slugify_paths;
 
 lazy_static! {

--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -12,10 +12,10 @@ use utils::fs::{find_related_assets, read_file};
 use utils::site::get_reading_analytics;
 use utils::templates::render_template;
 
-use content::file_info::FileInfo;
-use content::has_anchor;
-use content::ser::SerializingSection;
-use library::Library;
+use crate::content::file_info::FileInfo;
+use crate::content::has_anchor;
+use crate::content::ser::SerializingSection;
+use crate::library::Library;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Section {

--- a/components/library/src/content/ser.rs
+++ b/components/library/src/content/ser.rs
@@ -2,10 +2,11 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use serde_derive::Serialize;
 use tera::{Map, Value};
 
-use content::{Page, Section};
-use library::Library;
+use crate::content::{Page, Section};
+use crate::library::Library;
 use rendering::Heading;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]

--- a/components/library/src/lib.rs
+++ b/components/library/src/lib.rs
@@ -1,28 +1,3 @@
-extern crate serde;
-extern crate tera;
-#[macro_use]
-extern crate serde_derive;
-extern crate chrono;
-extern crate rayon;
-extern crate slotmap;
-#[macro_use]
-extern crate lazy_static;
-extern crate regex;
-
-#[cfg(test)]
-extern crate globset;
-#[cfg(test)]
-extern crate tempfile;
-#[cfg(test)]
-extern crate toml;
-
-extern crate config;
-extern crate front_matter;
-extern crate rendering;
-extern crate utils;
-#[macro_use]
-extern crate errors;
-
 mod content;
 mod library;
 mod pagination;
@@ -31,8 +6,8 @@ mod taxonomies;
 
 pub use slotmap::{DenseSlotMap, Key};
 
+pub use crate::library::Library;
 pub use content::{Page, Section, SerializingPage, SerializingSection};
-pub use library::Library;
 pub use pagination::Paginator;
 pub use sorting::sort_actual_pages_by_date;
 pub use taxonomies::{find_taxonomies, Taxonomy, TaxonomyItem};

--- a/components/library/src/library.rs
+++ b/components/library/src/library.rs
@@ -5,9 +5,9 @@ use slotmap::{DefaultKey, DenseSlotMap};
 
 use front_matter::SortBy;
 
+use crate::content::{Page, Section};
+use crate::sorting::{find_siblings, sort_pages_by_date, sort_pages_by_weight};
 use config::Config;
-use content::{Page, Section};
-use sorting::{find_siblings, sort_pages_by_date, sort_pages_by_weight};
 
 // Like vec! but for HashSet
 macro_rules! set {

--- a/components/library/src/pagination/mod.rs
+++ b/components/library/src/pagination/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use serde_derive::Serialize;
 use slotmap::DefaultKey;
 use tera::{to_value, Context, Tera, Value};
 
@@ -7,9 +8,9 @@ use config::Config;
 use errors::{Error, Result};
 use utils::templates::render_template;
 
-use content::{Section, SerializingPage, SerializingSection};
-use library::Library;
-use taxonomies::{Taxonomy, TaxonomyItem};
+use crate::content::{Section, SerializingPage, SerializingSection};
+use crate::library::Library;
+use crate::taxonomies::{Taxonomy, TaxonomyItem};
 
 #[derive(Clone, Debug, PartialEq)]
 enum PaginationRoot<'a> {
@@ -240,11 +241,11 @@ mod tests {
     use std::path::PathBuf;
     use tera::to_value;
 
+    use crate::content::{Page, Section};
+    use crate::library::Library;
+    use crate::taxonomies::{Taxonomy, TaxonomyItem};
     use config::Taxonomy as TaxonomyConfig;
-    use content::{Page, Section};
     use front_matter::SectionFrontMatter;
-    use library::Library;
-    use taxonomies::{Taxonomy, TaxonomyItem};
 
     use super::Paginator;
 

--- a/components/library/src/sorting.rs
+++ b/components/library/src/sorting.rs
@@ -4,7 +4,7 @@ use chrono::NaiveDateTime;
 use rayon::prelude::*;
 use slotmap::DefaultKey;
 
-use content::Page;
+use crate::content::Page;
 
 /// Used by the RSS feed
 /// There to not have to import sorting stuff in the site crate
@@ -91,7 +91,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{find_siblings, sort_pages_by_date, sort_pages_by_weight};
-    use content::Page;
+    use crate::content::Page;
     use front_matter::PageFrontMatter;
 
     fn create_page_with_date(date: &str) -> Page {

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -1,16 +1,17 @@
 use std::collections::HashMap;
 
+use serde_derive::Serialize;
 use slotmap::DefaultKey;
 use tera::{Context, Tera};
 
 use config::{Config, Taxonomy as TaxonomyConfig};
-use errors::{Error, Result};
+use errors::{bail, Error, Result};
 use utils::templates::render_template;
 
-use content::SerializingPage;
-use library::Library;
+use crate::content::SerializingPage;
+use crate::library::Library;
+use crate::sorting::sort_pages_by_date;
 use utils::slugs::maybe_slugify_paths;
-use sorting::sort_pages_by_date;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SerializedTaxonomyItem<'a> {
@@ -231,9 +232,9 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    use crate::content::Page;
+    use crate::library::Library;
     use config::{Config, Language, Taxonomy as TaxonomyConfig};
-    use content::Page;
-    use library::Library;
 
     #[test]
     fn can_make_taxonomies() {

--- a/components/link_checker/Cargo.toml
+++ b/components/link_checker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "link_checker"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 reqwest = "0.9"

--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -1,10 +1,4 @@
-extern crate reqwest;
-#[macro_use]
-extern crate lazy_static;
-
-extern crate config;
-extern crate errors;
-
+use lazy_static::lazy_static;
 use reqwest::header::{HeaderMap, ACCEPT};
 use reqwest::StatusCode;
 

--- a/components/rebuild/Cargo.toml
+++ b/components/rebuild/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rebuild"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 errors = { path = "../errors" }

--- a/components/rebuild/src/lib.rs
+++ b/components/rebuild/src/lib.rs
@@ -1,12 +1,6 @@
-extern crate site;
-#[macro_use]
-extern crate errors;
-extern crate front_matter;
-extern crate library;
-
 use std::path::{Component, Path};
 
-use errors::Result;
+use errors::{bail, Result};
 use front_matter::{PageFrontMatter, SectionFrontMatter};
 use library::{Page, Section};
 use site::Site;

--- a/components/rebuild/tests/rebuild.rs
+++ b/components/rebuild/tests/rebuild.rs
@@ -1,8 +1,3 @@
-extern crate fs_extra;
-extern crate rebuild;
-extern crate site;
-extern crate tempfile;
-
 use std::env;
 use std::fs::{self, File};
 use std::io::prelude::*;

--- a/components/rendering/Cargo.toml
+++ b/components/rendering/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rendering"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 tera = { version = "1", features = ["preserve_order"] }

--- a/components/rendering/benches/all.rs
+++ b/components/rendering/benches/all.rs
@@ -1,11 +1,3 @@
-#![feature(test)]
-extern crate tera;
-extern crate test;
-
-extern crate config;
-extern crate front_matter;
-extern crate rendering;
-
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/components/rendering/src/lib.rs
+++ b/components/rendering/src/lib.rs
@@ -1,26 +1,3 @@
-extern crate pulldown_cmark;
-extern crate syntect;
-extern crate tera;
-#[macro_use]
-extern crate serde_derive;
-extern crate pest;
-extern crate serde;
-#[macro_use]
-extern crate pest_derive;
-extern crate regex;
-#[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
-extern crate errors;
-extern crate config;
-extern crate front_matter;
-extern crate link_checker;
-extern crate utils;
-
-#[cfg(test)]
-extern crate templates;
-
 mod context;
 mod markdown;
 mod shortcode;

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use pulldown_cmark as cmark;
 use regex::Regex;
 use syntect::easy::HighlightLines;
@@ -5,11 +6,11 @@ use syntect::html::{
     start_highlighted_html_snippet, styled_line_to_highlighted_html, IncludeBackground,
 };
 
+use crate::context::RenderContext;
+use crate::table_of_contents::{make_table_of_contents, Heading};
 use config::highlighting::{get_highlighter, SYNTAX_SET, THEME_SET};
-use context::RenderContext;
 use errors::{Error, Result};
 use front_matter::InsertAnchor;
-use table_of_contents::{make_table_of_contents, Heading};
 use utils::site::resolve_internal_link;
 use utils::vec::InsertMany;
 use utils::slugs::maybe_slugify_anchors;

--- a/components/rendering/src/shortcode.rs
+++ b/components/rendering/src/shortcode.rs
@@ -1,10 +1,12 @@
+use lazy_static::lazy_static;
 use pest::iterators::Pair;
 use pest::Parser;
+use pest_derive::Parser;
 use regex::Regex;
 use tera::{to_value, Context, Map, Value};
 
-use context::RenderContext;
-use errors::{Error, Result};
+use crate::context::RenderContext;
+use errors::{bail, Error, Result};
 
 // This include forces recompiling this source file if the grammar file changes.
 // Uncomment it when doing changes to the .pest file

--- a/components/rendering/src/table_of_contents.rs
+++ b/components/rendering/src/table_of_contents.rs
@@ -1,3 +1,5 @@
+use serde_derive::Serialize;
+
 /// Populated while receiving events from the markdown parser
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct Heading {

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -1,9 +1,3 @@
-extern crate config;
-extern crate front_matter;
-extern crate rendering;
-extern crate templates;
-extern crate tera;
-
 use std::collections::HashMap;
 
 use tera::Tera;

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -2,6 +2,7 @@
 name = "search"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 elasticlunr-rs = "2"

--- a/components/search/src/lib.rs
+++ b/components/search/src/lib.rs
@@ -1,17 +1,9 @@
-extern crate elasticlunr;
-#[macro_use]
-extern crate lazy_static;
-extern crate ammonia;
-
-#[macro_use]
-extern crate errors;
-extern crate library;
-
 use std::collections::{HashMap, HashSet};
 
 use elasticlunr::{Index, Language};
+use lazy_static::lazy_static;
 
-use errors::Result;
+use errors::{bail, Result};
 use library::{Library, Section};
 
 pub const ELASTICLUNR_JS: &str = include_str!("elasticlunr.min.js");

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -2,6 +2,7 @@
 name = "site"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 tera = "1"

--- a/components/site/benches/load.rs
+++ b/components/site/benches/load.rs
@@ -1,9 +1,4 @@
 //! Benchmarking loading/markdown rendering of generated sites of various sizes
-
-#![feature(test)]
-extern crate site;
-extern crate test;
-
 use std::env;
 
 use site::Site;

--- a/components/site/benches/site.rs
+++ b/components/site/benches/site.rs
@@ -1,9 +1,3 @@
-#![feature(test)]
-extern crate library;
-extern crate site;
-extern crate tempfile;
-extern crate test;
-
 use std::env;
 
 use library::Paginator;

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -1,25 +1,3 @@
-extern crate glob;
-extern crate rayon;
-extern crate serde;
-extern crate tera;
-#[macro_use]
-extern crate serde_derive;
-extern crate sass_rs;
-
-#[macro_use]
-extern crate errors;
-extern crate config;
-extern crate front_matter;
-extern crate imageproc;
-extern crate library;
-extern crate link_checker;
-extern crate search;
-extern crate templates;
-extern crate utils;
-
-#[cfg(test)]
-extern crate tempfile;
-
 pub mod sitemap;
 
 use std::collections::HashMap;
@@ -33,7 +11,7 @@ use sass_rs::{compile_file, Options as SassOptions, OutputStyle};
 use tera::{Context, Tera};
 
 use config::{get_config, Config};
-use errors::{Error, ErrorKind, Result};
+use errors::{bail, Error, ErrorKind, Result};
 use front_matter::InsertAnchor;
 use library::{
     find_taxonomies, sort_actual_pages_by_date, Library, Page, Paginator, Section, Taxonomy,

--- a/components/site/src/sitemap.rs
+++ b/components/site/src/sitemap.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 
+use serde_derive::Serialize;
+
 use config::Config;
 use library::{Library, Taxonomy};
 use std::cmp::Ordering;

--- a/components/site/tests/common.rs
+++ b/components/site/tests/common.rs
@@ -1,11 +1,8 @@
-extern crate site;
-extern crate tempfile;
-
 use std::env;
 use std::path::PathBuf;
 
-use self::site::Site;
-use self::tempfile::{tempdir, TempDir};
+use site::Site;
+use tempfile::{tempdir, TempDir};
 
 // 2 helper macros to make all the build testing more bearable
 #[macro_export]

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -1,5 +1,3 @@
-extern crate config;
-extern crate site;
 mod common;
 
 use std::collections::HashMap;

--- a/components/site/tests/site_i18n.rs
+++ b/components/site/tests/site_i18n.rs
@@ -1,4 +1,3 @@
-extern crate site;
 mod common;
 
 use std::env;

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -2,6 +2,7 @@
 name = "templates"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 tera = "1"

--- a/components/templates/src/filters.rs
+++ b/components/templates/src/filters.rs
@@ -3,7 +3,7 @@ use std::hash::BuildHasher;
 
 use base64::{decode, encode};
 use pulldown_cmark as cmark;
-use tera::{to_value, Result as TeraResult, Value};
+use tera::{to_value, try_get_value, Result as TeraResult, Value};
 
 pub fn markdown<S: BuildHasher>(
     value: &Value,

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -1,6 +1,3 @@
-extern crate serde_json;
-extern crate toml;
-
 use utils::de::fix_toml_dates;
 use utils::fs::{get_file_time, is_path_in_directory, read_file};
 
@@ -324,6 +321,7 @@ mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
+    use serde_json::json;
     use tera::{to_value, Function};
 
     fn get_test_file(filename: &str) -> PathBuf {

--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -1,28 +1,7 @@
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate tera;
-extern crate base64;
-extern crate csv;
-extern crate image;
-extern crate pulldown_cmark;
-extern crate reqwest;
-extern crate url;
-#[cfg(test)]
-#[macro_use]
-extern crate serde_json;
-#[cfg(not(test))]
-extern crate serde_json;
-
-extern crate config;
-extern crate errors;
-extern crate imageproc;
-extern crate library;
-extern crate utils;
-
 pub mod filters;
 pub mod global_fns;
 
+use lazy_static::lazy_static;
 use tera::{Context, Tera};
 
 use errors::{Error, Result};

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "utils"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 errors = { path = "../errors" }

--- a/components/utils/src/lib.rs
+++ b/components/utils/src/lib.rs
@@ -1,15 +1,3 @@
-#[macro_use]
-extern crate errors;
-
-extern crate serde;
-#[cfg(test)]
-extern crate tempfile;
-extern crate tera;
-extern crate toml;
-extern crate unicode_segmentation;
-extern crate walkdir;
-extern crate slug;
-
 pub mod de;
 pub mod fs;
 pub mod net;

--- a/components/utils/src/site.rs
+++ b/components/utils/src/site.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::hash::BuildHasher;
 use unicode_segmentation::UnicodeSegmentation;
 
-use errors::Result;
+use errors::{bail, Result};
 
 /// Get word count and estimated reading time
 pub fn get_reading_analytics(content: &str) -> (usize, usize) {

--- a/components/utils/src/templates.rs
+++ b/components/utils/src/templates.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use tera::{Context, Tera};
 
-use errors::Result;
+use errors::{bail, Result};
 
 static DEFAULT_TPL: &str = include_str!("default_tpl.html");
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{App, AppSettings, Arg, SubCommand};
+use clap::{crate_authors, crate_description, crate_version, App, AppSettings, Arg, SubCommand};
 
 pub fn build_cli() -> App<'static, 'static> {
     App::new("zola")

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -3,7 +3,7 @@ use std::env;
 use errors::Result;
 use site::Site;
 
-use console;
+use crate::console;
 
 pub fn build(
     config_file: &str,

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use errors::Result;
 use site::Site;
 
-use console;
+use crate::console;
 
 pub fn check(
     config_file: &str,

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,11 +1,11 @@
 use std::fs::{canonicalize, create_dir};
 use std::path::Path;
 
-use errors::Result;
+use errors::{bail, Result};
 use utils::fs::create_file;
 
-use console;
-use prompt::{ask_bool, ask_url};
+use crate::console;
+use crate::prompt::{ask_bool, ask_url};
 
 const CONFIG: &str = r#"
 # The URL the site will be built for

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -21,8 +21,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-extern crate globset;
-
 use std::env;
 use std::fs::{read_dir, remove_dir_all, File};
 use std::io::Read;
@@ -39,12 +37,12 @@ use ctrlc;
 use notify::{watcher, RecursiveMode, Watcher};
 use ws::{Message, Sender, WebSocket};
 
-use cmd::serve::globset::GlobSet;
 use errors::{Error as ZolaError, Result};
+use globset::GlobSet;
 use site::Site;
 use utils::fs::copy_file;
 
-use console;
+use crate::console;
 use open;
 use rebuild;
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+
 use std::env;
 use std::error::Error as StdError;
 use std::io::Write;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,3 @@
-extern crate actix_files;
-extern crate actix_web;
-extern crate atty;
-#[macro_use]
-extern crate clap;
-extern crate chrono;
-#[macro_use]
-extern crate lazy_static;
-extern crate ctrlc;
-extern crate notify;
-extern crate termcolor;
-extern crate url;
-extern crate ws;
-
-extern crate site;
-#[macro_use]
-extern crate errors;
-extern crate front_matter;
-extern crate open;
-extern crate rebuild;
-extern crate utils;
-
 use std::time::Instant;
 
 use utils::net::{get_available_port, port_is_available};


### PR DESCRIPTION
Hyper 0.13 uses async but async functions aren't permitted in the 2015 edition of Rust.  This migrates Zola to the 2018 edition, so we can continue moving forward with #782.

The main changes to make this work were related to [path clarity](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html).  Besides that, this allows us to drop some `extern crate` statements as well.  There may be more tidying that can be done but this at least compiles/tests correctly.