### PR TITLE
Increase minimum Rust version to 1.39.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,9 +19,9 @@ stages:
             linux-stable:
               imageName: 'ubuntu-16.04'
               rustup_toolchain: stable
-            linux-1.35:
+            linux-1.39:
               imageName: 'ubuntu-16.04'
-              rustup_toolchain: 1.36.0
+              rustup_toolchain: 1.39.0
         pool:
           vmImage: $(imageName)
         steps:


### PR DESCRIPTION
It will be necessary to increase the minimum version of Rust used in CI to 1.39.0 to accommodate upcoming changes that use async/await.  We've already encountered a build issue in #892, due to a dependency requiring a newer version of Rust than `linux-1.35` was using (1.36.0).