### PR TITLE
Error messaging in tera_fn

### DIFF
--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -1,3 +1,5 @@
+use super::NamedTeraFn;
+
 use utils::de::fix_toml_dates;
 use utils::fs::{get_file_time, is_path_in_directory, read_file};
 
@@ -176,6 +178,7 @@ pub struct LoadData {
     client: Arc<Mutex<Client>>,
     result_cache: Arc<Mutex<HashMap<u64, Value>>>,
 }
+
 impl LoadData {
     pub fn new(base_path: PathBuf) -> Self {
         let client = Arc::new(Mutex::new(
@@ -187,6 +190,10 @@ impl LoadData {
         let result_cache = Arc::new(Mutex::new(HashMap::new()));
         Self { base_path, client, result_cache }
     }
+}
+
+impl NamedTeraFn for LoadData {
+    const NAME: &'static str = "load_data";
 }
 
 impl TeraFn for LoadData {

--- a/components/templates/src/global_fns/mod.rs
+++ b/components/templates/src/global_fns/mod.rs
@@ -17,19 +17,27 @@ use imageproc;
 #[macro_use]
 mod macros;
 
-mod load_data;
+mod named_tera_fn;
+pub use self::named_tera_fn::{NamedTeraFn, WrappedTeraFn};
 
+mod load_data;
 pub use self::load_data::LoadData;
 
 #[derive(Debug)]
 pub struct Trans {
     config: Config,
 }
+
 impl Trans {
     pub fn new(config: Config) -> Self {
         Self { config }
     }
 }
+
+impl NamedTeraFn for Trans {
+    const NAME: &'static str = "trans";
+}
+
 impl TeraFn for Trans {
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
         let key = required_arg!(String, args.get("key"), "`trans` requires a `key` argument.");
@@ -51,6 +59,7 @@ pub struct GetUrl {
     permalinks: HashMap<String, String>,
     content_path: PathBuf,
 }
+
 impl GetUrl {
     pub fn new(config: Config, permalinks: HashMap<String, String>, content_path: PathBuf) -> Self {
         Self { config, permalinks, content_path }
@@ -79,6 +88,10 @@ fn compute_file_sha256(path: &PathBuf) -> result::Result<String, io::Error> {
     let mut hasher = Sha256::new();
     io::copy(&mut file, &mut hasher)?;
     Ok(format!("{:x}", hasher.result()))
+}
+
+impl NamedTeraFn for GetUrl {
+    const NAME: &'static str = "get_url";
 }
 
 impl TeraFn for GetUrl {
@@ -135,6 +148,11 @@ impl TeraFn for GetUrl {
 pub struct ResizeImage {
     imageproc: Arc<Mutex<imageproc::Processor>>,
 }
+
+impl NamedTeraFn for ResizeImage {
+    const NAME: &'static str = "resize_image";
+}
+
 impl ResizeImage {
     pub fn new(imageproc: Arc<Mutex<imageproc::Processor>>) -> Self {
         Self { imageproc }
@@ -200,6 +218,10 @@ impl GetImageMeta {
     }
 }
 
+impl NamedTeraFn for GetImageMeta {
+    const NAME: &'static str = "get_image_metadata";
+}
+
 impl TeraFn for GetImageMeta {
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
         let path = required_arg!(
@@ -225,6 +247,7 @@ pub struct GetTaxonomyUrl {
     taxonomies: HashMap<String, HashMap<String, String>>,
     default_lang: String,
 }
+
 impl GetTaxonomyUrl {
     pub fn new(default_lang: &str, all_taxonomies: &[Taxonomy]) -> Self {
         let mut taxonomies = HashMap::new();
@@ -238,6 +261,11 @@ impl GetTaxonomyUrl {
         Self { taxonomies, default_lang: default_lang.to_string() }
     }
 }
+
+impl NamedTeraFn for GetTaxonomyUrl {
+    const NAME: &'static str = "get_taxonomy_url";
+}
+
 impl TeraFn for GetTaxonomyUrl {
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
         let kind = required_arg!(
@@ -278,11 +306,17 @@ pub struct GetPage {
     base_path: PathBuf,
     library: Arc<RwLock<Library>>,
 }
+
+impl NamedTeraFn for GetPage {
+    const NAME: &'static str = "get_page";
+}
+
 impl GetPage {
     pub fn new(base_path: PathBuf, library: Arc<RwLock<Library>>) -> Self {
         Self { base_path: base_path.join("content"), library }
     }
 }
+
 impl TeraFn for GetPage {
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
         let path = required_arg!(
@@ -304,11 +338,17 @@ pub struct GetSection {
     base_path: PathBuf,
     library: Arc<RwLock<Library>>,
 }
+
 impl GetSection {
     pub fn new(base_path: PathBuf, library: Arc<RwLock<Library>>) -> Self {
         Self { base_path: base_path.join("content"), library }
     }
 }
+
+impl NamedTeraFn for GetSection {
+    const NAME: &'static str = "get_section";
+}
+
 impl TeraFn for GetSection {
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
         let path = required_arg!(
@@ -343,6 +383,7 @@ pub struct GetTaxonomy {
     taxonomies: HashMap<String, Taxonomy>,
     default_lang: String,
 }
+
 impl GetTaxonomy {
     pub fn new(
         default_lang: &str,
@@ -356,6 +397,11 @@ impl GetTaxonomy {
         Self { taxonomies, library, default_lang: default_lang.to_string() }
     }
 }
+
+impl NamedTeraFn for GetTaxonomy {
+    const NAME: &'static str = "get_taxonomy";
+}
+
 impl TeraFn for GetTaxonomy {
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
         let kind = required_arg!(

--- a/components/templates/src/global_fns/named_tera_fn.rs
+++ b/components/templates/src/global_fns/named_tera_fn.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+use tera::{Function as TeraFn, Result, Value, Error};
+
+pub trait NamedTeraFn {
+    const NAME: &'static str;
+}
+
+#[derive(Debug)]
+pub struct WrappedTeraFn<F> {
+    f: F
+}
+
+impl <F> WrappedTeraFn<F> {
+    pub fn new(f: F) -> WrappedTeraFn<F> {
+        WrappedTeraFn { f }
+    }
+}
+
+impl <F> NamedTeraFn for WrappedTeraFn<F> where F: NamedTeraFn {
+    const NAME: &'static str = F::NAME;
+}
+
+impl <F> TeraFn for WrappedTeraFn<F> where F: NamedTeraFn + TeraFn {
+    fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
+        self.f.call(args).map_err(|e| {
+            Error::chain(format!("Failed in tera function call to `{}`", F::NAME), e)
+        })
+    }
+}


### PR DESCRIPTION
_This is a follow up to https://github.com/getzola/zola/pull/1036_

I wanted it to be a bit easier to identify that this error had come
from a specific function, and instead of adding that information to the
load_data function itself, wanted to investigate how errors were
reported in the first place.

```
Error: Failed to render page '/Users/stanistan/dev/stanistan.com/content/invoice/01.md'
Reason: Failed to render 'invoice.html'
>>> Reason: Failed in tera function call to `load_data` <<< NEW
Reason: Could not get response status for url: http://localhost:3000/invoice/01
```

---

This PR adds information to _every_ `global_fn` registered in tera by the zola.

The approach I've taken is:

1. create a `NamedTeraFn` trait which then means the `tera::Function` can have
   a statically associated name, the `site` no longer has to know the
   name of the function it is registering.
2. Wrap a `tera::Function` in another `tera::Function` which adds this
   name to any error that might have been produced, this is the
   `WrappedTeraFn`.
3. The functions are registered with a `register!` macro, which DRYs up
   those calls a bit.

LMK what you think-- I was also considering adding this functionality to `tera` itself, so that its transparent when calling the `register` methods and not here, but thought this was a better place to open this up for discussion given the context.



