### PR TITLE
Fix benchmarks

### DIFF
--- a/components/site/benches/gen.py
+++ b/components/site/benches/gen.py
@@ -98,7 +98,6 @@ def gen_skeleton(name, is_blog):
         shutil.rmtree(name)
 
     os.makedirs(os.path.join(name, "content"))
-    os.makedirs(os.path.join(name, "static"))
 
     with open(os.path.join(name, "config.toml"), "w") as f:
         if is_blog:
@@ -128,6 +127,7 @@ name = "Vincent Prouillet"
     # Re-use the test templates
     shutil.copytree("../../../test_site/templates", os.path.join(name, "templates"))
     shutil.copytree("../../../test_site/themes", os.path.join(name, "themes"))
+    shutil.copytree("../../../test_site/static", os.path.join(name, "static"))
 
 
 def gen_section(path, num_pages, is_blog):

--- a/components/site/benches/site.rs
+++ b/components/site/benches/site.rs
@@ -46,7 +46,7 @@ fn bench_render_feed(b: &mut test::Bencher) {
             site.library.read().unwrap().pages_values(),
             None,
             &site.config.default_language,
-            None,
+            |c| c,
         )
         .unwrap();
     });


### PR DESCRIPTION
Copy static folder from test_site to benchmark sites. Without, they cannot build because the theme's index.html calls site.css (which is in static).

Apparently render_feed changed signature and the benchmark was not updated. Now it compiles