### PR TITLE
Derive default

### DIFF
--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Language {
     /// The language code
@@ -11,12 +11,6 @@ pub struct Language {
     pub feed: bool,
     /// Whether to generate search index for that language, defaults to `false`
     pub search: bool,
-}
-
-impl Default for Language {
-    fn default() -> Self {
-        Language { code: String::new(), feed: false, search: false }
-    }
 }
 
 pub type TranslateTerm = HashMap<String, String>;

--- a/components/config/src/config/slugify.rs
+++ b/components/config/src/config/slugify.rs
@@ -2,20 +2,10 @@ use serde_derive::{Deserialize, Serialize};
 
 use utils::slugs::SlugifyStrategy;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Slugify {
     pub paths: SlugifyStrategy,
     pub taxonomies: SlugifyStrategy,
     pub anchors: SlugifyStrategy,
-}
-
-impl Default for Slugify {
-    fn default() -> Self {
-        Slugify {
-            paths: SlugifyStrategy::On,
-            taxonomies: SlugifyStrategy::On,
-            anchors: SlugifyStrategy::On,
-        }
-    }
 }

--- a/components/config/src/config/taxonomies.rs
+++ b/components/config/src/config/taxonomies.rs
@@ -1,6 +1,6 @@
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Taxonomy {
     /// The name used in the URL, usually the plural
@@ -30,18 +30,6 @@ impl Taxonomy {
             path
         } else {
             "page"
-        }
-    }
-}
-
-impl Default for Taxonomy {
-    fn default() -> Self {
-        Taxonomy {
-            name: String::new(),
-            paginate_by: None,
-            paginate_path: None,
-            feed: false,
-            lang: String::new(),
         }
     }
 }

