### PR TITLE
Add warning to not put taxonomies key in [extra] section

### DIFF
--- a/docs/content/documentation/content/taxonomies.md
+++ b/docs/content/documentation/content/taxonomies.md
@@ -16,6 +16,10 @@ For example the default would be page/1.
 - `feed`: if set to `true`, a feed (atom by default) will be generated for each term.
 - `lang`: only set this if you are making a multilingual site and want to indicate which language this taxonomy is for
 
+Insert into the configuration file (config.toml):
+
+⚠️ Place the taxonomies key in the main section and not in the `[extra]` section
+
 **Example 1:** (one language)
 
 ```toml


### PR DESCRIPTION
Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

Explanation:
Just a little change on the documentation to warn user to not put taxonomies key in the [extra] section of config.toml.
I did this mistake, because naturally you tend to put the taxonomies key at the end of the config file.
