### PR TITLE
Format code using cargo fmt

### DIFF
--- a/components/front_matter/src/page.rs
+++ b/components/front_matter/src/page.rs
@@ -90,9 +90,7 @@ impl PageFrontMatter {
             if d.contains('T') {
                 DateTime::parse_from_rfc3339(&d).ok().map(|s| s.naive_local())
             } else {
-                NaiveDate::parse_from_str(&d, "%Y-%m-%d")
-                    .ok()
-                    .map(|s| s.and_hms(0, 0, 0))
+                NaiveDate::parse_from_str(&d, "%Y-%m-%d").ok().map(|s| s.and_hms(0, 0, 0))
             }
         } else {
             None

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -167,7 +167,10 @@ impl Page {
                     if let Some(slug) = slug_from_dated_filename {
                         maybe_slugify_paths(&slug, config.slugify_paths)
                     } else {
-                        maybe_slugify_paths(parent.file_name().unwrap().to_str().unwrap(), config.slugify_paths)
+                        maybe_slugify_paths(
+                            parent.file_name().unwrap().to_str().unwrap(),
+                            config.slugify_paths,
+                        )
                     }
                 } else {
                     maybe_slugify_paths(&page.file.name, config.slugify_paths)

--- a/components/library/src/pagination/mod.rs
+++ b/components/library/src/pagination/mod.rs
@@ -195,10 +195,7 @@ impl<'a> Paginator<'a> {
         } else {
             format!("{}{}/", self.permalink, self.paginate_path)
         };
-        paginator.insert(
-            "base_url",
-            to_value(&base_url).unwrap(),
-        );
+        paginator.insert("base_url", to_value(&base_url).unwrap());
         paginator.insert("pages", to_value(&current_pager.pages).unwrap());
         paginator.insert("current_index", to_value(current_pager.index).unwrap());
         paginator.insert("total_pages", to_value(self.all_pages.len()).unwrap());
@@ -383,7 +380,6 @@ mod tests {
         assert_eq!(paginator.pagers[1].pages.len(), 2);
         assert_eq!(paginator.pagers[1].permalink, "https://vincent.is/posts/2/");
         assert_eq!(paginator.pagers[1].path, "posts/2/");
-
 
         let context = paginator.build_paginator_context(&paginator.pagers[0]);
         assert_eq!(context["base_url"], to_value("https://vincent.is/posts/").unwrap());

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -591,10 +591,7 @@ mod tests {
 
         assert_eq!(categories.items.len(), 1);
         assert_eq!(categories.items[0].name, "Écologie");
-        assert_eq!(
-            categories.items[0].permalink,
-            "http://a-website.com/fr/catégories/Écologie/"
-        );
+        assert_eq!(categories.items[0].permalink, "http://a-website.com/fr/catégories/Écologie/");
         assert_eq!(categories.items[0].pages.len(), 1);
     }
 
@@ -711,5 +708,4 @@ mod tests {
         );
         assert_eq!(categories.items[1].pages.len(), 1);
     }
-
 }

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -12,8 +12,8 @@ use config::highlighting::{get_highlighter, SYNTAX_SET, THEME_SET};
 use errors::{Error, Result};
 use front_matter::InsertAnchor;
 use utils::site::resolve_internal_link;
-use utils::vec::InsertMany;
 use utils::slugs::maybe_slugify_anchors;
+use utils::vec::InsertMany;
 
 use self::cmark::{Event, LinkType, Options, Parser, Tag};
 
@@ -297,9 +297,13 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
             let start_idx = heading_ref.start_idx;
             let end_idx = heading_ref.end_idx;
             let title = get_text(&events[start_idx + 1..end_idx]);
-            let id = heading_ref
-                .id
-                .unwrap_or_else(|| find_anchor(&inserted_anchors, maybe_slugify_anchors(&title, context.config.slugify_paths), 0));
+            let id = heading_ref.id.unwrap_or_else(|| {
+                find_anchor(
+                    &inserted_anchors,
+                    maybe_slugify_anchors(&title, context.config.slugify_paths),
+                    0,
+                )
+            });
             inserted_anchors.push(id.clone());
 
             // insert `id` to the tag

--- a/components/utils/src/lib.rs
+++ b/components/utils/src/lib.rs
@@ -2,6 +2,6 @@ pub mod de;
 pub mod fs;
 pub mod net;
 pub mod site;
+pub mod slugs;
 pub mod templates;
 pub mod vec;
-pub mod slugs;

--- a/components/utils/src/slugs.rs
+++ b/components/utils/src/slugs.rs
@@ -1,6 +1,6 @@
 fn strip_chars(s: &str, chars: &str) -> String {
     let mut sanitized_string = s.to_string();
-    sanitized_string.retain( |c| !chars.contains(c));
+    sanitized_string.retain(|c| !chars.contains(c));
     sanitized_string
 }
 
@@ -24,8 +24,7 @@ pub fn maybe_slugify_paths(s: &str, slugify: bool) -> String {
     if slugify {
         // ASCII slugification
         slug::slugify(s)
-    }
-    else {
+    } else {
         // Only remove forbidden characters
         strip_invalid_paths_chars(s)
     }
@@ -35,8 +34,7 @@ pub fn maybe_slugify_anchors(s: &str, slugify: bool) -> String {
     if slugify {
         // ASCII slugification
         slug::slugify(s)
-    }
-    else {
+    } else {
         // Only remove forbidden characters
         strip_invalid_anchors_chars(s)
     }


### PR DESCRIPTION
I usually try to format changes using `cargo fmt` before creating a PR but I've been having to manually remove unrelated format changes (to ensure the PR only contains relevant changes).  This PR is simply a `cargo fmt` run on the current next branch, to resolve this issue for the moment.