### PR TITLE
link_checker: Handle non-success status codes

### DIFF
--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -71,7 +71,37 @@ pub fn check_url(url: &str, config: &LinkChecker) -> LinkResult {
                 Err(e) => LinkResult { code: None, error: Some(e.to_string()) },
             }
         }
-        Ok(response) => LinkResult { code: Some(response.status()), error: None },
+        Ok(response) => {
+            if response.status().is_success() {
+                LinkResult { code: Some(response.status()), error: None }
+            } else {
+                let error_string = if response.status().is_informational() {
+                    String::from(format!(
+                        "Informational status code ({}) received",
+                        response.status()
+                    ))
+                } else if response.status().is_redirection() {
+                    String::from(format!(
+                        "Redirection status code ({}) received",
+                        response.status()
+                    ))
+                } else if response.status().is_client_error() {
+                    String::from(format!(
+                        "Client error status code ({}) received",
+                        response.status()
+                    ))
+                } else if response.status().is_server_error() {
+                    String::from(format!(
+                        "Server error status code ({}) received",
+                        response.status()
+                    ))
+                } else {
+                    String::from("Non-success status code received")
+                };
+
+                LinkResult { code: None, error: Some(error_string) }
+            }
+        }
         Err(e) => LinkResult { code: None, error: Some(e.description().to_string()) },
     };
 


### PR DESCRIPTION
The `can_fail_404_links()` test doesn't encounter a 404 response in actuality, since the google.comys domain doesn't resolve.  When the test is updated such that the response's status code is a 404, the test fails because the `check_url()` function doesn't handle non-success responses how the test's assertions expect.  This commit updates `check_url()` to handle non-success responses, treating them much like errors.

If any (or all) of the non-success status code types (informational, redirection, client error, server error) should be handled in a different fashion, let me know.  If `check_url()`'s current behavior is correct, I'll get rid of these changes and update the `can_fail_404_links()` test instead.

Either way, this will help with the forthcoming test changes related to HTTP mocking.  I already have those changes finished (#898) but it will fail the `can_fail_404_links()` test until this is addressed.