### PR TITLE
Zola is now available in the official Arch repos

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -16,10 +16,10 @@ $ brew install zola
 
 ### Arch Linux
 
-Use your favourite AUR helper to install the `zola-bin` package.
+Zola is available in the official Arch Linux repositories.
 
 ```bash
-$ yay -S zola-bin
+$ pacman -S zola
 ```
 
 ### Fedora


### PR DESCRIPTION
I just put zola in the official Arch repos and the docs should reflect this change.

I hope it's correct to make this PR for `master` as opposed to `next` as it's a docs change.