### PR TITLE
Treat 304 as valid, add mock tests, fix mock path issue

### DIFF
--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -325,6 +325,11 @@ mod tests {
     use serde_json::json;
     use tera::{to_value, Function};
 
+    // NOTE: HTTP mock paths below are randomly generated to avoid name
+    // collisions. Mocks with the same path can sometimes bleed between tests
+    // and cause them to randomly pass/fail. Please make sure to use unique
+    // paths when adding or modifying tests that use Mockito.
+
     fn get_test_file(filename: &str) -> PathBuf {
         let test_files = PathBuf::from("../utils/test-files").canonicalize().unwrap();
         return test_files.join(filename);
@@ -366,14 +371,14 @@ mod tests {
 
     #[test]
     fn calculates_cache_key_for_url() {
-        let _m = mock("GET", "/test")
+        let _m = mock("GET", "/kr1zdgbm4y")
             .with_header("content-type", "text/plain")
             .with_body("Test")
             .create();
 
-        let url = format!("{}{}", mockito::server_url(), "/test");
+        let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y");
         let cache_key = DataSource::Url(url.parse().unwrap()).get_cache_key(&OutputFormat::Plain);
-        assert_eq!(cache_key, 12502656262443320092);
+        assert_eq!(cache_key, 425638486551656875);
     }
 
     #[test]
@@ -396,7 +401,7 @@ mod tests {
 
     #[test]
     fn can_load_remote_data() {
-        let _m = mock("GET", "/json")
+        let _m = mock("GET", "/zpydpkjj67")
             .with_header("content-type", "application/json")
             .with_body(
                 r#"{
@@ -408,7 +413,7 @@ mod tests {
             )
             .create();
 
-        let url = format!("{}{}", mockito::server_url(), "/json");
+        let url = format!("{}{}", mockito::server_url(), "/zpydpkjj67");
         let static_fn = LoadData::new(PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(&url).unwrap());
@@ -419,13 +424,13 @@ mod tests {
 
     #[test]
     fn fails_when_request_404s() {
-        let _m = mock("GET", "/404")
+        let _m = mock("GET", "/aazeow0kog")
             .with_status(404)
             .with_header("content-type", "text/plain")
             .with_body("Not Found")
             .create();
 
-        let url = format!("{}{}", mockito::server_url(), "/404");
+        let url = format!("{}{}", mockito::server_url(), "/aazeow0kog");
         let static_fn = LoadData::new(PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(&url).unwrap());


### PR DESCRIPTION
This continues the work started in #897.

## Redirections

Regarding the discussion in that PR, 301, 302, 303, 307, and 308 redirections are handled by reqwest and the `response.status().is_redirection()` conditional block in `check_url()` wouldn't be reached under those circumstances.  However, 300 (Multiple Choices), 304 (Not Modified), 305 (Use Proxy), and 306 (Switch Proxy, deprecated in HTTP 1.1) still reach that conditional block, since they're not handled by reqwest. As such, I've decided to keep the `is_redirection()` conditional block.

At least to me, the 304 response seems like it would be okay to treat as a valid response, so I modified `is_valid()` and `check_url()` to treat it like a success response.  If you disagree, I can remove these changes and it will be treated like an error.  Either way, it will likely never be encountered in practice, since it's sent in response to a request's `If-Modified-Since` or `If-Match` headers (which we're not using here).

## Added Tests

I added `link_checker` tests for 301-to-200 status codes, 301-to-404 status codes, and 500 status codes, to test redirections and the previously-added `response.status()` checking for non-success status codes in `check_url()`.

## Mockito Path Collisions

While adding the redirection tests, I encountered an issue with Mockito, where mocks with the same path (e.g., `mock("GET", "/test")`) can potentially bleed between tests, so you may end up with an unexpected response which causes the test to sometimes pass and sometimes fail.  To avoid this, I made the mock paths unique across tests, using pseudorandom alphanumeric paths.  The current path naming scheme makes it easy to add new tests (without having to keep all the existing path names in your head) but if you would like to go about it a different way, just let me know.

The path names should be kept unique going forward as tests are added or changed, so I added a note above the tests in `/components/link_checker/src/lib.rs` and `/components/templates/src/global_fns/load_data.rs`.  I may try to create an example to demonstrate the issue and see if the Mockito folks will look into it but this is the current state of affairs, at least.

## Etc.

Besides this, I fixed Clippy warnings about using `String::from()` around `format!()`.  I forgot that `format!()` returns a `String` (not a `str`), so the `String::from()` was unnecessary.