### PR TITLE
Making Chinese and Japanese search indexing optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,6 +2817,7 @@ dependencies = [
  "notify",
  "open",
  "rebuild",
+ "search",
  "site",
  "termcolor",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ errors = { path = "components/errors" }
 front_matter = { path = "components/front_matter" }
 utils = { path = "components/utils" }
 rebuild = { path = "components/rebuild" }
+search = { path = "components/search" }
 
 [workspace]
 members = [

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -12,3 +12,8 @@ lazy_static = "1"
 errors = { path = "../errors" }
 library = { path = "../library" }
 config = { path = "../config" }
+
+[features]
+default = []
+indexing-zh = ["elasticlunr-rs/zh"]
+indexing-ja = ["elasticlunr-rs/ja"]

--- a/docs/content/documentation/content/multilingual.md
+++ b/docs/content/documentation/content/multilingual.md
@@ -20,6 +20,12 @@ languages = [
 If you want to use per-language taxonomies, ensure you set the `lang` field in their
 configuration.
 
+Note: By default, Chinese and Japanese search indexing is not included. You can include
+the support by building `zola` using `cargo build --features search/indexing-ja search/indexing-zh`.
+Please also note that, enabling Chinese indexing will increase the binary size by approximately
+5 MB while enabling Japanese indexing will increase the binary size by approximately 70 MB 
+due to the incredibly large dictionaries.
+
 ## Content
 Once the languages have been added, you can start to translate your content. Zola
 uses the filename to detect the language:


### PR DESCRIPTION
Previous discussion: #1102.

This Pull Request still requires some discussions as the current implementation is less than ideal due to the following reasons:

- The languages included by default are hardcoded, if the upstream decides to add a new language, then that ~~laundry~~ list needs to be updated.
- The Chinese segmentation library is significantly smaller (~5 MB) than the Japanese one (~60 MB), is it a good idea to just includes the Chinese segmentation library by default?
- Many languages have several different variants, if someone wants to, say include Simplified Chinese and Traditional Chinese on the same website, then there will be issues with the search indexing (as the language codes will not be ISO 639-1 compliant). So do we need to implement a system to convert the language codes to ISO 639-1 code so that `elasticlunr-rs` will work?

--------------------------------------------------------------------------------------------------

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [X] Have you created/updated the relevant documentation page(s)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getzola/zola/1115)
<!-- Reviewable:end -->
