### PR TITLE
Fix Clippy warnings

### DIFF
--- a/components/front_matter/src/page.rs
+++ b/components/front_matter/src/page.rs
@@ -87,11 +87,11 @@ impl PageFrontMatter {
     pub fn date_to_datetime(&mut self) {
         self.datetime = if let Some(ref d) = self.date {
             if d.contains('T') {
-                DateTime::parse_from_rfc3339(&d).ok().and_then(|s| Some(s.naive_local()))
+                DateTime::parse_from_rfc3339(&d).ok().map(|s| s.naive_local())
             } else {
                 NaiveDate::parse_from_str(&d, "%Y-%m-%d")
                     .ok()
-                    .and_then(|s| Some(s.and_hms(0, 0, 0)))
+                    .map(|s| s.and_hms(0, 0, 0))
             }
         } else {
             None

--- a/components/library/src/pagination/mod.rs
+++ b/components/library/src/pagination/mod.rs
@@ -190,7 +190,7 @@ impl<'a> Paginator<'a> {
         }
         paginator.insert("number_pagers", to_value(&self.pagers.len()).unwrap());
         let base_url = if self.paginate_path.is_empty() {
-            format!("{}", self.permalink)
+            self.permalink.to_string()
         } else {
             format!("{}{}/", self.permalink, self.paginate_path)
         };


### PR DESCRIPTION
This fixes the following Clippy warnings:

```
warning: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
  --> components/front_matter/src/page.rs:90:17
   |
90 |                 DateTime::parse_from_rfc3339(&d).ok().and_then(|s| Some(s.naive_local()))
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `DateTime::parse_from_rfc3339(&d).ok().map(|s| s.naive_local())`
   |
   = note: `#[warn(clippy::option_and_then_some)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_and_then_some
```

```
warning: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
  --> components/front_matter/src/page.rs:92:17
   |
92 | /                 NaiveDate::parse_from_str(&d, "%Y-%m-%d")
93 | |                     .ok()
94 | |                     .and_then(|s| Some(s.and_hms(0, 0, 0)))
   | |___________________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_and_then_some
help: try this
   |
92 |                 NaiveDate::parse_from_str(&d, "%Y-%m-%d")
93 |                     .ok().map(|s| s.and_hms(0, 0, 0))
   |
```

```
warning: useless use of `format!`
   --> components/library/src/pagination/mod.rs:193:13
    |
193 |             format!("{}", self.permalink)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `self.permalink.to_string()`
    |
    = note: `#[warn(clippy::useless_format)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format
```

I did not address the following Clippy warning, since it requires more architectural changes and I didn't want to make a decision on how to best approach it:

```
warning: this function has too many arguments (8/7)
   --> src/cmd/serve.rs:147:1
    |
147 | / pub fn serve(
148 | |     interface: &str,
149 | |     port: u16,
150 | |     output_dir: &str,
...   |
155 | |     include_drafts: bool,
156 | | ) -> Result<()> {
    | |_______________^
    |
    = note: `#[warn(clippy::too_many_arguments)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
```