### PR TITLE
Fixing a panic in load_data

### DIFF
--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -210,11 +210,10 @@ impl TeraFn for LoadData {
                     .send()
                     .and_then(|res| res.error_for_status())
                     .map_err(|e| {
-                        format!(
-                            "Failed to request {}: {}",
-                            url,
-                            e.status().expect("response status")
-                        )
+                        match e.status() {
+                            Some(status) => format!("Failed to request {}: {}", url, status),
+                            None => format!("Could not get response status for url: {}", url),
+                        }
                     })?;
                 response
                     .text()


### PR DESCRIPTION
If there is no response from the server, `load_data` would panic with: `response status`.

This patch removes the `expect` in favor of an error message that we couldn't get a response from the server for a given url.

**Before:**

```
Building site...
-> Creating 7 pages (3 orphan), 7 sections, and processing 1 images
thread 'main' panicked at 'response status', components/templates/src/global_fns/load_data.rs:216:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

**After:**

```
Error: Failed to render page '/Users/stanistan/dev/stanistan.com/content/invoice/01.md'
Reason: Failed to render 'invoice.html'
Reason: Could not get response status for url: http://localhost:3000/invoice/01
```

---

Following up, I started thinking about it would be great if the function called in the templates would -- by default -- have messages that told you that they failed. I'm playing around with automatically wrapping all the registered Terra functions with messages/context using [Error::chain](https://docs.rs/tera/1.3.0/tera/struct.Error.html#method.chain) so that the above response would look more like:

```
Error: Failed to render page '/Users/stanistan/dev/stanistan.com/content/invoice/01.md'
Reason: Failed to render 'invoice.html'
Reason: Failed calling tera function 'load_data'
Reason: Could not get response status for url: http://localhost:3000/invoice/01
```

Are you interested in a PR for this?
