### PR TITLE
[RFC] non-HTML output

### DIFF
--- a/components/library/src/content/ser.rs
+++ b/components/library/src/content/ser.rs
@@ -57,6 +57,7 @@ impl<'a> TranslatedContent<'a> {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SerializingPage<'a> {
     relative_path: &'a str,
+    plain_content: &'a str,
     content: &'a str,
     permalink: &'a str,
     slug: &'a str,
@@ -121,6 +122,7 @@ impl<'a> SerializingPage<'a> {
         SerializingPage {
             relative_path: &page.file.relative,
             ancestors,
+            plain_content: &page.plain_content,
             content: &page.content,
             permalink: &page.permalink,
             slug: &page.slug,
@@ -178,6 +180,7 @@ impl<'a> SerializingPage<'a> {
         SerializingPage {
             relative_path: &page.file.relative,
             ancestors,
+            plain_content: &page.plain_content,
             content: &page.content,
             permalink: &page.permalink,
             slug: &page.slug,
@@ -211,6 +214,7 @@ impl<'a> SerializingPage<'a> {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SerializingSection<'a> {
     relative_path: &'a str,
+    plain_content: &'a str,
     content: &'a str,
     permalink: &'a str,
     ancestors: Vec<String>,
@@ -252,6 +256,7 @@ impl<'a> SerializingSection<'a> {
         SerializingSection {
             relative_path: &section.file.relative,
             ancestors,
+            plain_content: &section.plain_content,
             content: &section.content,
             permalink: &section.permalink,
             title: &section.meta.title,
@@ -289,6 +294,7 @@ impl<'a> SerializingSection<'a> {
         SerializingSection {
             relative_path: &section.file.relative,
             ancestors,
+            plain_content: &section.plain_content,
             content: &section.content,
             permalink: &section.permalink,
             title: &section.meta.title,

--- a/components/rendering/src/lib.rs
+++ b/components/rendering/src/lib.rs
@@ -10,12 +10,22 @@ use markdown::markdown_to_html;
 pub use shortcode::render_shortcodes;
 pub use table_of_contents::Heading;
 
-pub fn render_content(content: &str, context: &RenderContext) -> Result<markdown::Rendered> {
+pub fn render_plain_content(content: &str, context: &RenderContext) -> Result<String> {
     // Don't do shortcodes if there is nothing like a shortcode in the content
     if content.contains("{{") || content.contains("{%") {
-        let rendered = render_shortcodes(content, context)?;
-        return markdown_to_html(&rendered, context);
+        return render_shortcodes(content, context);
     }
+    Ok(content.to_string())
+}
 
+pub fn render_html_content(content: &str, context: &RenderContext) -> Result<markdown::Rendered> {
     markdown_to_html(&content, context)
+}
+
+/// The functions render_plain_content and render_html_content
+/// were split so the intermediate result may be used.
+/// Tnis is left for testing purposes
+pub fn render_content(content: &str, context: &RenderContext) -> Result<markdown::Rendered> {
+    render_plain_content(content, context)
+        .and_then(|res| render_html_content(&res, context))
 }

--- a/components/site/tests/site_gemini.rs
+++ b/components/site/tests/site_gemini.rs
@@ -1,0 +1,41 @@
+mod common;
+
+use std::env;
+
+use common::build_site;
+use site::Site;
+
+#[test]
+fn can_parse_gemini_site() {
+    let mut path = env::current_dir().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
+    path.push("test_site_gemini");
+    let config_file = path.join("config.toml");
+    let mut site = Site::new(&path, &config_file).unwrap();
+    site.load().unwrap();
+    let library = site.library.read().unwrap();
+
+    assert_eq!(library.pages().len(), 3);
+    assert_eq!(library.sections().len(), 2);
+}
+
+#[test]
+fn can_build_gemini_site() {
+    let (_, _tmp_dir, public) = build_site("test_site_gemini");
+    assert!(&public.exists());
+    assert!(file_exists!(public, "index.gemini"));
+    assert!(file_exists!(public, "hidden/orphan/index.gemini"));
+    assert!(file_exists!(public, "posts/index.gemini"));
+    // TODO: These fail; investigate!
+    assert!(file_exists!(public, "posts/first/index.gemini"));
+    assert!(file_exists!(public, "posts/another/index.gemini"));
+
+    // orphan page is templated correctly
+    assert!(file_contains!(public, "hidden/orphan/index.gemini", "back to site root"));
+    assert!(file_contains!(public, "hidden/orphan/index.gemini", "# Orphan page"));
+
+    // post list works
+    assert!(file_contains!(public, "posts/index.gemini",
+        "=> gemini://test.invalid/posts/first/ 2020-01-01 First post"));
+    assert!(file_contains!(public, "posts/index.gemini",
+        "=> gemini://test.invalid/posts/another/ 2020-02-01 Another one"));
+}

--- a/docs/content/documentation/templates/non-html.md
+++ b/docs/content/documentation/templates/non-html.md
@@ -1,0 +1,38 @@
++++
+title = "Non-HTML output"
+weight = 100
++++
+
+While Zola is best suited for generating HTML, it can be used for other output formats as well. Note that this does not have first class support and not all features will work.
+
+## Output filename
+
+Filenames are affected by
+
+* Content filename, eg. `foo.md`
+* Template extension, eg. `page.html`
+* URL beautification, meaning files are always output as `index.*` to support paths without file extension.
+
+With the example combination, the output file would be `foo/index.html`.
+
+To change the output file extension, just change to a template with the desired extension.
+
+## Whitespace
+
+For text-based formats, the [whitespace control](https://tera.netlify.app/docs/#whitespace-control) is quite useful. An useful pattern is removing the whitespace at the end whenever there's a Tera delimiter at the end a line (that is, use `-}}` or `-%}`).
+
+## Markdown rendering
+
+The main focus of Zola is in rendering markdown to HTML. That's what the `markdown` filter does and `page.content` is the resulting HTML.
+
+For non-HTML formats it's usually better to use `page.plain_content` which has Tera expressions and statements evaluated, but no HTML conversion.
+
+Content files still need to be `*.md` and have a front matter.
+
+## Always created files
+
+Zola will always create `404.html`, `robots.txt` and `sitemap.xml`. See their respective documentation for customization information.
+
+## Examples
+
+See [`test_site_gemini/`](https://github.com/getzola/zola/tree/master/test_site_gemini) in the source code repository for a simple test site with [text/gemini](https://gemini.circumlunar.space/) output.

--- a/test_site_gemini/config.toml
+++ b/test_site_gemini/config.toml
@@ -1,0 +1,1 @@
+base_url = "gemini://test.invalid"

--- a/test_site_gemini/content/_index.md
+++ b/test_site_gemini/content/_index.md
@@ -1,0 +1,10 @@
++++
+template = "home.gemini"
++++
+# Test gemini site
+
+Welcome!
+
+=> posts/ Posts
+
+Goodbye!

--- a/test_site_gemini/content/hidden/orphan.md
+++ b/test_site_gemini/content/hidden/orphan.md
@@ -1,0 +1,6 @@
++++
+template = "page.gemini"
++++
+# Orphan page
+
+Hello gemini!

--- a/test_site_gemini/content/posts/_index.md
+++ b/test_site_gemini/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+template = "section.gemini"
+page_template = "page.gemini"
++++

--- a/test_site_gemini/content/posts/another.md
+++ b/test_site_gemini/content/posts/another.md
@@ -1,0 +1,7 @@
++++
+title = "Another one"
+date = 2020-02-01
++++
+This is another post.
+
+See ya!

--- a/test_site_gemini/content/posts/first.md
+++ b/test_site_gemini/content/posts/first.md
@@ -1,0 +1,5 @@
++++
+title = "First post"
+date = 2020-01-01
++++
+Hello world! This is my first post!

--- a/test_site_gemini/templates/home.gemini
+++ b/test_site_gemini/templates/home.gemini
@@ -1,0 +1,1 @@
+{{ section.plain_content -}}

--- a/test_site_gemini/templates/page.gemini
+++ b/test_site_gemini/templates/page.gemini
@@ -1,0 +1,3 @@
+=> / back to site root
+
+{{ page.plain_content -}}

--- a/test_site_gemini/templates/section.gemini
+++ b/test_site_gemini/templates/section.gemini
@@ -1,0 +1,7 @@
+{{ section.plain_content -}}
+
+# Posts
+
+{% for page in section.pages -%}
+=> {{ page.permalink | safe }} {{ page.date | date }} {{ page.title }}
+{% endfor -%}


### PR DESCRIPTION
I'm posting this for discussion. Feedback is welcome and I'm willing to work on this.

I'll switch my own gemini site to use this probably this weekend.

---
Support non-HTML templates

- allow templates with any file extension
- use the template extension for output filenames
- add plain_content that has been rendered with Tera, but not
  markdown->HTML
- add simple example/test: test_site_gemini
- write basic documentation

See discussion in issue #905.
---

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
