### PR TITLE
Fix toml parse error line number (kind of)

### DIFF
--- a/components/front_matter/src/lib.rs
+++ b/components/front_matter/src/lib.rs
@@ -13,7 +13,7 @@ pub use section::SectionFrontMatter;
 
 lazy_static! {
     static ref PAGE_RE: Regex =
-        Regex::new(r"^[[:space:]]*\+\+\+\r?\n((?s).*?(?-s))\+\+\+\r?\n?((?s).*(?-s))$").unwrap();
+        Regex::new(r"^[[:space:]]*\+\+\+(\r?\n(?s).*?(?-s))\+\+\+\r?\n?((?s).*(?-s))$").unwrap();
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
@@ -37,7 +37,7 @@ pub enum InsertAnchor {
 
 /// Split a file between the front matter and its content
 /// Will return an error if the front matter wasn't found
-fn split_content(file_path: &Path, content: &str) -> Result<(String, String)> {
+fn split_content<'c>(file_path: &Path, content: &'c str) -> Result<(&'c str, &'c str)> {
     if !PAGE_RE.is_match(content) {
         bail!(
             "Couldn't find front matter in `{}`. Did you forget to add `+++`?",
@@ -50,15 +50,15 @@ fn split_content(file_path: &Path, content: &str) -> Result<(String, String)> {
     // caps[0] is the full match
     // caps[1] => front matter
     // caps[2] => content
-    Ok((caps[1].to_string(), caps[2].to_string()))
+    Ok((caps.get(1).unwrap().as_str(), caps.get(2).unwrap().as_str()))
 }
 
 /// Split a file between the front matter and its content.
 /// Returns a parsed `SectionFrontMatter` and the rest of the content
-pub fn split_section_content(
+pub fn split_section_content<'c>(
     file_path: &Path,
-    content: &str,
-) -> Result<(SectionFrontMatter, String)> {
+    content: &'c str,
+) -> Result<(SectionFrontMatter, &'c str)> {
     let (front_matter, content) = split_content(file_path, content)?;
     let meta = SectionFrontMatter::parse(&front_matter).map_err(|e| {
         Error::chain(
@@ -71,7 +71,7 @@ pub fn split_section_content(
 
 /// Split a file between the front matter and its content
 /// Returns a parsed `PageFrontMatter` and the rest of the content
-pub fn split_page_content(file_path: &Path, content: &str) -> Result<(PageFrontMatter, String)> {
+pub fn split_page_content<'c>(file_path: &Path, content: &'c str) -> Result<(PageFrontMatter, &'c str)> {
     let (front_matter, content) = split_content(file_path, content)?;
     let meta = PageFrontMatter::parse(&front_matter).map_err(|e| {
         Error::chain(

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -136,7 +136,7 @@ impl Page {
 
         page.lang = page.file.find_language(config)?;
 
-        page.raw_content = content;
+        page.raw_content = content.to_string();
         let (word_count, reading_time) = get_reading_analytics(&page.raw_content);
         page.word_count = Some(word_count);
         page.reading_time = Some(reading_time);

--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -107,7 +107,7 @@ impl Section {
         let (meta, content) = split_section_content(file_path, content)?;
         let mut section = Section::new(file_path, meta, base_path);
         section.lang = section.file.find_language(config)?;
-        section.raw_content = content;
+        section.raw_content = content.to_string();
         let (word_count, reading_time) = get_reading_analytics(&section.raw_content);
         section.word_count = Some(word_count);
         section.reading_time = Some(reading_time);


### PR DESCRIPTION
This is a minor hack to make the frontmatter toml parsing error locations appear in the right place: simply include the newline between `+++` and the frontmatter. Because virtually all frontmatter won't have additional newlines *before* the `+++`, this should give correct error locations in virtually every case. Also a minor change to split_content, to reduce unnecessary string copies.

Fixes #1133

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?



