### PR TITLE
Fix benchmarks (rendering, site)

### DIFF
--- a/components/rendering/benches/all.rs
+++ b/components/rendering/benches/all.rs
@@ -1,5 +1,7 @@
+#![feature(test)]
+extern crate test;
+
 use std::collections::HashMap;
-use std::path::Path;
 
 use config::Config;
 use front_matter::InsertAnchor;
@@ -85,7 +87,7 @@ fn bench_render_content_with_highlighting(b: &mut test::Bencher) {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
     let context =
-        RenderContext::new(&tera, &config, "", &permalinks_ctx, Path::new(""), InsertAnchor::None);
+        RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
     b.iter(|| render_content(CONTENT, &context).unwrap());
 }
 
@@ -97,7 +99,7 @@ fn bench_render_content_without_highlighting(b: &mut test::Bencher) {
     let mut config = Config::default();
     config.highlight_code = false;
     let context =
-        RenderContext::new(&tera, &config, "", &permalinks_ctx, Path::new(""), InsertAnchor::None);
+        RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
     b.iter(|| render_content(CONTENT, &context).unwrap());
 }
 
@@ -109,7 +111,7 @@ fn bench_render_content_no_shortcode(b: &mut test::Bencher) {
     config.highlight_code = false;
     let permalinks_ctx = HashMap::new();
     let context =
-        RenderContext::new(&tera, &config, "", &permalinks_ctx, Path::new(""), InsertAnchor::None);
+        RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
 
     b.iter(|| render_content(&content2, &context).unwrap());
 }
@@ -121,7 +123,7 @@ fn bench_render_shortcodes_one_present(b: &mut test::Bencher) {
     let config = Config::default();
     let permalinks_ctx = HashMap::new();
     let context =
-        RenderContext::new(&tera, &config, "", &permalinks_ctx, Path::new(""), InsertAnchor::None);
+        RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
 
     b.iter(|| render_shortcodes(CONTENT, &context));
 }

--- a/components/site/benches/load.rs
+++ b/components/site/benches/load.rs
@@ -1,4 +1,7 @@
 //! Benchmarking loading/markdown rendering of generated sites of various sizes
+#![feature(test)]
+extern crate test;
+
 use std::env;
 
 use site::Site;

--- a/components/site/benches/site.rs
+++ b/components/site/benches/site.rs
@@ -1,3 +1,6 @@
+#![feature(test)]
+extern crate test;
+
 use std::env;
 
 use library::Paginator;


### PR DESCRIPTION
It turns out that I broke benchmarks in #885 because I was a little heavy-handed in my removal of `extern crate` statements and attributes.  This restores the necessary `#![feature(test)]` and `extern crate test;` for these benchmarks to work.

I fixed the `RenderContext::new()` errors in the rendering benchmark, where six parameters were provided but five were expected.

Past this, the `/components/site/benches/load.rs` benchmark fails for some reason and simply gives an `error: bench failed` message.  If you have any insight on how to fix this, I can try to tackle it in this PR, otherwise you can take care of it sometime later.