### PR TITLE
Fix pagination section memory issue

### DIFF
--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -252,6 +252,16 @@ impl Section {
     pub fn to_serialized_basic<'a>(&'a self, library: &'a Library) -> SerializingSection<'a> {
         SerializingSection::from_section_basic(self, Some(library))
     }
+
+    pub fn paginate_by(&self) -> Option<usize> {
+        match self.meta.paginate_by {
+            None => None,
+            Some(x) => match x {
+                0 => None,
+                _ => Some(x)
+            }
+        }
+    }
 }
 
 /// Used to create a default index section if there is no _index.md in the root content directory

--- a/components/site/src/sitemap.rs
+++ b/components/site/src/sitemap.rs
@@ -85,14 +85,13 @@ pub fn find_entries<'a>(
         })
         .collect::<Vec<_>>();
 
-    for section in library.sections_values().iter().filter(|s| s.meta.paginate_by.is_some()) {
-        let number_pagers = match section.meta.paginate_by.unwrap() {
-            0 => 1 as isize,
-            _ => (section.pages.len() as f64 / section.meta.paginate_by.unwrap() as f64).ceil() as isize
-        };
-        for i in 1..=number_pagers {
-            let permalink = format!("{}{}/{}/", section.permalink, section.meta.paginate_path, i);
-            sections.push(SitemapEntry::new(Cow::Owned(permalink), None))
+    for section in library.sections_values().iter() {
+        if let Some(paginate_by) = section.paginate_by() {
+            let number_pagers = (section.pages.len() as f64 / paginate_by as f64).ceil() as isize;
+            for i in 1..=number_pagers {
+                let permalink = format!("{}{}/{}/", section.permalink, section.meta.paginate_path, i);
+                sections.push(SitemapEntry::new(Cow::Owned(permalink), None))
+            }
         }
     }
 

--- a/components/site/src/sitemap.rs
+++ b/components/site/src/sitemap.rs
@@ -86,8 +86,10 @@ pub fn find_entries<'a>(
         .collect::<Vec<_>>();
 
     for section in library.sections_values().iter().filter(|s| s.meta.paginate_by.is_some()) {
-        let number_pagers =
-            (section.pages.len() as f64 / section.meta.paginate_by.unwrap() as f64).ceil() as isize;
+        let number_pagers = match section.meta.paginate_by.unwrap() {
+            0 => 1 as isize,
+            _ => (section.pages.len() as f64 / section.meta.paginate_by.unwrap() as f64).ceil() as isize
+        };
         for i in 1..=number_pagers {
             let permalink = format!("{}{}/{}/", section.permalink, section.meta.paginate_path, i);
             sections.push(SitemapEntry::new(Cow::Owned(permalink), None))


### PR DESCRIPTION
When paginate_by is zero, set number_pagers to 1 so at least 1 sitemap section is pushed. I don't know if this breaks sitemap generation and will need a bit of help testing.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [n/a] Have you created/updated the relevant documentation page(s)?