--- a/components/library/src/content/file_info.rs
+++ b/components/library/src/content/file_info.rs
@@ -27,7 +27,7 @@ pub fn find_content_components<P: AsRef<Path>>(path: P) -> Vec<String> {
 }
 
 /// Struct that contains all the information about the actual file
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct FileInfo {
     /// The full path to the .md file
     pub path: PathBuf,
@@ -140,22 +140,6 @@ impl FileInfo {
         let lang = parts.swap_remove(0);
 
         Ok(lang)
-    }
-}
-
-#[doc(hidden)]
-impl Default for FileInfo {
-    fn default() -> FileInfo {
-        FileInfo {
-            path: PathBuf::new(),
-            parent: PathBuf::new(),
-            grand_parent: None,
-            filename: String::new(),
-            name: String::new(),
-            components: vec![],
-            relative: String::new(),
-            canonical: PathBuf::new(),
-        }
     }
 }
 

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -29,7 +29,7 @@ lazy_static! {
     ).unwrap();
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Page {
     /// All info about the actual file
     pub file: FileInfo,
@@ -91,31 +91,7 @@ impl Page {
     pub fn new<P: AsRef<Path>>(file_path: P, meta: PageFrontMatter, base_path: &PathBuf) -> Page {
         let file_path = file_path.as_ref();
 
-        Page {
-            file: FileInfo::new_page(file_path, base_path),
-            meta,
-            ancestors: vec![],
-            raw_content: "".to_string(),
-            assets: vec![],
-            serialized_assets: vec![],
-            content: "".to_string(),
-            slug: "".to_string(),
-            path: "".to_string(),
-            components: vec![],
-            permalink: "".to_string(),
-            summary: None,
-            earlier: None,
-            later: None,
-            lighter: None,
-            heavier: None,
-            toc: vec![],
-            word_count: None,
-            reading_time: None,
-            lang: String::new(),
-            translations: Vec::new(),
-            internal_links_with_anchors: Vec::new(),
-            external_links: Vec::new(),
-        }
+        Page { file: FileInfo::new_page(file_path, base_path), meta, ..Self::default() }
     }
 
     pub fn is_draft(&self) -> bool {
@@ -338,36 +314,6 @@ impl Page {
 
     pub fn to_serialized_basic<'a>(&'a self, library: &'a Library) -> SerializingPage<'a> {
         SerializingPage::from_page_basic(self, Some(library))
-    }
-}
-
-impl Default for Page {
-    fn default() -> Page {
-        Page {
-            file: FileInfo::default(),
-            meta: PageFrontMatter::default(),
-            ancestors: vec![],
-            raw_content: "".to_string(),
-            assets: vec![],
-            serialized_assets: vec![],
-            content: "".to_string(),
-            slug: "".to_string(),
-            path: "".to_string(),
-            components: vec![],
-            permalink: "".to_string(),
-            summary: None,
-            earlier: None,
-            later: None,
-            lighter: None,
-            heavier: None,
-            toc: vec![],
-            word_count: None,
-            reading_time: None,
-            lang: String::new(),
-            translations: Vec::new(),
-            internal_links_with_anchors: Vec::new(),
-            external_links: Vec::new(),
-        }
     }
 }
 

--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -17,7 +17,8 @@ use crate::content::has_anchor;
 use crate::content::ser::SerializingSection;
 use crate::library::Library;
 
-#[derive(Clone, Debug, PartialEq)]
+// Default is used to create a default index section if there is no _index.md in the root content directory
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Section {
     /// All info about the actual file
     pub file: FileInfo,
@@ -74,28 +75,7 @@ impl Section {
     ) -> Section {
         let file_path = file_path.as_ref();
 
-        Section {
-            file: FileInfo::new_section(file_path, base_path),
-            meta,
-            ancestors: vec![],
-            path: "".to_string(),
-            components: vec![],
-            permalink: "".to_string(),
-            raw_content: "".to_string(),
-            assets: vec![],
-            serialized_assets: vec![],
-            content: "".to_string(),
-            pages: vec![],
-            ignored_pages: vec![],
-            subsections: vec![],
-            toc: vec![],
-            word_count: None,
-            reading_time: None,
-            lang: String::new(),
-            translations: Vec::new(),
-            internal_links_with_anchors: Vec::new(),
-            external_links: Vec::new(),
-        }
+        Section { file: FileInfo::new_section(file_path, base_path), meta, ..Self::default() }
     }
 
     pub fn parse(
@@ -262,34 +242,6 @@ impl Section {
                 0 => None,
                 _ => Some(x),
             },
-        }
-    }
-}
-
-/// Used to create a default index section if there is no _index.md in the root content directory
-impl Default for Section {
-    fn default() -> Section {
-        Section {
-            file: FileInfo::default(),
-            meta: SectionFrontMatter::default(),
-            ancestors: vec![],
-            path: "".to_string(),
-            components: vec![],
-            permalink: "".to_string(),
-            raw_content: "".to_string(),
-            assets: vec![],
-            serialized_assets: vec![],
-            content: "".to_string(),
-            pages: vec![],
-            ignored_pages: vec![],
-            subsections: vec![],
-            toc: vec![],
-            reading_time: None,
-            word_count: None,
-            lang: String::new(),
-            translations: Vec::new(),
-            internal_links_with_anchors: Vec::new(),
-            external_links: Vec::new(),
         }
     }
 }

--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -56,7 +56,7 @@ pub fn check_url(url: &str, config: &LinkChecker) -> Result {
                 response.copy_to(&mut buf).unwrap();
                 match String::from_utf8(buf) {
                     Ok(s) => s,
-                    Err(_) => return Err("The page didn't return valid UTF-8".to_string())
+                    Err(_) => return Err("The page didn't return valid UTF-8".to_string()),
                 }
             };
 

--- a/components/rendering/src/table_of_contents.rs
+++ b/components/rendering/src/table_of_contents.rs
@@ -1,7 +1,7 @@
 use serde_derive::Serialize;
 
 /// Populated while receiving events from the markdown parser
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize)]
 pub struct Heading {
     pub level: u32,
     pub id: String,
@@ -12,19 +12,7 @@ pub struct Heading {
 
 impl Heading {
     pub fn new(level: u32) -> Heading {
-        Heading {
-            level,
-            id: String::new(),
-            permalink: String::new(),
-            title: String::new(),
-            children: Vec::new(),
-        }
-    }
-}
-
-impl Default for Heading {
-    fn default() -> Self {
-        Heading::new(0)
+        Heading { level, ..Self::default() }
     }
 }
 

--- a/components/utils/src/slugs.rs
+++ b/components/utils/src/slugs.rs
@@ -11,6 +11,12 @@ pub enum SlugifyStrategy {
     Off,
 }
 
+impl Default for SlugifyStrategy {
+    fn default() -> Self {
+        SlugifyStrategy::On
+    }
+}
+
 fn strip_chars(s: &str, chars: &str) -> String {
     let mut sanitized_string = s.to_string();
     sanitized_string.retain(|c| !chars.contains(c));


### PR DESCRIPTION
Most custom `Default` impls can simply be derived; I went through and replaced all the ones where this is possible. Also updated various `new` methods to use `..Self::default()`.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?


