### PR TITLE
Fix warning when building site tests

### DIFF
--- a/components/site/tests/common.rs
+++ b/components/site/tests/common.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::env;
 use std::path::PathBuf;
 


### PR DESCRIPTION
For the site integration tests, we have a file of common code which is
used by multiple files in `tests/`.  However, not all functions in
this file are used by all files in `tests/`.

As Cargo compiles each `tests/*.rs` file as a separate crate, this
means that some of these crates end up with unused code.  Rust notices
this and prints a warning.

Let's tell Rust that we don't care about dead code in this file so
that the warning is not printed.
