### PR TITLE
Add an optionnal `lang` parameter to get_url

### DIFF
--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -114,6 +114,16 @@ link like the ones used in Markdown, starting from the root `content` directory.
 {% set url = get_url(path="@/blog/_index.md") %}
 ```
 
+It accepts an optionnal parameter `lang` in order to compute a *language-aware URL* in multilingual websites. Assuming `config.base_url` is `"http://example.com"`, the following snippet will:
+
+- return `"http://example.com/blog/"` if `config.default_language` is `"en"`
+- return `"http://example.com/en/blog/"` if `config.default_language` is **not** `"en"` and `"en"` appears in `config.languages`
+- fail otherwise, with the error message `"'en' is not an authorized language (check config.languages)."`
+
+```jinja2
+{% set url = get_url(path="@/blog/_index.md", lang="en") %}
+```
+
 This can also be used to get the permalinks for static assets, for example if
 we want to link to the file that is located at `static/css/app.css`:
 


### PR DESCRIPTION
Hi,

This PR adds an optionnal `lang` keyword to the `get_url` filter, as discussed *a long time ago* [here](https://zola.discourse.group/t/rfc-i18n/13).

If a file has the following path (relative to the content folder) `a_section/a_md_file.md`, then get_url(path="@/a_section/a_md_file.md", lang="fr") will return:

- $BASE_URL/a_section/a_md_file if the default language is fr
- $BASE_URL/fr/a_section/a_md_file if the default language is not fr and fr is in `config.languages`
- It will fail otherwise, with the *nice* error message `"'fr' is not an authorized language (check config.languages)."`


