### PR TITLE
WIP: Don't fail to rebuild the site when a page is edited (fix #1014)

### DIFF
--- a/components/rebuild/src/lib.rs
+++ b/components/rebuild/src/lib.rs
@@ -342,11 +342,11 @@ pub fn after_content_change(site: &mut Site, path: &Path) -> Result<()> {
     let is_md = path.extension().unwrap() == "md";
     let index = path.parent().unwrap().join("index.md");
 
-    let mut potential_indices = vec![path.parent().unwrap().join("index.md")];
+    /*let mut potential_indices = vec![path.parent().unwrap().join("index.md")];
     for language in &site.config.languages {
         potential_indices.push(path.parent().unwrap().join(format!("index.{}.md", language.code)));
     }
-    let colocated_index = potential_indices.contains(&path.to_path_buf());
+    let colocated_index = potential_indices.contains(&path.to_path_buf());*/
 
     // A few situations can happen:
     // 1. Change on .md files
@@ -361,17 +361,15 @@ pub fn after_content_change(site: &mut Site, path: &Path) -> Result<()> {
     //       2. Something? Update the page
     if is_md {
         // only delete if it was able to be added in the first place
+        // TODO: shouldn't we delete the element in any case, because it appears to have been added
+        // in the first place?
         if !index.exists() && !path.exists() {
             return delete_element(site, path, is_section);
         }
 
         // Added another .md in a assets directory
-        if index.exists() && path.exists() && !colocated_index {
-            bail!(
-                "Change on {:?} detected but only files named `index.md` with an optional language code are allowed",
-                path.display()
-            );
-        } else if index.exists() && !path.exists() {
+        // TODO: see TODO above
+        if index.exists() && !path.exists() {
             // deleted the wrong .md, do nothing
             return Ok(());
         }


### PR DESCRIPTION
Removing the block which bailed seems to match expected behavior in #1014. I don't believe this change will break anything.

I'm not entirely sure this function does what it's supposed to do. I'm not entirely sure what it's supposed to do. I would expect something like this:

- 1. Entry is a file => What is it?
  - 1. Entry is markdown => Does it still exist?
    - 1. Yes => handle_{page,section}_editing
    - 2. No => delete_element
  - 2. Entry is something else => Does it still exist?
    - 1. Yes => copy it as a colocated asset, rebuild associated pages
    - 2. No => remove from colocated assets, rebuild associated pages
- 2. Entry is a folder => Does it still exist?
  - 1. Yes => find pages/sections inside (add pages/sections inside)
  - 2. No => remove pages/sections matching this basepath

Instead i see delete_element is called only if `!index.exists() && !path.exists()`. why? shouldn't delete_element be called if we have content/{_index,test}.md and have deletion of test.md?