### PR TITLE
Add --force/-f flag to init, for creation in non-empty dir

### DIFF
--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -20,6 +20,8 @@ $ zola init
 
 If the `my_site` directory already exists, Zola will only populate it if it contains only hidden files (dotfiles are ignored). If no `my_site` argument is passed, Zola will try to populate the current directory.
 
+In case you want to attempt to populate a non-empty directory and are brave, you can use `zola init --force`. Note that this will _not_ overwrite existing folders or files; in those cases you will get a `File exists (os error 17)` error or similar.
+
 You can initialize a git repository and a Zola site directly from within a new folder:
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,11 +24,15 @@ pub fn build_cli() -> App<'static, 'static> {
         .subcommands(vec![
             SubCommand::with_name("init")
                 .about("Create a new Zola project")
-                .arg(
+                .args(&[
                     Arg::with_name("name")
                         .default_value(".")
-                        .help("Name of the project. Will create a new directory with that name in the current directory")
-                ),
+                        .help("Name of the project. Will create a new directory with that name in the current directory"),
+                    Arg::with_name("force")
+                        .short("f")
+                        .takes_value(false)
+                        .help("Force creation of project even if directory is non-empty")
+                ]),
             SubCommand::with_name("build")
                 .about("Deletes the output directory if there is one and builds the site")
                 .args(&[

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -56,10 +56,11 @@ pub fn is_directory_quasi_empty(path: &Path) -> Result<bool> {
     Ok(false)
 }
 
-pub fn create_new_project(name: &str) -> Result<()> {
+pub fn create_new_project(name: &str, force: bool) -> Result<()> {
     let path = Path::new(name);
+
     // Better error message than the rust default
-    if path.exists() && !is_directory_quasi_empty(&path)? {
+    if path.exists() && !is_directory_quasi_empty(&path)? && !force {
         if name == "." {
             bail!("The current directory is not an empty folder (hidden files are ignored).");
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,8 @@ fn main() {
 
     match matches.subcommand() {
         ("init", Some(matches)) => {
-            match cmd::create_new_project(matches.value_of("name").unwrap()) {
+            let force = matches.is_present("force");
+            match cmd::create_new_project(matches.value_of("name").unwrap(), force) {
                 Ok(()) => (),
                 Err(e) => {
                     console::unravel_errors("Failed to create the project", &e);


### PR DESCRIPTION
Sorry for not discussing this first. I needed the feature for my own good, since I was about to create my first Zola web site (:tada:) tonight and I had the previous (Jekyll) version of the site in a submodule already. It was easier/more fun to try to add this missing flag to Zola rather than trying to workaround it... :see_no_evil: 

Note that `--force` is not as evil as one might think in this case. It merely bypasses the "folder exists" check. We could do a real `--force` flag that overwrites any existing content & configuration, but that's definitely something much more dangerous than what this PR aims to achieve.

----

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
