### PR TITLE
Support relative links for root directory (fix #1028)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let root_dir = match matches.value_of("root").unwrap() {
         "." => env::current_dir().unwrap(),
-        path => PathBuf::from(path),
+        path => PathBuf::from(path).canonicalize().expect(&format!("Cannot find root directory: {}", path)),
     };
     let config_file = match matches.value_of("config") {
         Some(path) => PathBuf::from(path),


### PR DESCRIPTION
This patch should fix the issues mentioned in #1028 by:

- canonicalizing the path inherited from the CLI (i.e. expanding relative path to an absolute one)
- prefixing the serve's watchers paths with the root directory