### PR TITLE
Access heading level in anchor-link.html

### DIFF
--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -329,7 +329,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                 };
                 let mut c = tera::Context::new();
                 c.insert("id", &id);
-                c.insert("lvl", &heading_ref.level);
+                c.insert("level", &heading_ref.level);
 
                 let anchor_link = utils::templates::render_template(
                     &ANCHOR_LINK_TEMPLATE,

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -329,6 +329,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                 };
                 let mut c = tera::Context::new();
                 c.insert("id", &id);
+                c.insert("lvl", &heading_ref.level);
 
                 let anchor_link = utils::templates::render_template(
                     &ANCHOR_LINK_TEMPLATE,

--- a/docs/content/documentation/content/linking.md
+++ b/docs/content/documentation/content/linking.md
@@ -39,7 +39,12 @@ This option is set at the section level: the `insert_anchor_links` variable on t
 
 The default template is very basic and will need CSS tweaks in your project to look decent.
 If you want to change the anchor template, it can be easily overwritten by
-creating an `anchor-link.html` file in the `templates` directory, which gets an `id` variable.
+creating an `anchor-link.html` file in the `templates` directory.
+
+The anchor link template has the following variables:
+
+- `id`: the heading's id after applying the rules defined by `slugify.anchors`
+- `lvl`: the heading level (between 1 and 6)
 
 ## Internal links
 Linking to other pages and their headings is so common that Zola adds a

--- a/docs/content/documentation/content/linking.md
+++ b/docs/content/documentation/content/linking.md
@@ -44,7 +44,7 @@ creating an `anchor-link.html` file in the `templates` directory.
 The anchor link template has the following variables:
 
 - `id`: the heading's id after applying the rules defined by `slugify.anchors`
-- `lvl`: the heading level (between 1 and 6)
+- `level`: the heading level (between 1 and 6)
 
 ## Internal links
 Linking to other pages and their headings is so common that Zola adds a


### PR DESCRIPTION
This is a super trivial patch to access heading level as ~~lvl~~ `level` in anchor-link.html. The usecase is i really enjoy markdown-style headings on my blog. However, without this i have to use CSS tricks which means i can't make the # clickable. Here's what i want to do:

```
<a class="zola-anchor" href="#{{ id }}" aria-label="anchor link for {{ id }}">{% for i in range(end=level) %}#{% endfor %}</a> 
```