### PR TITLE
Further refine the slugification story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Breaking
 - Remove `toc` variable in section/page context and pass it to `page.toc` and `section.toc` instead so they are
 accessible everywhere
-- [Slugification](https://en.wikipedia.org/wiki/Slug_(web_publishing)#Slug) of page paths is now optional. By default, every path will be slugified as it is happening right now.
-To keep non-ASCII characters,  set `slugify_paths = true` in your config.
+- [Slugification](https://en.wikipedia.org/wiki/Slug_(web_publishing)#Slug) of page paths is no longer performed by default.
+  To return to the 0.9.0 behaviour, set `slugify_paths = true` in your config.
 
 ### Other
 - Add zenburn syntax highlighting theme
@@ -16,6 +16,7 @@ To keep non-ASCII characters,  set `slugify_paths = true` in your config.
 - Allow skipping anchor checking in `zola check` for some URL prefixes
 - Allow skipping prefixes in `zola check`
 - Check for path collisions when building the site
+- Add `slugify_anchors` config option to disable slugification of anchors
 
 ## 0.9.0 (2019-09-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ accessible everywhere
 - Allow skipping prefixes in `zola check`
 - Check for path collisions when building the site
 - Add `slugify_anchors` config option to disable slugification of anchors
+- Add `slugify_taxonomy_terms` config option to disable slugification of taxonomy terms
 
 ## 0.9.0 (2019-09-28)
 

--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -130,8 +130,10 @@ pub struct Config {
     /// key into different language.
     translations: HashMap<String, TranslateTerm>,
 
-    /// Whether to slugify page and taxonomy URLs (disable for UTF-8 URLs)
+    /// Whether to slugify page slugs (disable for UTF-8 URLs)
     pub slugify_paths: bool,
+    /// Whether to slugify taxonomy terms (disable for UTF-8 URLs)
+    pub slugify_taxonomy_terms: bool,
     /// Whether to slugify anchors (disable for UTF-8 URLs)
     pub slugify_anchors: bool,
     /// Whether to highlight all code blocks found in markdown files. Defaults to false
@@ -359,6 +361,7 @@ impl Default for Config {
             description: None,
             theme: None,
             slugify_paths: false,
+            slugify_taxonomy_terms: true,
             slugify_anchors: true,
             highlight_code: false,
             highlight_theme: "base16-ocean-dark".to_string(),

--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -132,6 +132,8 @@ pub struct Config {
 
     /// Whether to slugify page and taxonomy URLs (disable for UTF-8 URLs)
     pub slugify_paths: bool,
+    /// Whether to slugify anchors (disable for UTF-8 URLs)
+    pub slugify_anchors: bool,
     /// Whether to highlight all code blocks found in markdown files. Defaults to false
     pub highlight_code: bool,
     /// Which themes to use for code highlighting. See Readme for supported themes
@@ -356,7 +358,8 @@ impl Default for Config {
             title: None,
             description: None,
             theme: None,
-            slugify_paths: true,
+            slugify_paths: false,
+            slugify_anchors: true,
             highlight_code: false,
             highlight_theme: "base16-ocean-dark".to_string(),
             default_language: "en".to_string(),

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -19,7 +19,7 @@ use utils::templates::render_template;
 use crate::content::file_info::FileInfo;
 use crate::content::has_anchor;
 use crate::content::ser::SerializingPage;
-use utils::slugs::maybe_slugify_paths;
+use utils::slugs::maybe_slugify;
 
 lazy_static! {
     // Based on https://regex101.com/r/H2n38Z/1/tests
@@ -161,24 +161,24 @@ impl Page {
 
         page.slug = {
             if let Some(ref slug) = page.meta.slug {
-                maybe_slugify_paths(&slug.trim(), config.slugify_paths)
+                maybe_slugify(&slug.trim(), config.slugify_paths)
             } else if page.file.name == "index" {
                 if let Some(parent) = page.file.path.parent() {
                     if let Some(slug) = slug_from_dated_filename {
-                        maybe_slugify_paths(&slug, config.slugify_paths)
+                        maybe_slugify(&slug, config.slugify_paths)
                     } else {
-                        maybe_slugify_paths(
+                        maybe_slugify(
                             parent.file_name().unwrap().to_str().unwrap(),
                             config.slugify_paths,
                         )
                     }
                 } else {
-                    maybe_slugify_paths(&page.file.name, config.slugify_paths)
+                    maybe_slugify(&page.file.name, config.slugify_paths)
                 }
             } else if let Some(slug) = slug_from_dated_filename {
-                maybe_slugify_paths(&slug, config.slugify_paths)
+                maybe_slugify(&slug, config.slugify_paths)
             } else {
-                maybe_slugify_paths(&page.file.name, config.slugify_paths)
+                maybe_slugify(&page.file.name, config.slugify_paths)
             }
         };
 
@@ -637,9 +637,11 @@ Hello world
         File::create(nested_path.join("graph.jpg")).unwrap();
         File::create(nested_path.join("fail.png")).unwrap();
 
+        let mut config = Config::default();
+        config.slugify_paths = true;
         let res = Page::from_file(
             nested_path.join("index.md").as_path(),
-            &Config::default(),
+            &config,
             &path.to_path_buf(),
         );
         assert!(res.is_ok());

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -11,7 +11,7 @@ use utils::templates::render_template;
 use crate::content::SerializingPage;
 use crate::library::Library;
 use crate::sorting::sort_pages_by_date;
-use utils::slugs::maybe_slugify_paths;
+use utils::slugs::maybe_slugify;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SerializedTaxonomyItem<'a> {
@@ -70,7 +70,7 @@ impl TaxonomyItem {
             })
             .collect();
         let (mut pages, ignored_pages) = sort_pages_by_date(data);
-        let slug = maybe_slugify_paths(name, config.slugify_paths);
+        let slug = maybe_slugify(name, config.slugify_paths);
         let permalink = if taxonomy.lang != config.default_language {
             config.make_permalink(&format!("/{}/{}/{}", taxonomy.lang, taxonomy.name, slug))
         } else {
@@ -241,6 +241,7 @@ mod tests {
         let mut config = Config::default();
         let mut library = Library::new(2, 0, false);
 
+        config.slugify_paths = true;
         config.taxonomies = vec![
             TaxonomyConfig {
                 name: "categories".to_string(),
@@ -336,6 +337,7 @@ mod tests {
         let mut config = Config::default();
         let mut library = Library::new(2, 0, false);
 
+        config.slugify_paths = true;
         config.taxonomies = vec![
             TaxonomyConfig {
                 name: "categories".to_string(),
@@ -459,6 +461,7 @@ mod tests {
         config.languages.push(Language { rss: false, code: "fr".to_string(), search: false });
         let mut library = Library::new(2, 0, true);
 
+        config.slugify_paths = true;
         config.taxonomies = vec![
             TaxonomyConfig {
                 name: "categories".to_string(),

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -70,7 +70,7 @@ impl TaxonomyItem {
             })
             .collect();
         let (mut pages, ignored_pages) = sort_pages_by_date(data);
-        let slug = maybe_slugify(name, config.slugify_paths);
+        let slug = maybe_slugify(name, config.slugify_taxonomy_terms);
         let permalink = if taxonomy.lang != config.default_language {
             config.make_permalink(&format!("/{}/{}/{}", taxonomy.lang, taxonomy.name, slug))
         } else {
@@ -241,7 +241,6 @@ mod tests {
         let mut config = Config::default();
         let mut library = Library::new(2, 0, false);
 
-        config.slugify_paths = true;
         config.taxonomies = vec![
             TaxonomyConfig {
                 name: "categories".to_string(),
@@ -337,7 +336,6 @@ mod tests {
         let mut config = Config::default();
         let mut library = Library::new(2, 0, false);
 
-        config.slugify_paths = true;
         config.taxonomies = vec![
             TaxonomyConfig {
                 name: "categories".to_string(),
@@ -461,7 +459,6 @@ mod tests {
         config.languages.push(Language { rss: false, code: "fr".to_string(), search: false });
         let mut library = Library::new(2, 0, true);
 
-        config.slugify_paths = true;
         config.taxonomies = vec![
             TaxonomyConfig {
                 name: "categories".to_string(),
@@ -568,7 +565,7 @@ mod tests {
     #[test]
     fn can_make_utf8_taxonomies() {
         let mut config = Config::default();
-        config.slugify_paths = false;
+        config.slugify_taxonomy_terms = false;
         config.languages.push(Language {
             rss: false,
             code: "fr".to_string(),
@@ -601,7 +598,7 @@ mod tests {
     #[test]
     fn can_make_slugified_taxonomies_in_multiple_languages() {
         let mut config = Config::default();
-        config.slugify_paths = true;
+        config.slugify_taxonomy_terms = true;
         config.languages.push(Language {
             rss: false,
             code: "fr".to_string(),

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -300,7 +300,16 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
             let id = heading_ref.id.unwrap_or_else(|| {
                 find_anchor(
                     &inserted_anchors,
-                    maybe_slugify(&title, context.config.slugify_anchors),
+                    if context.config.slugify_anchors {
+                        maybe_slugify(&title, true)
+                    } else {
+                        // In conformant HTML documents, id values “must not contain any ASCII
+                        // whitespace”, so we turn it into underscores. (In practice, space in IDs
+                        // work fine across the board, hence not filtering it out from any
+                        // manually-specified IDs: if the user wrote a space in explicitly, they
+                        // probably want it.)
+                        title.replace(|c: char| c.is_ascii_whitespace(), "_")
+                    },
                     0,
                 )
             });

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -12,7 +12,7 @@ use config::highlighting::{get_highlighter, SYNTAX_SET, THEME_SET};
 use errors::{Error, Result};
 use front_matter::InsertAnchor;
 use utils::site::resolve_internal_link;
-use utils::slugs::maybe_slugify_anchors;
+use utils::slugs::maybe_slugify;
 use utils::vec::InsertMany;
 
 use self::cmark::{Event, LinkType, Options, Parser, Tag};
@@ -300,7 +300,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
             let id = heading_ref.id.unwrap_or_else(|| {
                 find_anchor(
                     &inserted_anchors,
-                    maybe_slugify_anchors(&title, context.config.slugify_paths),
+                    maybe_slugify(&title, context.config.slugify_anchors),
                     0,
                 )
             });

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -350,10 +350,10 @@ fn can_add_non_slug_id_to_headings() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
-    config.slugify_paths = false;
+    config.slugify_anchors = false;
     let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
     let res = render_content(r#"# L'écologie et vous"#, &context).unwrap();
-    assert_eq!(res.body, "<h1 id=\"L'écologie_et_vous\">L'écologie et vous</h1>\n");
+    assert_eq!(res.body, "<h1 id=\"L'écologie et vous\">L'écologie et vous</h1>\n");
 }
 
 #[test]

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -353,7 +353,7 @@ fn can_add_non_slug_id_to_headings() {
     config.slugify_anchors = false;
     let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
     let res = render_content(r#"# L'écologie et vous"#, &context).unwrap();
-    assert_eq!(res.body, "<h1 id=\"L'écologie et vous\">L'écologie et vous</h1>\n");
+    assert_eq!(res.body, "<h1 id=\"L'écologie_et_vous\">L'écologie et vous</h1>\n");
 }
 
 #[test]

--- a/components/utils/src/slugs.rs
+++ b/components/utils/src/slugs.rs
@@ -1,42 +1,8 @@
-fn strip_chars(s: &str, chars: &str) -> String {
-    let mut sanitized_string = s.to_string();
-    sanitized_string.retain(|c| !chars.contains(c));
-    sanitized_string
-}
-
-fn strip_invalid_paths_chars(s: &str) -> String {
-    // NTFS forbidden characters : https://gist.github.com/doctaphred/d01d05291546186941e1b7ddc02034d3
-    // Also we need to trim . from the end of filename
-    let trimmed = s.trim_end_matches(|c| c == ' ' || c == '.');
-    let cleaned = trimmed.replace(" ", "_");
-    // And () [] since they are not allowed in markdown links
-    strip_chars(&cleaned, "<>:/|?*#()[]\n\"\\\r\t")
-}
-
-fn strip_invalid_anchors_chars(s: &str) -> String {
-    // spaces are not valid in markdown links
-    let cleaned = s.replace(" ", "_");
-    // https://tools.ietf.org/html/rfc3986#section-3.5
-    strip_chars(&cleaned, "\"#%<>[\\]()^`{|}")
-}
-
-pub fn maybe_slugify_paths(s: &str, slugify: bool) -> String {
+pub fn maybe_slugify(s: &str, slugify: bool) -> String {
     if slugify {
-        // ASCII slugification
         slug::slugify(s)
     } else {
-        // Only remove forbidden characters
-        strip_invalid_paths_chars(s)
-    }
-}
-
-pub fn maybe_slugify_anchors(s: &str, slugify: bool) -> String {
-    if slugify {
-        // ASCII slugification
-        slug::slugify(s)
-    } else {
-        // Only remove forbidden characters
-        strip_invalid_anchors_chars(s)
+        s.to_string()
     }
 }
 
@@ -45,61 +11,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn strip_invalid_paths_chars_works() {
-        let tests = vec![
-            // no newlines
-            ("test\ntest", "testtest"),
-            // no whitespaces
-            ("test ", "test"),
-            ("t est ", "t_est"),
-            // invalid NTFS
-            ("test .", "test"),
-            ("test. ", "test"),
-            ("test#test/test?test", "testtesttesttest"),
-            // Invalid CommonMark chars in links
-            ("test (hey)", "test_hey"),
-            ("test (hey", "test_hey"),
-            ("test hey)", "test_hey"),
-            ("test [hey]", "test_hey"),
-            ("test [hey", "test_hey"),
-            ("test hey]", "test_hey"),
-            // UTF-8
-            ("日本", "日本"),
-        ];
-
-        for (input, expected) in tests {
-            assert_eq!(strip_invalid_paths_chars(&input), expected);
-        }
+    fn maybe_slugify_enabled() {
+        assert_eq!(maybe_slugify("héhé", true), "hehe");
     }
 
     #[test]
-    fn strip_invalid_anchors_chars_works() {
-        let tests = vec![
-            ("日本", "日本"),
-            // Some invalid chars get removed
-            ("test#", "test"),
-            ("test<", "test"),
-            ("test%", "test"),
-            ("test^", "test"),
-            ("test{", "test"),
-            ("test|", "test"),
-            ("test(", "test"),
-            // Spaces are replaced by `_`
-            ("test hey", "test_hey"),
-        ];
-
-        for (input, expected) in tests {
-            assert_eq!(strip_invalid_anchors_chars(&input), expected);
-        }
-    }
-
-    #[test]
-    fn maybe_slugify_paths_enabled() {
-        assert_eq!(maybe_slugify_paths("héhé", true), "hehe");
-    }
-
-    #[test]
-    fn maybe_slugify_paths_disabled() {
-        assert_eq!(maybe_slugify_paths("héhé", false), "héhé");
+    fn maybe_slugify_disabled() {
+        assert_eq!(maybe_slugify("héhé", false), "héhé");
     }
 }

--- a/docs/content/documentation/content/linking.md
+++ b/docs/content/documentation/content/linking.md
@@ -5,8 +5,8 @@ weight = 50
 
 ## Heading id and anchor insertion
 While rendering the Markdown content, a unique id will automatically be assigned to each heading. 
-This id is created by converting the heading text to a [slug](https://en.wikipedia.org/wiki/Semantic_URL#Slug) if `slugify_paths` is enabled.
-if `slugify_paths` is disabled, whitespaces are replaced by `_` and the following characters are stripped: `#`, `%`, `<`, `>`, `[`, `]`, `(`, `)`, \`, `^`, `{`, `|`, `}`.
+This id is created by converting the heading text to a [slug](https://en.wikipedia.org/wiki/Semantic_URL#Slug) if `slugify_anchors` is enabled.
+if `slugify_anchors` is disabled, the heading text is used verbatim.
 A number is appended at the end if the slug already exists for that article 
 For example:
 

--- a/docs/content/documentation/content/linking.md
+++ b/docs/content/documentation/content/linking.md
@@ -6,7 +6,7 @@ weight = 50
 ## Heading id and anchor insertion
 While rendering the Markdown content, a unique id will automatically be assigned to each heading. 
 This id is created by converting the heading text to a [slug](https://en.wikipedia.org/wiki/Semantic_URL#Slug) if `slugify_anchors` is enabled.
-if `slugify_anchors` is disabled, the heading text is used verbatim.
+If `slugify_anchors` is disabled, ASCII whitespace is replaced by `_` (since it's forbidden in IDs in conforming HTML documents) but no other modifications to the heading text are made.
 A number is appended at the end if the slug already exists for that article 
 For example:
 

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -34,13 +34,7 @@ For any page within your content folder, its output path will be defined by eith
 - its `slug` frontmatter key
 - its filename
 
-Either way, these proposed path will be sanitized before being used.
-If `slugify_paths` is enabled in the site's config - the default - paths are [slugified](https://en.wikipedia.org/wiki/Clean_URL#Slug). 
-Otherwise, a simpler sanitation is performed, outputting only valid NTFS paths. 
-The following characters are removed: `<`, `>`, `:`, `/`, `|`, `?`, `*`, `#`, `\\`, `(`, `)`, `[`, `]` as well as newlines and tabulations. 
-Additionally, trailing whitespace and dots are removed and whitespaces are replaced by `_`.
-
-**NOTE:** To produce URLs containing non-English characters (UTF8), `slugify_paths` needs to be set to `false`.
+If `slugify_paths` is enabled in the site's config, paths are [slugified](https://en.wikipedia.org/wiki/Clean_URL#Slug).
 
 ### Path from frontmatter
 

--- a/docs/content/documentation/content/taxonomies.md
+++ b/docs/content/documentation/content/taxonomies.md
@@ -52,7 +52,7 @@ categories = ["programming"]
 
 In a similar manner to how section and pages calculate their output path:
 - the taxonomy name is never slugified
-- the taxonomy entry (eg. as specific tag) is slugified when `slugify_paths` is enabled in the configuration
+- the taxonomy entry (eg. as specific tag) is slugified when `slugify_taxonomy_terms` is enabled in the configuration
 
 The taxonomy pages are then available at the following paths:
 

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -33,6 +33,10 @@ theme = ""
 # URLs they want in the filenames or page/section slug field.
 slugify_paths = false
 
+# Slugify taxonomy terms. Enabled by default; disabling this causes taxonomy
+# terms to be used as slugs without any modification.
+slugify_taxonomy_terms = false
+
 # Slugify anchors. Enabled by default; disabling this causes automatic heading
 # IDs to be the heading text, with ASCII whitespace replaced with underscores.
 slugify_anchors = true

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -34,7 +34,7 @@ theme = ""
 slugify_paths = false
 
 # Slugify anchors. Enabled by default; disabling this causes automatic heading
-# IDs to be the heading text, unaltered.
+# IDs to be the heading text, with ASCII whitespace replaced with underscores.
 slugify_anchors = true
 
 # When set to "true", all code blocks are highlighted.

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -27,9 +27,15 @@ default_language = "en"
 # The site theme to use.
 theme = ""
 
-# Slugify paths for compatibility with ASCII-only URLs produced by Zola < 0.9
-# Enabling this setting removes non-English (UTF8) characters in URLs
+# Slugify paths for compatibility with ASCII-only URLs produced by Zola < 0.10.0
+# Enabling this makes URLs lowercase, ASCII-only, and turns spaces into hyphens.
+# Most sites won't need to touch this, if they are in the habit of putting the
+# URLs they want in the filenames or page/section slug field.
 slugify_paths = false
+
+# Slugify anchors. Enabled by default; disabling this causes automatic heading
+# IDs to be the heading text, unaltered.
+slugify_anchors = true
 
 # When set to "true", all code blocks are highlighted.
 highlight_code = false

--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -5,6 +5,7 @@ compile_sass = true
 generate_rss = true
 theme = "sample"
 slugify_paths = true
+slugify_anchors = true
 
 taxonomies = [
     {name = "categories", rss = true},

--- a/test_site_i18n/config.toml
+++ b/test_site_i18n/config.toml
@@ -1,6 +1,8 @@
 # The URL the site will be built for
 base_url = "https://example.com"
 
+slugify_paths = true
+
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = false
 


### PR DESCRIPTION
https://github.com/getzola/zola/issues/768#issuecomment-570557713 is the discussion and source of what I’ve done in this commit.

The work included in here:

- Stop stripping any characters from paths or anchors: none of the restrictions are fundamentally valid, and they prevent realistic uses.

- Split slugify_paths into slugify_paths and slugify_anchors, and change anchors to using slugify_anchors.

- Turn slugify_paths off by default, and ensure that all the documentation is consistent about this (it wasn’t).

One potentially controversial part of this is ceasing turning spaces into underscores in anchors with slugify_anchors off. I consider that a legitimate slugification scheme, and contrary to the declared intent of `slugify_anchors = false`. I think it’s best left to the future where we can specify `slugify_anchors = "Spaces_to_underscores"` or similar. (Because there are further variants of it.)

Fixes #768.