### PR TITLE
Update filetime crate to 0.2.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,9 +466,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "filetime"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
  "cfg-if",
  "libc",

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1"
 serde_derive = "1"
 slug = "0.1"
 percent-encoding = "2"
-filetime = "0.2.8"
+filetime = "0.2.12"
 
 errors = { path = "../errors" }
 


### PR DESCRIPTION
This PR updates the `filetime` dependency in `components/utils` to version 0.2.12. This version contains a bug fix for atime/mtime setting, which fixes the new file copying routines on OpenBSD.
