### PR TITLE
Change continue-reading to use a span with id instead of a named anchor in a paragraph

### DIFF
--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -17,8 +17,7 @@ use utils::vec::InsertMany;
 
 use self::cmark::{Event, LinkType, Options, Parser, Tag};
 
-const CONTINUE_READING: &str =
-    "<p id=\"zola-continue-reading\"><a name=\"continue-reading\"></a></p>\n";
+const CONTINUE_READING: &str = "<span id=\"continue-reading\"></span>";
 const ANCHOR_LINK_TEMPLATE: &str = "anchor-link.html";
 
 #[derive(Debug)]

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -757,7 +757,7 @@ Bla bla
     .unwrap();
     assert_eq!(
         res.body,
-        "<p>Hello <a href=\"https://vincentprouillet.com\">My site</a></p>\n<p id=\"zola-continue-reading\"><a name=\"continue-reading\"></a></p>\n<p>Bla bla</p>\n"
+        "<p>Hello <a href=\"https://vincentprouillet.com\">My site</a></p>\n<span id=\"continue-reading\"></span>\n<p>Bla bla</p>\n"
     );
     assert_eq!(
         res.summary_len,

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -239,11 +239,11 @@ fn can_build_site_with_live_reload_and_drafts() {
     // no live reload code
     assert!(file_contains!(public, "index.html", "/livereload.js"));
 
-    // the summary anchor link has been created
+    // the summary target has been created
     assert!(file_contains!(
         public,
         "posts/python/index.html",
-        r#"<a name="continue-reading"></a>"#
+        r#"<span id="continue-reading"></span>"#
     ));
 
     // Drafts are included

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -141,6 +141,5 @@ where you want the summary to end. The content up to that point will be
 available separately in the
 [template](@/documentation/templates/pages-sections.md#page-variables).
 
-An anchor link to this position named `continue-reading` is created, wrapped in a paragraph
-with a `zola-continue-reading` id, so you can link directly to it if needed. For example:
+A span element in this position with a `continue-reading` id is created, so you can link directly to it if needed. For example:
 `<a href="{{ page.permalink }}#continue-reading">Continue Reading</a>`.


### PR DESCRIPTION
Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [X] Have you created/updated the relevant documentation page(s)?

Closes #940, with the bonus that now it is possible to add `<!-- more -->` inside a paragraph without breaking it. In my tests the target goes to the same position as before when `<!-- more -->` is added between paragraphs.

