### PR TITLE
Theme translations

### DIFF
--- a/components/config/src/config.rs
+++ b/components/config/src/config.rs
@@ -306,12 +306,11 @@ impl Config {
                 continue;
             }
             if !val.is_table() {
-                // We don't want to merge this because it's not a map
+                // We don't want to merge this because it's not a map (table)
                 continue;
             }
             let child = val.as_table().unwrap();
             // We borrow mutably the site's extra subsection but only if it's a Table
-            // We can unwrap safely because we just checked the key was in there
             let site_val = self.extra.get_mut(key).unwrap();
             if !site_val.is_table() {
                 // ERROR because user rewrote a theme config's mapping
@@ -336,18 +335,16 @@ impl Config {
     /// Merges the translations from the theme with the config translations
     fn add_theme_translations(&mut self, theme: &Theme) -> Result<()> {
         for (key, val) in &theme.translations {
-            // Ideally we don't have to merge the translations for languages
-            // not enabled in config.languages. However currently zola loads from
-            // config translations for disabled languages so let's not care for now.
-
             if !self.translations.contains_key(key) {
                 // The key was not in site config, so we create it now
                 self.translations.insert(key.to_string(), val.clone().into());
                 continue;
             }
 
+            // There is already translations in this language in the site config,
+            // so we create a new map from theme's translations for this language,
+            // and extend the site translations with it
             let mut t = val.clone();
-            // Can unwrap safely
             t.extend(self.translations.get(key).unwrap().clone());
             self.translations.insert(key.to_string(), t);
         }

--- a/components/config/src/theme.rs
+++ b/components/config/src/theme.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use serde_derive::{Deserialize, Serialize};
 use toml::Value as Toml;
 
+use crate::config::TranslateTerm;
 use errors::{bail, Result};
 use utils::fs::read_file_with_error;
 
@@ -14,6 +15,7 @@ use utils::fs::read_file_with_error;
 pub struct Theme {
     /// All user params set in [extra] in the theme.toml
     pub extra: HashMap<String, Toml>,
+    pub translations: HashMap<String, TranslateTerm>,
 }
 
 impl Theme {
@@ -25,17 +27,23 @@ impl Theme {
         };
 
         let mut extra = HashMap::new();
+        let mut translations = HashMap::new();
         if let Some(theme_table) = theme.as_table() {
             if let Some(ex) = theme_table.get("extra") {
                 if ex.is_table() {
                     extra = ex.clone().try_into().unwrap();
                 }
             }
+            if let Some(t) = theme_table.get("translations") {
+                if t.is_table() {
+                    translations = t.clone().try_into().unwrap();
+                }
+            }
         } else {
             bail!("Expected the `theme.toml` to be a TOML table")
         }
 
-        Ok(Theme { extra })
+        Ok(Theme { extra, translations })
     }
 
     /// Parses a theme file from the given path

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -85,9 +85,12 @@ ignored_content = []
 # A list of directories used to search for additional `.sublime-syntax` files.
 extra_syntaxes = []
 
-# Optional translation object. The key if present should be a language code.
+# Optionally, use translation strings in your templates. The key,
+# if present should be a language code. If a theme provides translation
+# strings, they can be overriden here.
 # Example:
 #     default_language = "fr"
+#     languages = [{ code = "en" }]
 #
 #     [translations]
 #     [translations.fr]
@@ -119,8 +122,9 @@ anchors = "on"
 # Optional translation object. Keys should be language codes.
 [translations]
 
-# You can put any kind of data here. The data
-# will be accessible in all templates.
+# You can put any kind of data here. The data will be accessible
+# in all templates. If a theme defines some extra variables, they
+# can be overriden here.
 [extra]
 ```
 

--- a/docs/content/documentation/themes/creating-a-theme.md
+++ b/docs/content/documentation/themes/creating-a-theme.md
@@ -29,6 +29,10 @@ demo = ""
 # Use snake_casing to be consistent with the rest of Zola
 [extra]
 
+# Similar to extra, any variable here can be overriden in `config.toml`
+# This is used to hold translation strings for your theme
+[translations]
+
 # The theme author info: you!
 [author]
 name = "Vincent Prouillet"


### PR DESCRIPTION
Discussion [on the forum](https://zola.discourse.group/t/i18n-theme-translations/388)

In investigating this problem, i uncovered a problem that using sub-tables like `[extra.foo]` would not allow to keep theme defaults when a single key was overriden in site config. A new test l.585 catches this.

I also added a test l.454 to ensure trying to override a theme's table with another type errors, so that if a theme is expecting a mapping it will not produce weirder errors.

I updated the docs.

Let me know if there's anything to change, but feel free to take/edit it in any way you please.