### PR TITLE
Fix RSS template (#969)

### DIFF
--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -298,7 +298,7 @@ fn can_build_site_with_taxonomies() {
     assert!(file_contains!(
         public,
         "categories/a/rss.xml",
-        "https://replace-this-with-your-url.com/categories/a/rss.xml"
+        "https://replace-this-with-your-url.com/posts/with-assets/"
     ));
     // Extending from a theme works
     assert!(file_contains!(public, "categories/a/index.html", "EXTENDED"));

--- a/components/templates/src/builtins/rss.xml
+++ b/components/templates/src/builtins/rss.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+<rss version="2.0">
     <channel>
         <title>{{ config.title }}</title>
         <link>{{ config.base_url | escape_xml | safe }}</link>
         <description>{{ config.description }}</description>
         <generator>Zola</generator>
         <language>{{ config.default_language }}</language>
-        <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
         <lastBuildDate>{{ last_build_date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
         {% for page in pages %}
             <item>


### PR DESCRIPTION
Remove a tag imported from Atom from the otherwise valid RSS template.

Fixes #967
Identical to #969 with tests updated