### PR TITLE
Add support for SVG files to `get_image_metadata` (Fixes #769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add 2 syntax highlighting themes: `green` and `railsbase16-green-screen-dark`
 - Enable task lists in Markdown
+- Add support for SVG in `get_image_metadata`
 
 ## 0.11.0 (2020-05-25)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,6 +1664,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
+ "regex-syntax 0.6.18",
  "thread_local",
 ]
 
@@ -1754,6 +1761,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5001f134077069d87f77c8b9452b690df2445f7a43f1c7ca4a1af8dd505789d"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -2043,6 +2059,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "svg_metadata"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe5b1fbd62339f055704951dcaf2e757c460b9f6abe17f6de0d2563da821c57"
+dependencies = [
+ "doc-comment",
+ "lazy_static",
+ "regex",
+ "roxmltree",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2145,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "sha2",
+ "svg_metadata",
  "tera",
  "toml",
  "url",
@@ -2667,6 +2696,12 @@ dependencies = [
  "markup5ever",
  "time",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb4240203dadf40be2de9369e5c6dec1bf427528115b030baca3334c18362d7"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,7 +1664,6 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "regex-syntax 0.6.18",
  "thread_local",
 ]
 

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -21,6 +21,7 @@ utils = { path = "../utils" }
 library = { path = "../library" }
 config = { path = "../config" }
 imageproc = { path = "../imageproc" }
+svg_metadata = "0.4.1"
 
 [dependencies.reqwest]
 version = "0.10"

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -165,7 +165,8 @@ Whenever hashing files, whether using `get_file_hash` or `get_url(..., cachebust
 
 
 ### `get_image_metadata`
-Gets metadata for an image.  Currently, the only supported keys are `width` and `height`.
+Gets metadata for an image. This supports common formats like JPEG, PNG, as well as SVG.  
+Currently, the only supported keys are `width` and `height`.
 
 ```jinja2
   {% set meta = get_image_metadata(path="...") %}


### PR DESCRIPTION
This is the second attempt to fix #769. 🤞 
Tested it on my blog and it was working nicely.

Tried a couple of variants to write the size calculation idiomatically, but if anyone has a better idea, I'm open for suggestions.

#### Important caveat
If a user works with SVGs on their site **and** an SVG neither provides width/height nor viewport information **and** the user is calling `get_image_metadata()`, the build will fail with an error message, because zola could not determine the image proportions. I think that's an acceptable tradeoff, though as the user was explicitly asking for the metadata in a template. I'd even go so far to say that it's expected behavior to stop compilation instead of silently rendering with missing image proportions, but it's certainly something to be aware of.