### PR TITLE
add .dockerignore file to reduce intermediate docker image size and build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+.dockerignore
+.git*
+Dockerfile
+
+# From .gitignore
+target
+.idea/
+test_site/public
+test_site_i18n/public
+docs/public
+
+small-blog
+medium-blog
+big-blog
+huge-blog
+extra-huge-blog
+small-kb
+medium-kb
+huge-kb
+
+current.bench
+now.bench
+*.zst
+
+# snapcraft artifacts
+snap/.snapcraft
+parts
+prime
+stage
+
+# nixos dependencies snippet
+shell.nix
+# vim temporary files
+**/.*.sw*


### PR DESCRIPTION
This reduced the intermediate container size by a few GBs (mainly because `target/` is that large) for me when building locally and made the build faster because of that.

When working on the `Dockerfile`, this should greatly speed up the development because the changes on the file itself do not invalidate the build results.

This also helps to keep the build more reproducible as it avoids e.g. the contents of `target/` being used for the docker build.

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?