### PR TITLE
Fixing a missing link to Tera Filters

### DIFF
--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -58,7 +58,7 @@ Custom templates are not required to live at the root of your `templates` direct
 For example, `product_pages/with_pictures.html` is a valid template.
 
 ## Built-in filters
-Zola adds a few filters in addition to [those](https://tera.netlify.com/docs/templates/#built-in-filters) already present
+Zola adds a few filters in addition to [those](https://tera.netlify.com/docs/#filters) already present
 in Tera.
 
 ### markdown


### PR DESCRIPTION
The previous link results in a 404. This is the updated link.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?