### PR TITLE
Fix Docsascode theme live demo URL

### DIFF
--- a/docs/content/themes/docsascode-theme/index.md
+++ b/docs/content/themes/docsascode-theme/index.md
@@ -12,7 +12,7 @@ repository = "https://github.com/codeandmedia/zola_docsascode_theme.git"
 homepage = "https://github.com/codeandmedia/zola_docsascode_theme"
 minimum_version = "0.10.0"
 license = "MIT"
-demo = "docsascode.codeandmedia.com"
+demo = "https://docsascode.codeandmedia.com"
 
 [extra.author]
 name = "Roman Soldatenkov"


### PR DESCRIPTION
The live demo URL for the Docsascode theme was broken, this PR fixes it.