### PR TITLE
Doc add a missing arg to `get_taxonomy_url`

### DIFF
--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -158,11 +158,13 @@ Gets metadata for an image.  Currently, the only supported keys are `width` and 
 Gets the permalink for the taxonomy item found.
 
 ```jinja2
-{% set url = get_taxonomy_url(kind="categories", name=page.taxonomies.category) %}
+{% set url = get_taxonomy_url(kind="categories", name=page.taxonomies.category, lang=page.lang) %}
 ```
 
 `name` will almost always come from a variable but in case you want to do it manually,
 the value should be the same as the one in the front matter, not the slugified version.
+
+`lang` (optional) default to `config.default_language` in config.toml
 
 ### `get_taxonomy`
 Gets the whole taxonomy of a specific kind.


### PR DESCRIPTION
This feature is already exist, but not in the doc yet

Related #766

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
