### PR TITLE
fix: update year in docs template

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -99,7 +99,7 @@
             {% endblock content %}
         </div>
         <footer>
-            ©2017-2019 — <a class="white" href="http://vincentprouillet.com">Vincent Prouillet</a> and <a class="white" href="https://github.com/getzola/zola/graphs/contributors">contributors</a>
+            ©2017-2020 — <a class="white" href="http://vincentprouillet.com">Vincent Prouillet</a> and <a class="white" href="https://github.com/getzola/zola/graphs/contributors">contributors</a>
         </footer>
 
         <script type="text/javascript" src="{{ get_url(path="elasticlunr.min.js") }}"></script>


### PR DESCRIPTION
Updated the copyright year in the docs template to reflect the new year.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?



