### PR TITLE
WIP: Refactor internationalization system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.13.0 (unreleased)
+
+
 ## 0.12.0 (2020-09-04)
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "serde_derive",
  "syntect",
  "toml",
+ "unic-langid",
  "utils",
 ]
 
@@ -1118,6 +1119,7 @@ dependencies = [
  "tempfile",
  "tera",
  "toml",
+ "unic-langid",
  "utils",
 ]
 
@@ -1927,6 +1929,7 @@ dependencies = [
  "syntect",
  "templates",
  "tera",
+ "unic-langid",
  "utils",
 ]
 
@@ -2088,6 +2091,7 @@ dependencies = [
  "errors",
  "lazy_static",
  "library",
+ "unic-langid",
 ]
 
 [[package]]
@@ -2186,6 +2190,7 @@ dependencies = [
  "tempfile",
  "templates",
  "tera",
+ "unic-langid",
  "utils",
 ]
 
@@ -2362,6 +2367,7 @@ dependencies = [
  "svg_metadata",
  "tera",
  "toml",
+ "unic-langid",
  "url",
  "utils",
 ]
@@ -2447,6 +2453,12 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29738eedb4388d9ea620eeab9384884fc3f06f586a2eddb56bedc5885126c7c1"
 
 [[package]]
 name = "tinyvec"
@@ -2583,6 +2595,50 @@ name = "unic-common"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73328fcd730a030bdb19ddf23e192187a6b01cd98be6d3140622a89129459ce5"
+dependencies = [
+ "unic-langid-impl",
+ "unic-langid-macros",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4a8eeaf0494862c1404c95ec2f4c33a2acff5076f64314b465e3ddae1b934d"
+dependencies = [
+ "serde",
+ "tinystr",
+]
+
+[[package]]
+name = "unic-langid-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f980d6d87e8805f2836d64b4138cc95aa7986fa63b1f51f67d5fbff64dd6e5"
+dependencies = [
+ "proc-macro-hack",
+ "tinystr",
+ "unic-langid-impl",
+ "unic-langid-macros-impl",
+]
+
+[[package]]
+name = "unic-langid-macros-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29396ffd97e27574c3e01368b1a64267d3064969e4848e2e130ff668be9daa9f"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn",
+ "unic-langid-impl",
+]
 
 [[package]]
 name = "unic-segment"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+
+[[package]]
 name = "assert-json-diff"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +576,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3b6132d1377d8776409a337c6851d342aee4e85277c96ecd2755c4e0efde1d"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a094d494ab2ed06077e9a95f4e47f446c376de95f6c93045dd88c499bfcd70"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rental",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0f7e83d14cccbf26e165d8881dcac5891af0d85a88543c09dd72ebd31d91ba"
+
+[[package]]
+name = "fluent-template-macros"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7ab5c993d21eb718ebf2c254ed390f483b2a8dabbda796bf342602f1689e8a"
+dependencies = [
+ "flume",
+ "ignore",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-templates"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947b404b72a987a47f14dc80f9235e979ef03f133846bbfe2c84d0b25d31d3b8"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-bundle",
+ "fluent-langneg",
+ "fluent-syntax",
+ "fluent-template-macros",
+ "flume",
+ "heck",
+ "ignore",
+ "lazy_static",
+ "log",
+ "once_cell",
+ "serde_json",
+ "snafu",
+ "tera",
+ "unic-langid",
+]
+
+[[package]]
+name = "flume"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835349a364636c2aaafda82d5514c32ac7463898207ae5f97d978a82ad26b517"
+dependencies = [
+ "futures",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,12 +731,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -692,6 +802,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project",
@@ -699,6 +810,15 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1010,6 +1130,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0ed58ba6089d49f8a9a7d5e16fc9b9e2019cdf40ef270f3d465fa244d9630b"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c271cdb1f12a9feb3a017619c3ee681f971f270f6757341d6abe1f9f7a98bc3"
+dependencies = [
+ "tinystr",
+ "unic-langid",
 ]
 
 [[package]]
@@ -1934,6 +2074,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rental"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
+dependencies = [
+ "rental-impl",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,6 +2383,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
+name = "snafu"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5aed652511f5c9123cf2afbe9c244c29db6effa2abb05c866e965c82405ce"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf8f7d5720104a9df0f7076a8682024e958bba0fe9848767bb44f251f3648e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2420,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string_cache"
@@ -2355,6 +2543,7 @@ dependencies = [
  "config",
  "csv",
  "errors",
+ "fluent-templates",
  "image",
  "imageproc",
  "lazy_static",
@@ -2562,6 +2751,15 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "type-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2741b1474c327d95c1f1e3b0a2c3977c8e128409c572a33af2914e7d636717"
+dependencies = [
+ "fxhash",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "zola"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zola"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com>"]
 edition = "2018"
 license = "MIT"

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4"
 globset = "0.4"
 lazy_static = "1"
 syntect = "4.1"
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -1,16 +1,95 @@
 use std::collections::HashMap;
 
 use serde_derive::{Deserialize, Serialize};
+use toml::Value as Toml;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// Contains site settings that can be set differently for each language
+///
+/// When rendering pages, this will be merged with the options for the default language, the
+/// details of which are documented for each field separately.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
-pub struct Language {
-    /// The language code
-    pub code: String,
-    /// Whether to generate a feed for that language, defaults to `false`
-    pub feed: bool,
-    /// Whether to generate search index for that language, defaults to `false`
-    pub search: bool,
+pub struct LocaleOptions {
+    /// How to refer to the language in URLs
+    ///
+    /// The localization functions require a valid language identifier to work correctly. Some
+    /// multilingual sites might already be using language names that do not conform to the
+    /// canonical [BCP 47] syntax, and this lets us keep links to them working currently.
+    ///
+    /// If empty or not set, the `language_code` will be used.
+    ///
+    /// [BCP 47]: https://tools.ietf.org/html/bcp47
+    pub language_alias: String,
+
+    /// Title of the site. Defaults to none
+    ///
+    /// This will not fall back to how it's set for the default language.
+    pub title: Option<String>,
+    /// Description of the site. Defaults to None.
+    ///
+    /// This will not fall back to how it's set for the default language.
+    pub description: Option<String>,
+
+    /// Taxonomies available for a language
+    ///
+    /// This will not fall back to how it's set for the default language.
+    pub taxonomies: Vec<super::taxonomies::Taxonomy>,
+
+    /// Whether to generate a feed for a language
+    ///
+    /// If unset in a translation, it will fall back to how it's set for the default language.
+    /// Its default value for the primary language is `false`.
+    pub generate_feed: Option<bool>,
+    /// The number of articles to include in the feed for a language
+    ///
+    /// If unset in a translation, it will fall back to how it's set for the default language.
+    /// Its default value for the primary language is all.
+    ///
+    /// All has been represented as None since the beginning, hence the awkward Option<Option<_>>.
+    pub feed_limit: Option<Option<usize>>,
+
+    /// Whether to generate search index for a language
+    ///
+    /// If unset in a translation, it will fall back to how it's set for the default language.
+    /// Its default value for the default language is `false`.
+    pub build_search_index: Option<bool>,
+    /// The search config, telling what to include in the search index for a language
+    ///
+    /// If unset in a translation, it will fall back to how it's set for the default language.
+    /// If unset for the default language, it will be set to [Search::default].
+    pub search: Option<super::search::Search>,
+
+    /// All user parameters set in `[extra]`
+    ///
+    /// This supersedes `[translations]` from previous versions. Serde ensures that this is a Toml
+    /// table by attempting to convert it into a `HashMap<String, toml::Value>`. This would,
+    /// however, make us do `.get().unwrap().get().unwrap()` for retrieveing a nested value; but we
+    /// treat this as opaque data, and do not attempt to modify it.
+    ///
+    /// For localizations, this will be recursively merged with that of the default language.
+    pub extra: HashMap<String, Toml>,
 }
 
-pub type TranslateTerm = HashMap<String, String>;
+impl LocaleOptions {
+    /// Sets the default values when set for the default language.
+    ///
+    /// This had to be done here, because serde does not yet support #[serde(default)] for newtype
+    /// structs.
+    pub fn default_for_default_lang() -> Self {
+        LocaleOptions {
+            language_alias: String::new(),
+            title: None,
+            description: None,
+            taxonomies: Vec::new(),
+            generate_feed: Some(false),
+            feed_limit: Some(None),
+            build_search_index: Some(false),
+            search: Some(super::search::Search::default()),
+            extra: HashMap::new(),
+        }
+    }
+
+    pub fn default_for_additional_lang() -> Self {
+        LocaleOptions::default()
+    }
+}

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -16,7 +16,7 @@ pub struct LocaleOptions {
     /// multilingual sites might already be using language names that do not conform to the
     /// canonical [BCP 47] syntax, and this lets us keep links to them working currently.
     ///
-    /// If empty or not set, the `language_code` will be used.
+    /// If empty or not set, the language code will be used.
     ///
     /// [BCP 47]: https://tools.ietf.org/html/bcp47
     pub language_alias: String,
@@ -73,7 +73,7 @@ pub struct LocaleOptions {
 impl LocaleOptions {
     /// Sets the default values when set for the default language.
     ///
-    /// This had to be done here, because serde does not yet support #[serde(default)] for newtype
+    /// This had to be done here, because serde does not yet support `#[serde(default)]` for newtype
     /// structs.
     pub fn default_for_default_lang() -> Self {
         LocaleOptions {

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -35,6 +35,8 @@ pub enum Mode {
 ///
 /// It's a newtype struct wrapping [Config], where `0.default_language_options` contains the
 /// settings for `0.lang`.
+///
+/// [Config]: struct.Config.html
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct LocalizedConfig(pub Config);
@@ -43,6 +45,8 @@ pub struct LocalizedConfig(pub Config);
 ///
 /// It will be processed into a [LocalizedConfig] to create a transparent and backwards-compatible
 /// localization for templates.
+///
+/// [LocalizedConfig]: struct.LocalizedConfig.html
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -55,7 +59,11 @@ pub struct Config {
     /// The language that this config applies to
     ///
     /// This is done to make [LocalizedConfig] self-contained. For [Config], this is always equal
-    /// to `default_language`.
+    /// to [default_language].
+    ///
+    /// [Config]: struct.Config.html
+    /// [LocalizedConfig]: struct.LocalizedConfig.html
+    /// [default_language]: #structfield.default_language
     #[serde(skip_deserializing)]
     pub lang: LanguageIdentifier,
 
@@ -63,6 +71,9 @@ pub struct Config {
     ///
     /// MUST be a valid language, specified using the [BCP 47] syntax. To retain backwards
     /// compatibility with other language naming systems, the [language_alias] option was added.
+    ///
+    /// [BCP 47]: https://tools.ietf.org/html/bcp47
+    /// [language_alias]: struct.LocaleOptions.html#structfield.language_alias
     pub default_language: LanguageIdentifier,
     /// Site-wide defaults for langauge-specific settings
     ///
@@ -82,6 +93,8 @@ pub struct Config {
     /// are.
     ///
     /// Having an entry for the default language is treated as an error.
+    ///
+    /// [LocaleOptions]: struct.LocaleOptions.html
     pub languages: HashMap<LanguageIdentifier, languages::LocaleOptions>,
 
     /// Whether to highlight all code blocks found in markdown files. Defaults to false
@@ -304,6 +317,8 @@ impl Config {
     /// Should be called after merging with theme.
     ///
     /// How each field is handled during merging is described in [LocaleOptions]'s documentation.
+    ///
+    /// [LocaleOptions]: struct.LocaleOptions.html
     pub fn merge_languages_with_default(&mut self) -> Result<()> {
         let def_o = &self.default_language_options;
         for (_, opt) in self.languages.iter_mut() {

--- a/components/config/src/config/search.rs
+++ b/components/config/src/config/search.rs
@@ -1,5 +1,6 @@
 use serde_derive::{Deserialize, Serialize};
 
+/// Controls how search indexes are built
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Search {

--- a/components/config/src/config/slugify.rs
+++ b/components/config/src/config/slugify.rs
@@ -2,6 +2,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use utils::slugs::SlugifyStrategy;
 
+/// Controls how URLs are slugified
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Slugify {

--- a/components/config/src/config/taxonomies.rs
+++ b/components/config/src/config/taxonomies.rs
@@ -1,4 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
+use unic_langid::LanguageIdentifier;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
@@ -11,9 +12,12 @@ pub struct Taxonomy {
     pub paginate_path: Option<String>,
     /// Whether to generate a feed only for each taxonomy term, defaults to false
     pub feed: bool,
-    /// The language for that taxonomy, only used in multilingual sites.
-    /// Defaults to the config `default_language` if not set
-    pub lang: String,
+
+    // Only for convenience/backwards compatibility
+    #[serde(skip_deserializing)]
+    pub lang: LanguageIdentifier,
+    #[serde(skip_deserializing)]
+    pub language_alias: String,
 }
 
 impl Taxonomy {

--- a/components/config/src/config/taxonomies.rs
+++ b/components/config/src/config/taxonomies.rs
@@ -1,6 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 use unic_langid::LanguageIdentifier;
 
+/// A way of grouping pages
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Taxonomy {

--- a/components/config/src/highlighting.rs
+++ b/components/config/src/highlighting.rs
@@ -16,11 +16,13 @@ lazy_static! {
         from_binary(include_bytes!("../../../sublime/themes/all.themedump"));
 }
 
+/// Get a highlighter for a given ssyntax, and whether it was specified in [`extra_syntax_set`].
+///
+/// If no hightlighter was found, silently fall back to plain text.
+///
+/// [`extra_syntax_set`]: struct.Config.html#structfield.extra_syntax_set
 /// Returns the highlighter and whether it was found in the extra or not
-pub fn get_highlighter(
-    language: Option<&str>,
-    config: &Config
-) -> (HighlightLines<'static>, bool) {
+pub fn get_highlighter(language: Option<&str>, config: &Config) -> (HighlightLines<'static>, bool) {
     let theme = &THEME_SET.themes[&config.highlight_theme];
     let mut in_extra = false;
 

--- a/components/config/src/highlighting.rs
+++ b/components/config/src/highlighting.rs
@@ -17,11 +17,14 @@ lazy_static! {
 }
 
 /// Returns the highlighter and whether it was found in the extra or not
-pub fn get_highlighter<'a>(info: &str, config: &Config) -> (HighlightLines<'a>, bool) {
+pub fn get_highlighter(
+    language: Option<&str>,
+    config: &Config
+) -> (HighlightLines<'static>, bool) {
     let theme = &THEME_SET.themes[&config.highlight_theme];
     let mut in_extra = false;
 
-    if let Some(ref lang) = info.split(' ').next() {
+    if let Some(ref lang) = language {
         let syntax = SYNTAX_SET
             .find_syntax_by_token(lang)
             .or_else(|| {

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -2,7 +2,8 @@ mod config;
 pub mod highlighting;
 mod theme;
 pub use crate::config::{
-    languages::Language, link_checker::LinkChecker, slugify::Slugify, taxonomies::Taxonomy, Config,
+    languages::LocaleOptions, link_checker::LinkChecker, search::Search, slugify::Slugify,
+    taxonomies::Taxonomy, Config, LocalizedConfig,
 };
 
 use std::path::Path;

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -1,10 +1,12 @@
 mod config;
 pub mod highlighting;
 mod theme;
+
 pub use crate::config::{
     languages::LocaleOptions, link_checker::LinkChecker, search::Search, slugify::Slugify,
     taxonomies::Taxonomy, Config, LocalizedConfig,
 };
+pub use crate::theme::Theme;
 
 use std::path::Path;
 

--- a/components/config/src/theme.rs
+++ b/components/config/src/theme.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde_derive::{Deserialize, Serialize};
 use unic_langid::LanguageIdentifier;
 
-use crate::config::languages::*;
+use crate::config::languages::LocaleOptions;
 use errors::Result;
 use utils::fs::read_file_with_error;
 

--- a/components/config/src/theme.rs
+++ b/components/config/src/theme.rs
@@ -2,40 +2,55 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use serde_derive::{Deserialize, Serialize};
-use toml::Value as Toml;
+use unic_langid::LanguageIdentifier;
 
-use errors::{bail, Result};
+use crate::config::languages::*;
+use errors::Result;
 use utils::fs::read_file_with_error;
 
 /// Holds the data from a `theme.toml` file.
-/// There are other fields than `extra` in it but Zola
-/// itself doesn't care about them.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+///
+/// There are other fields, but Zola only cares about `[extra]` and `[languages]`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Theme {
-    /// All user params set in [extra] in the theme.toml
-    pub extra: HashMap<String, Toml>,
+    /// The primary/default language of the theme
+    ///
+    /// MUST be a valid language, specified using the [BCP 47] syntax. To retain backwards
+    /// compatibility with other language naming systems, the [language_alias] option was added.
+    ///
+    /// If not specified, [default_language_options] will be merged into
+    /// [config.default_language_options] regardless of [config.default_language].
+    pub default_language: Option<LanguageIdentifier>,
+    /// Theme-wide defaults for locale-specific options
+    ///
+    /// All values except those in `[extra]` are ignored.
+    ///
+    /// This is flattened when serializing/deserializing, i.e. its fields will appear as if they
+    /// were at the top level alongside base_url. These values are used for the default language,
+    /// and other languages will fall back to these values if they are not overridden in
+    /// `languages`
+    #[serde(flatten, default = "LocaleOptions::default_for_default_lang")]
+    pub default_language_options: LocaleOptions,
+
+    /// Language-specific options for translations of this site
+    ///
+    /// All values except those in `[extra]` are ignored.
+    ///
+    /// The key of the TOML table (represented as a HashMap in Rust) is a valid language code, and
+    /// its values can be used for overriding some of the site-wide settings.
+    ///
+    /// See [LocaleOptions] for what options can be specified here and what their default values
+    /// are.
+    ///
+    /// Having an entry for the default language is treated as an error.
+    pub languages: HashMap<LanguageIdentifier, LocaleOptions>,
 }
 
 impl Theme {
     /// Parses a TOML string to our Theme struct
     pub fn parse(content: &str) -> Result<Theme> {
-        let theme = match content.parse::<Toml>() {
-            Ok(t) => t,
-            Err(e) => bail!(e),
-        };
-
-        let mut extra = HashMap::new();
-        if let Some(theme_table) = theme.as_table() {
-            if let Some(ex) = theme_table.get("extra") {
-                if ex.is_table() {
-                    extra = ex.clone().try_into().unwrap();
-                }
-            }
-        } else {
-            bail!("Expected the `theme.toml` to be a TOML table")
-        }
-
-        Ok(Theme { extra })
+        toml::from_str::<Theme>(content).map_err(|e| e.into())
     }
 
     /// Parses a theme file from the given path
@@ -47,5 +62,15 @@ impl Theme {
              and does it have a `theme.toml` inside?",
         )?;
         Theme::parse(&content)
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Theme {
+            default_language: None,
+            default_language_options: LocaleOptions::default_for_default_lang(),
+            languages: HashMap::new(),
+        }
     }
 }

--- a/components/library/Cargo.toml
+++ b/components/library/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1"
 serde_derive = "1"
 regex = "1"
 lazy_static = "1"
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
 
 front_matter = { path = "../front_matter" }
 config = { path = "../config" }

--- a/components/library/src/content/file_info.rs
+++ b/components/library/src/content/file_info.rs
@@ -1,7 +1,15 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+
 use std::path::{Path, PathBuf};
 
-use config::Config;
-use errors::{bail, Result};
+lazy_static! {
+    // Based on https://regex101.com/r/H2n38Z/1/tests
+    // A regex parsing RFC3339 date followed by {_,-}, and some characters (name)
+    static ref RFC3339_DATE: Regex = Regex::new(
+        r"^(?P<datetime>(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)([01][0-9]|2[0-3]):([0-5][0-9])))?)(_|-)(?P<name>.+$)"
+    ).unwrap();
+}
 
 /// Takes a full path to a file and returns only the components after the first `content` directory
 /// Will not return the filename as last component
@@ -26,15 +34,48 @@ pub fn find_content_components<P: AsRef<Path>>(path: P) -> Vec<String> {
     components
 }
 
-/// Struct that contains all the information about the actual file
+/// Return a (name, maybe_lang) tuple if name has a possible language in it
+pub fn get_language<S: AsRef<str>>(name: S) -> (String, Option<String>) {
+    // Go with the assumption that no one is using '.' in filenames (regardless of whether the site
+    // is multilingual)
+    if !name.as_ref().contains('.') {
+        return (name.as_ref().to_string(), None);
+    }
+
+    let parts: Vec<String> = name.as_ref().splitn(2, '.').map(|s| s.to_string()).collect();
+    (parts[0].clone(), Some(parts[1].clone()))
+}
+
+/// Return a (name, date) tuple if name has a date in it
+///
+/// This only makes sense for pages, not sections.
+pub fn get_date<S: AsRef<str>>(name: S) -> (String, Option<String>) {
+    if let Some(ref caps) = RFC3339_DATE.captures(name.as_ref()) {
+        return (
+            caps.name("name").unwrap().as_str().to_string(),
+            Some(caps.name("datetime").unwrap().as_str().to_string()),
+        );
+    }
+    (name.as_ref().to_string(), None)
+}
+
+/// Strip `{date}{_,-}` prefix and `.{lang}` suffix from name
+pub fn clear_filename<S: AsRef<str>>(name: S) -> String {
+    let (name, _) = get_language(name);
+    let (name, _) = get_date(name);
+    name
+}
+
+/// Struct that contains all the information about the actual file and data extracted from its name
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct FileInfo {
     /// The full path to the .md file
     pub path: PathBuf,
-    /// The on-disk filename, will differ from the `name` when there is a language code in it
+    /// The on-disk filename, will differ from the `name` when there is a language code or date in it
     pub filename: String,
     /// The name of the .md file without the extension, always `_index` for sections
-    /// Doesn't contain the language if there was one in the filename
+    /// Doesn't contain the language if there was one in the filename.
+    /// Doesn't contain the date if it was specified in the filename.
     pub name: String,
     /// The .md path, starting from the content directory, with `/` slashes
     pub relative: String,
@@ -49,6 +90,12 @@ pub struct FileInfo {
     /// This is `parent` + `name`, used to find content referring to the same content but in
     /// various languages.
     pub canonical: PathBuf,
+    /// The `lang` part of the {name}.{lang}.md naming scheme. There is no guarantee that this
+    /// language is enabled for the site.
+    pub maybe_lang: Option<String>,
+    /// The `date` part of the {date}{_,-}{name}.md naming scheme. Guranteed to be a RFC3339
+    /// date in valid form
+    pub date: Option<String>,
 }
 
 impl FileInfo {
@@ -56,19 +103,26 @@ impl FileInfo {
         let file_path = path.to_path_buf();
         let mut parent = file_path.parent().expect("Get parent of page").to_path_buf();
         let name = path.file_stem().unwrap().to_string_lossy().to_string();
-        let canonical = parent.join(&name);
         let mut components =
             find_content_components(&file_path.strip_prefix(base_path).unwrap_or(&file_path));
+        assert!(!name.is_empty());
         let relative = if !components.is_empty() {
             format!("{}/{}.md", components.join("/"), name)
         } else {
             format!("{}.md", name)
         };
+        let (name, maybe_lang) = get_language(name);
+        let (name, mut date) = get_date(&name);
+        let canonical = parent.join(&name);
 
         // If we have a folder with an asset, don't consider it as a component
-        // Splitting on `.` as we might have a language so it isn't *only* index but also index.fr
-        // etc
-        if !components.is_empty() && name.split('.').collect::<Vec<_>>()[0] == "index" {
+        // By this point, any language and date, as well as extension has been stripped from name,
+        // so checking it is easy.
+        if !components.is_empty() && name == "index" {
+            if date.is_none() {
+                date = get_date(parent.file_name().unwrap().to_str().unwrap()).1;
+            }
+
             components.pop();
             // also set parent_path to grandparent instead
             parent = parent.parent().unwrap().to_path_buf();
@@ -84,6 +138,8 @@ impl FileInfo {
             name,
             components,
             relative,
+            maybe_lang,
+            date,
         }
     }
 
@@ -93,12 +149,15 @@ impl FileInfo {
         let name = path.file_stem().unwrap().to_string_lossy().to_string();
         let components =
             find_content_components(&file_path.strip_prefix(base_path).unwrap_or(&file_path));
+        assert!(!name.is_empty());
         let relative = if !components.is_empty() {
             format!("{}/{}.md", components.join("/"), name)
         } else {
             format!("{}.md", name)
         };
         let grand_parent = parent.parent().map(|p| p.to_path_buf());
+
+        let (name, maybe_lang) = get_language(name);
 
         FileInfo {
             filename: file_path.file_name().unwrap().to_string_lossy().to_string(),
@@ -109,37 +168,9 @@ impl FileInfo {
             name,
             components,
             relative,
+            maybe_lang,
+            date: None,
         }
-    }
-
-    /// Look for a language in the filename.
-    /// If a language has been found, update the name of the file in this struct to
-    /// remove it and return the language code
-    pub fn find_language(&mut self, config: &Config) -> Result<String> {
-        // No languages? Nothing to do
-        if !config.is_multilingual() {
-            return Ok(config.default_language.clone());
-        }
-
-        if !self.name.contains('.') {
-            return Ok(config.default_language.clone());
-        }
-
-        // Go with the assumption that no one is using `.` in filenames when using i18n
-        // We can document that
-        let mut parts: Vec<String> = self.name.splitn(2, '.').map(|s| s.to_string()).collect();
-
-        // The language code is not present in the config: typo or the user forgot to add it to the
-        // config
-        if !config.languages_codes().contains(&parts[1].as_ref()) {
-            bail!("File {:?} has a language code of {} which isn't present in the config.toml `languages`", self.path, parts[1]);
-        }
-
-        self.name = parts.swap_remove(0);
-        self.canonical = self.path.parent().expect("Get parent of page path").join(&self.name);
-        let lang = parts.swap_remove(0);
-
-        Ok(lang)
     }
 }
 
@@ -147,9 +178,7 @@ impl FileInfo {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use config::{Config, Language};
-
-    use super::{find_content_components, FileInfo};
+    use super::*;
 
     #[test]
     fn can_find_content_components() {
@@ -177,67 +206,94 @@ mod tests {
     }
 
     #[test]
-    fn can_find_valid_language_in_page() {
-        let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
-        let mut file = FileInfo::new_page(
+    fn can_get_language_in_page() {
+        let file = FileInfo::new_page(
             &Path::new("/home/vincent/code/site/content/posts/tutorials/python.fr.md"),
             &PathBuf::new(),
         );
-        let res = file.find_language(&config);
-        assert!(res.is_ok());
-        assert_eq!(res.unwrap(), "fr");
+        assert_eq!(file.maybe_lang.unwrap(), "fr");
+        assert_eq!(file.name, "python");
     }
 
     #[test]
-    fn can_find_valid_language_in_page_with_assets() {
-        let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
-        let mut file = FileInfo::new_page(
+    fn can_get_language_in_page_with_assets() {
+        let file = FileInfo::new_page(
             &Path::new("/home/vincent/code/site/content/posts/tutorials/python/index.fr.md"),
             &PathBuf::new(),
         );
         assert_eq!(file.components, ["posts".to_string(), "tutorials".to_string()]);
-        let res = file.find_language(&config);
-        assert!(res.is_ok());
-        assert_eq!(res.unwrap(), "fr");
+        assert_eq!(file.maybe_lang.unwrap(), "fr");
+        assert_eq!(file.name, "index");
     }
 
     #[test]
-    fn do_nothing_on_unknown_language_in_page_with_i18n_off() {
-        let config = Config::default();
-        let mut file = FileInfo::new_page(
-            &Path::new("/home/vincent/code/site/content/posts/tutorials/python.fr.md"),
+    fn doesnt_fail_on_no_language_in_page() {
+        let file = FileInfo::new_page(
+            &Path::new("/home/vincent/code/site/content/posts/tutorials/python/index.md"),
             &PathBuf::new(),
         );
-        let res = file.find_language(&config);
-        assert!(res.is_ok());
-        assert_eq!(res.unwrap(), config.default_language);
+        assert!(file.maybe_lang.is_none());
+        assert_eq!(file.name, "index");
     }
 
     #[test]
-    fn errors_on_unknown_language_in_page_with_i18n_on() {
-        let mut config = Config::default();
-        config.languages.push(Language { code: String::from("it"), feed: false, search: false });
-        let mut file = FileInfo::new_page(
-            &Path::new("/home/vincent/code/site/content/posts/tutorials/python.fr.md"),
-            &PathBuf::new(),
+    fn doesnt_fail_on_no_language_in_page_with_assets() {
+        let file = FileInfo::new_page(
+            &Path::new("/home/vincent/code/content/site/content/posts/tutorials/python/index.md"),
+            &PathBuf::from("/home/vincent/code/content/site"),
         );
-        let res = file.find_language(&config);
-        assert!(res.is_err());
+        assert_eq!(file.components, ["posts".to_string(), "tutorials".to_string()]);
+        assert!(file.maybe_lang.is_none());
+        assert_eq!(file.name, "index");
     }
 
     #[test]
-    fn can_find_valid_language_in_section() {
-        let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
-        let mut file = FileInfo::new_section(
+    fn can_get_language_in_section() {
+        let file = FileInfo::new_section(
             &Path::new("/home/vincent/code/site/content/posts/tutorials/_index.fr.md"),
             &PathBuf::new(),
         );
-        let res = file.find_language(&config);
-        assert!(res.is_ok());
-        assert_eq!(res.unwrap(), "fr");
+        assert_eq!(file.maybe_lang.unwrap(), "fr");
+        assert_eq!(file.name, "_index");
+    }
+
+    #[test]
+    fn can_get_short_date_in_page() {
+        let file = FileInfo::new_page(&Path::new("2018-10-08_hello.md"), &PathBuf::new());
+        assert_eq!(file.date, Some("2018-10-08".to_string()));
+        assert_eq!(file.name, "hello");
+    }
+
+    #[test]
+    fn can_get_full_rfc3339_date_in_page() {
+        let file = FileInfo::new_page(&Path::new("2018-10-02T15:00:00Z-hello.md"), &PathBuf::new());
+        assert_eq!(file.date, Some("2018-10-02T15:00:00Z".to_string()));
+        assert_eq!(file.name, "hello");
+    }
+
+    #[test]
+    fn cannot_get_date_in_section() {
+        let file =
+            FileInfo::new_section(&Path::new("2018-10-02T15:00:00Z_index.md"), &PathBuf::new());
+        assert!(file.date.is_none());
+        assert_eq!(file.name, "2018-10-02T15:00:00Z_index");
+    }
+
+    #[test]
+    fn can_get_lang_and_short_date_in_page() {
+        let file = FileInfo::new_page(&Path::new("2018-10-08-hello.fr.md"), &PathBuf::new());
+        assert_eq!(file.name, "hello");
+        assert_eq!(file.maybe_lang, Some("fr".to_string()));
+        assert_eq!(file.date, Some("2018-10-08".to_string()));
+    }
+
+    #[test]
+    fn can_get_lang_and_full_rfc3339_date_in_page() {
+        let file =
+            FileInfo::new_page(&Path::new("2018-10-02T15:00:00Z-hello.fr.md"), &PathBuf::new());
+        assert_eq!(file.name, "hello");
+        assert_eq!(file.maybe_lang, Some("fr".to_string()));
+        assert_eq!(file.date, Some("2018-10-02T15:00:00Z".to_string()));
     }
 
     /// Regression test for https://github.com/getzola/zola/issues/854
@@ -255,15 +311,12 @@ mod tests {
 
     /// Regression test for https://github.com/getzola/zola/issues/854
     #[test]
-    fn correct_canonical_after_find_language() {
-        let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
-        let mut file = FileInfo::new_page(
+    fn correct_canonical_with_language() {
+        let file = FileInfo::new_page(
             &Path::new("/home/vincent/code/site/content/posts/tutorials/python/index.fr.md"),
             &PathBuf::new(),
         );
-        let res = file.find_language(&config);
-        assert!(res.is_ok());
+        assert_eq!(file.maybe_lang.unwrap(), "fr");
         assert_eq!(
             file.canonical,
             Path::new("/home/vincent/code/site/content/posts/tutorials/python/index")

--- a/components/library/src/content/file_info.rs
+++ b/components/library/src/content/file_info.rs
@@ -34,7 +34,7 @@ pub fn find_content_components<P: AsRef<Path>>(path: P) -> Vec<String> {
     components
 }
 
-/// Return a (name, maybe_lang) tuple if name has a possible language in it
+/// Return a `(name, maybe_lang)` tuple if name has a possible language in it
 pub fn get_language<S: AsRef<str>>(name: S) -> (String, Option<String>) {
     // Go with the assumption that no one is using '.' in filenames (regardless of whether the site
     // is multilingual)
@@ -42,11 +42,11 @@ pub fn get_language<S: AsRef<str>>(name: S) -> (String, Option<String>) {
         return (name.as_ref().to_string(), None);
     }
 
-    let parts: Vec<String> = name.as_ref().splitn(2, '.').map(|s| s.to_string()).collect();
+    let parts: Vec<String> = name.as_ref().splitn(2, '.').map(ToString::to_string).collect();
     (parts[0].clone(), Some(parts[1].clone()))
 }
 
-/// Return a (name, date) tuple if name has a date in it
+/// Return a `(name, date)` tuple if name has a date in it
 ///
 /// This only makes sense for pages, not sections.
 pub fn get_date<S: AsRef<str>>(name: S) -> (String, Option<String>) {
@@ -106,10 +106,10 @@ impl FileInfo {
         let mut components =
             find_content_components(&file_path.strip_prefix(base_path).unwrap_or(&file_path));
         assert!(!name.is_empty());
-        let relative = if !components.is_empty() {
-            format!("{}/{}.md", components.join("/"), name)
-        } else {
+        let relative = if components.is_empty() {
             format!("{}.md", name)
+        } else {
+            format!("{}/{}.md", components.join("/"), name)
         };
         let (name, maybe_lang) = get_language(name);
         let (name, mut date) = get_date(&name);
@@ -150,12 +150,12 @@ impl FileInfo {
         let components =
             find_content_components(&file_path.strip_prefix(base_path).unwrap_or(&file_path));
         assert!(!name.is_empty());
-        let relative = if !components.is_empty() {
-            format!("{}/{}.md", components.join("/"), name)
-        } else {
+        let relative = if components.is_empty() {
             format!("{}.md", name)
+        } else {
+            format!("{}/{}.md", components.join("/"), name)
         };
-        let grand_parent = parent.parent().map(|p| p.to_path_buf());
+        let grand_parent = parent.parent().map(Path::to_path_buf);
 
         let (name, maybe_lang) = get_language(name);
 

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -124,7 +124,7 @@ impl Page {
                     .get_language_identifier(&l)
                     .ok_or_else(||
                         format!("File `{}` has a language of `{}` which isn't present in config.toml. Not that if a `language_alias` was specified, you must use that.\nHint: Possible values are {:?}.", file_path.display(), l, config.language_aliases())
-                        )?;
+                        )?.clone();
             }
         } else {
             page.lang = config.default_language.clone();
@@ -296,7 +296,7 @@ impl Page {
         context.insert("lang", &self.lang);
         context.insert("language_alias", &self.language_alias);
 
-        render_template(&tpl_name, tera, context, &config.theme).map_err(|e| {
+        render_template(&tpl_name, tera, &context, &config.theme).map_err(|e| {
             Error::chain(format!("Failed to render page '{}'", self.file.path.display()), e)
         })
     }

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -104,7 +104,7 @@ impl Page {
         let (meta, content) = split_page_content(file_path, content)?;
         let mut page = Page::new(file_path, meta, base_path);
 
-        if let Some(ref l) = page.file.maybe_lang {
+        if let Some(ref l) = page.file.lang {
             if !config.is_multilingual() {
                 // TODO: add test
                 bail!(
@@ -155,7 +155,7 @@ impl Page {
             } else if page.file.name == "index" {
                 if let Some(parent) = page.file.path.parent() {
                     slugify_paths(
-                        &super::file_info::clear_filename(
+                        &super::file_info::strip_filename_info(
                             parent.file_name().unwrap().to_str().unwrap(),
                         ),
                         config.slugify.paths,

--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -111,7 +111,7 @@ impl Section {
                     .get_language_identifier(&l)
                     .ok_or_else(||
                         format!("File `{}` has a language of `{}` which isn't present in config.toml. Not that if a `language_alias` was specified, you must use that.\nHint: Possible values are {:?}.", file_path.display(), l, config.language_aliases())
-                        )?;
+                        )?.clone();
             }
         } else {
             section.lang = config.default_language.clone();
@@ -242,7 +242,7 @@ impl Section {
         context.insert("lang", &self.lang);
         context.insert("language_alias", &self.language_alias);
 
-        render_template(tpl_name, tera, context, &config.theme).map_err(|e| {
+        render_template(tpl_name, tera, &context, &config.theme).map_err(|e| {
             Error::chain(format!("Failed to render section '{}'", self.file.path.display()), e)
         })
     }

--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -91,7 +91,7 @@ impl Section {
         let (meta, content) = split_section_content(file_path, content)?;
         let mut section = Section::new(file_path, meta, base_path);
 
-        if let Some(ref l) = section.file.maybe_lang {
+        if let Some(ref l) = section.file.lang {
             if !config.is_multilingual() {
                 // TODO: add test
                 bail!(

--- a/components/library/src/content/ser.rs
+++ b/components/library/src/content/ser.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use serde_derive::Serialize;
 use tera::{Map, Value};
+use unic_langid::LanguageIdentifier;
 
 use crate::content::{Page, Section};
 use crate::library::Library;
@@ -11,7 +12,8 @@ use rendering::Heading;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct TranslatedContent<'a> {
-    lang: &'a str,
+    lang: &'a LanguageIdentifier,
+    language_alias: &'a str,
     permalink: &'a str,
     title: &'a Option<String>,
     /// The path to the markdown file; useful for retrieving the full page through
@@ -28,6 +30,7 @@ impl<'a> TranslatedContent<'a> {
             let other = library.get_section_by_key(*key);
             translations.push(TranslatedContent {
                 lang: &other.lang,
+                language_alias: &other.language_alias,
                 permalink: &other.permalink,
                 title: &other.meta.title,
                 path: &other.file.path,
@@ -44,6 +47,7 @@ impl<'a> TranslatedContent<'a> {
             let other = library.get_page_by_key(*key);
             translations.push(TranslatedContent {
                 lang: &other.lang,
+                language_alias: &other.language_alias,
                 permalink: &other.permalink,
                 title: &other.meta.title,
                 path: &other.file.path,
@@ -78,7 +82,8 @@ pub struct SerializingPage<'a> {
     reading_time: Option<usize>,
     assets: &'a [String],
     draft: bool,
-    lang: &'a str,
+    lang: &'a LanguageIdentifier,
+    language_alias: &'a str,
     lighter: Option<Box<SerializingPage<'a>>>,
     heavier: Option<Box<SerializingPage<'a>>>,
     earlier: Option<Box<SerializingPage<'a>>>,
@@ -142,6 +147,7 @@ impl<'a> SerializingPage<'a> {
             assets: &page.serialized_assets,
             draft: page.is_draft(),
             lang: &page.lang,
+            language_alias: &page.language_alias,
             lighter,
             heavier,
             earlier,
@@ -204,6 +210,7 @@ impl<'a> SerializingPage<'a> {
             assets: &page.serialized_assets,
             draft: page.is_draft(),
             lang: &page.lang,
+            language_alias: &page.language_alias,
             lighter: None,
             heavier: None,
             earlier: None,
@@ -227,7 +234,8 @@ pub struct SerializingSection<'a> {
     toc: &'a [Heading],
     word_count: Option<usize>,
     reading_time: Option<usize>,
-    lang: &'a str,
+    lang: &'a LanguageIdentifier,
+    language_alias: &'a str,
     assets: &'a [String],
     pages: Vec<SerializingPage<'a>>,
     subsections: Vec<&'a str>,
@@ -269,6 +277,7 @@ impl<'a> SerializingSection<'a> {
             reading_time: section.reading_time,
             assets: &section.serialized_assets,
             lang: &section.lang,
+            language_alias: &section.language_alias,
             pages,
             subsections,
             translations,
@@ -306,6 +315,7 @@ impl<'a> SerializingSection<'a> {
             reading_time: section.reading_time,
             assets: &section.serialized_assets,
             lang: &section.lang,
+            language_alias: &section.language_alias,
             pages: vec![],
             subsections,
             translations,

--- a/components/library/src/pagination/mod.rs
+++ b/components/library/src/pagination/mod.rs
@@ -135,7 +135,7 @@ impl<'a> Paginator<'a> {
         }
 
         for key in self.all_pages.to_mut().iter_mut() {
-            let page = library.get_page_by_key(key.clone());
+            let page = library.get_page_by_key(*key);
             current_page.push(page.to_serialized_basic(library));
 
             if current_page.len() == self.paginate_by {
@@ -249,7 +249,7 @@ impl<'a> Paginator<'a> {
         context.insert("current_path", &pager.path);
         context.insert("paginator", &self.build_paginator_context(pager));
 
-        render_template(&self.template, tera, context, &config.theme)
+        render_template(&self.template, tera, &context, &config.theme)
             .map_err(|e| Error::chain(format!("Failed to render pager {}", pager.index), e))
     }
 }

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -54,7 +54,7 @@ impl TaxonomyItem {
         name: &str,
         taxonomy: &TaxonomyConfig,
         config: &Config,
-        keys: Vec<DefaultKey>,
+        keys: &[DefaultKey],
         library: &Library,
     ) -> Self {
         // Taxonomy are almost always used for blogs so we filter by dates
@@ -135,7 +135,7 @@ impl Taxonomy {
     ) -> Taxonomy {
         let mut sorted_items = vec![];
         for (name, pages) in items {
-            sorted_items.push(TaxonomyItem::new(&name, &kind, config, pages, library));
+            sorted_items.push(TaxonomyItem::new(&name, &kind, config, &pages, library));
         }
         //sorted_items.sort_by(|a, b| a.name.cmp(&b.name));
         sorted_items.sort_by(|a, b| match a.slug.cmp(&b.slug) {
@@ -186,7 +186,7 @@ impl Taxonomy {
         );
         context.insert("current_path", &format!("/{}/{}/", self.kind.name, item.slug));
 
-        render_template(&format!("{}/single.html", self.kind.name), tera, context, &config.theme)
+        render_template(&format!("{}/single.html", self.kind.name), tera, &context, &config.theme)
             .map_err(|e| {
                 Error::chain(format!("Failed to render single term {} page.", self.kind.name), e)
             })
@@ -210,7 +210,7 @@ impl Taxonomy {
         assert!(!self.kind.name.is_empty());
         context.insert("current_path", &format!("/{}/", self.kind.name));
 
-        render_template(&format!("{}/list.html", self.kind.name), tera, context, &config.theme)
+        render_template(&format!("{}/list.html", self.kind.name), tera, &context, &config.theme)
             .map_err(|e| {
                 Error::chain(format!("Failed to render a list of {} page.", self.kind.name), e)
             })

--- a/components/rendering/Cargo.toml
+++ b/components/rendering/Cargo.toml
@@ -15,6 +15,7 @@ pest = "2"
 pest_derive = "2"
 regex = "1"
 lazy_static = "1"
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
 
 errors = { path = "../errors" }
 front_matter = { path = "../front_matter" }

--- a/components/rendering/benches/all.rs
+++ b/components/rendering/benches/all.rs
@@ -7,6 +7,9 @@ use config::Config;
 use front_matter::InsertAnchor;
 use rendering::{render_content, render_shortcodes, RenderContext};
 use tera::Tera;
+use unic_langid::{langid, LanguageIdentifier};
+
+const EN: &LanguageIdentifier = &langid!("en");
 
 static CONTENT: &'static str = r#"
 # Modus cognitius profanam ne duae virtutis mundi
@@ -86,7 +89,7 @@ fn bench_render_content_with_highlighting(b: &mut test::Bencher) {
     tera.add_raw_template("shortcodes/youtube.html", "{{id}}").unwrap();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     b.iter(|| render_content(CONTENT, &context).unwrap());
 }
 
@@ -97,7 +100,7 @@ fn bench_render_content_without_highlighting(b: &mut test::Bencher) {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = false;
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     b.iter(|| render_content(CONTENT, &context).unwrap());
 }
 
@@ -108,7 +111,7 @@ fn bench_render_content_no_shortcode(b: &mut test::Bencher) {
     let mut config = Config::default();
     config.highlight_code = false;
     let permalinks_ctx = HashMap::new();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
     b.iter(|| render_content(&content2, &context).unwrap());
 }
@@ -119,7 +122,7 @@ fn bench_render_shortcodes_one_present(b: &mut test::Bencher) {
     tera.add_raw_template("shortcodes/youtube.html", "{{id}}").unwrap();
     let config = Config::default();
     let permalinks_ctx = HashMap::new();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
     b.iter(|| render_shortcodes(CONTENT, &context));
 }

--- a/components/rendering/src/context.rs
+++ b/components/rendering/src/context.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
+use tera::{Context, Tera};
+use unic_langid::LanguageIdentifier;
+
 use config::Config;
 use front_matter::InsertAnchor;
-use tera::{Context, Tera};
 
 /// All the information from the zola site that is needed to render HTML from markdown
 #[derive(Debug)]
@@ -13,6 +15,7 @@ pub struct RenderContext<'a> {
     pub current_page_permalink: &'a str,
     pub permalinks: &'a HashMap<String, String>,
     pub insert_anchor: InsertAnchor,
+    pub lang: &'a LanguageIdentifier,
 }
 
 impl<'a> RenderContext<'a> {
@@ -22,9 +25,10 @@ impl<'a> RenderContext<'a> {
         current_page_permalink: &'a str,
         permalinks: &'a HashMap<String, String>,
         insert_anchor: InsertAnchor,
+        lang: &'a LanguageIdentifier,
     ) -> RenderContext<'a> {
         let mut tera_context = Context::new();
-        tera_context.insert("config", config);
+        tera_context.insert("config", &config.get_localized(lang).expect("`lang` in config"));
         RenderContext {
             tera,
             tera_context,
@@ -32,6 +36,7 @@ impl<'a> RenderContext<'a> {
             permalinks,
             insert_anchor,
             config,
+            lang,
         }
     }
 }

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -330,7 +330,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                 let anchor_link = utils::templates::render_template(
                     &ANCHOR_LINK_TEMPLATE,
                     context.tera,
-                    c,
+                    &c,
                     &None,
                 )
                 .map_err(|e| Error::chain("Failed to render anchor link template", e))?;

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -1,14 +1,11 @@
 use lazy_static::lazy_static;
 use pulldown_cmark as cmark;
 use regex::Regex;
-use syntect::easy::HighlightLines;
-use syntect::html::{
-    start_highlighted_html_snippet, styled_line_to_highlighted_html, IncludeBackground,
-};
+use syntect::html::{start_highlighted_html_snippet, IncludeBackground};
 
 use crate::context::RenderContext;
 use crate::table_of_contents::{make_table_of_contents, Heading};
-use config::highlighting::{get_highlighter, SYNTAX_SET, THEME_SET};
+use config::highlighting::THEME_SET;
 use errors::{Error, Result};
 use front_matter::InsertAnchor;
 use utils::site::resolve_internal_link;
@@ -17,6 +14,10 @@ use utils::vec::InsertMany;
 
 use self::cmark::{Event, LinkType, Options, Parser, Tag};
 use pulldown_cmark::CodeBlockKind;
+
+mod codeblock;
+mod fence;
+use self::codeblock::CodeBlock;
 
 const CONTINUE_READING: &str = "<span id=\"continue-reading\"></span>";
 const ANCHOR_LINK_TEMPLATE: &str = "anchor-link.html";
@@ -172,8 +173,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
     // Set while parsing
     let mut error = None;
 
-    let mut background = IncludeBackground::Yes;
-    let mut highlighter: Option<(HighlightLines, bool)> = None;
+    let mut highlighter: Option<CodeBlock> = None;
 
     let mut inserted_anchors: Vec<String> = vec![];
     let mut headings: Vec<Heading> = vec![];
@@ -192,26 +192,14 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
             .map(|event| {
                 match event {
                     Event::Text(text) => {
-                        // if we are in the middle of a code block
-                        if let Some((ref mut highlighter, in_extra)) = highlighter {
-                            let highlighted = if in_extra {
-                                if let Some(ref extra) = context.config.extra_syntax_set {
-                                    highlighter.highlight(&text, &extra)
-                                } else {
-                                    unreachable!(
-                                        "Got a highlighter from extra syntaxes but no extra?"
-                                    );
-                                }
-                            } else {
-                                highlighter.highlight(&text, &SYNTAX_SET)
-                            };
-                            //let highlighted = &highlighter.highlight(&text, ss);
-                            let html = styled_line_to_highlighted_html(&highlighted, background);
-                            return Event::Html(html.into());
+                        // if we are in the middle of a highlighted code block
+                        if let Some(ref mut code_block) = highlighter {
+                            let html = code_block.highlight(&text);
+                            Event::Html(html.into())
+                        } else {
+                            // Business as usual
+                            Event::Text(text)
                         }
-
-                        // Business as usual
-                        Event::Text(text)
                     }
                     Event::Start(Tag::CodeBlock(ref kind)) => {
                         if !context.config.highlight_code {
@@ -221,16 +209,21 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                         let theme = &THEME_SET.themes[&context.config.highlight_theme];
                         match kind {
                             CodeBlockKind::Indented => (),
-                            CodeBlockKind::Fenced(info) => {
-                                highlighter = Some(get_highlighter(info, &context.config));
+                            CodeBlockKind::Fenced(fence_info) => {
+                                // This selects the background color the same way that
+                                // start_coloured_html_snippet does
+                                let color = theme
+                                    .settings
+                                    .background
+                                    .unwrap_or(::syntect::highlighting::Color::WHITE);
+
+                                highlighter = Some(CodeBlock::new(
+                                    fence_info,
+                                    &context.config,
+                                    IncludeBackground::IfDifferent(color),
+                                ));
                             }
                         };
-                        // This selects the background color the same way that start_coloured_html_snippet does
-                        let color = theme
-                            .settings
-                            .background
-                            .unwrap_or(::syntect::highlighting::Color::WHITE);
-                        background = IncludeBackground::IfDifferent(color);
                         let snippet = start_highlighted_html_snippet(theme);
                         let mut html = snippet.0;
                         html.push_str("<code>");

--- a/components/rendering/src/markdown/codeblock.rs
+++ b/components/rendering/src/markdown/codeblock.rs
@@ -1,0 +1,196 @@
+use syntect::html::{IncludeBackground, styled_line_to_highlighted_html};
+use syntect::easy::HighlightLines;
+use syntect::parsing::SyntaxSet;
+use syntect::highlighting::{Color, Theme, Style};
+use config::Config;
+use config::highlighting::{get_highlighter, SYNTAX_SET, THEME_SET};
+use std::cmp::min;
+use std::collections::HashSet;
+
+use super::fence::{FenceSettings, Range};
+
+pub struct CodeBlock<'config> {
+    highlighter: HighlightLines<'static>,
+    extra_syntax_set: Option<&'config SyntaxSet>,
+    background: IncludeBackground,
+    theme: &'static Theme,
+
+    /// List of ranges of lines to highlight.
+    highlight_lines: Vec<Range>,
+    /// The number of lines in the code block being processed.
+    num_lines: usize,
+}
+
+impl<'config> CodeBlock<'config> {
+    pub fn new(
+        fence_info: &str,
+        config: &'config Config,
+        background: IncludeBackground,
+    ) -> Self {
+        let fence_info = FenceSettings::new(fence_info);
+        let theme = &THEME_SET.themes[&config.highlight_theme];
+        let (highlighter, in_extra) = get_highlighter(fence_info.language, config);
+        Self {
+            highlighter,
+            extra_syntax_set: match in_extra {
+                true => config.extra_syntax_set.as_ref(),
+                false => None,
+            },
+            background,
+            theme,
+
+            highlight_lines: fence_info.highlight_lines,
+            num_lines: 0,
+        }
+    }
+
+    pub fn highlight(&mut self, text: &str) -> String {
+        let highlighted = self.highlighter.highlight(
+            text,
+            self.extra_syntax_set.unwrap_or(&SYNTAX_SET),
+        );
+        let line_boundaries = self.find_line_boundaries(&highlighted);
+
+        // First we make sure that `highlighted` is split at every line
+        // boundary. The `styled_line_to_highlighted_html` function will
+        // merge split items with identical styles, so this is not a
+        // problem.
+        //
+        // Note that this invalidates the values in `line_boundaries`.
+        // The `perform_split` function takes it by value to ensure that
+        // we don't use it later.
+        let mut highlighted = perform_split(&highlighted, line_boundaries);
+
+        let hl_background = self.theme.settings.line_highlight
+                .unwrap_or(Color { r: 255, g: 255, b: 0, a: 0 });
+
+
+        let hl_lines = self.get_highlighted_lines();
+        color_highlighted_lines(&mut highlighted, &hl_lines, hl_background);
+
+        styled_line_to_highlighted_html(&highlighted, self.background)
+    }
+
+    fn find_line_boundaries(&mut self, styled: &[(Style, &str)]) -> Vec<StyledIdx> {
+        let mut boundaries = Vec::new();
+        for (vec_idx, (_style, s)) in styled.iter().enumerate() {
+            for (str_idx, character) in s.char_indices() {
+                if character == '\n' {
+                    boundaries.push(StyledIdx {
+                        vec_idx,
+                        str_idx,
+                    });
+                }
+            }
+        }
+        self.num_lines = boundaries.len() + 1;
+        boundaries
+    }
+
+    fn get_highlighted_lines(&self) -> HashSet<usize> {
+        let mut lines = HashSet::new();
+        for range in &self.highlight_lines {
+            for line in range.from ..= min(range.to, self.num_lines) {
+                // Ranges are one-indexed
+                lines.insert(line.saturating_sub(1));
+            }
+        }
+        lines
+    }
+}
+
+/// This is an index of a character in a `&[(Style, &'b str)]`. The `vec_idx` is the
+/// index in the slice, and `str_idx` is the byte index of the character in the
+/// corresponding string slice.
+///
+/// The `Ord` impl on this type sorts lexiographically on `vec_idx`, and then `str_idx`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct StyledIdx {
+    vec_idx: usize,
+    str_idx: usize,
+}
+
+/// This is a utility used by `perform_split`. If the `vec_idx` in the `StyledIdx` is
+/// equal to the provided value, return the `str_idx`, otherwise return `None`.
+fn get_str_idx_if_vec_idx_is(idx: Option<&StyledIdx>, vec_idx: usize) -> Option<usize> {
+    match idx {
+        Some(idx) if idx.vec_idx == vec_idx => Some(idx.str_idx),
+        _ => None,
+    }
+}
+
+/// This function assumes that `line_boundaries` is sorted according to the `Ord` impl on
+/// the `StyledIdx` type.
+fn perform_split<'b>(
+    split: &[(Style, &'b str)],
+    line_boundaries: Vec<StyledIdx>
+) -> Vec<(Style, &'b str)> {
+    let mut result = Vec::new();
+
+    let mut idxs_iter = line_boundaries.into_iter().peekable();
+
+    for (split_idx, item) in split.iter().enumerate() {
+        let mut last_split = 0;
+
+        // Since `line_boundaries` is sorted, we know that any remaining indexes in
+        // `idxs_iter` have `vec_idx >= split_idx`, and that if there are any with
+        // `vec_idx == split_idx`, they will be first.
+        //
+        // Using the `get_str_idx_if_vec_idx_is` utility, this loop will keep consuming
+        // indexes from `idxs_iter` as long as `vec_idx == split_idx` holds. Once
+        // `vec_idx` becomes larger than `split_idx`, the loop will finish without
+        // consuming that index.
+        //
+        // If `idxs_iter` is empty, or there are no indexes with `vec_idx == split_idx`,
+        // the loop does nothing.
+        while let Some(str_idx) = get_str_idx_if_vec_idx_is(idxs_iter.peek(), split_idx) {
+            // Consume the value we just peeked.
+            idxs_iter.next();
+
+            // This consumes the index to split at. We add one to include the newline
+            // together with its own line, rather than as the first character in the next
+            // line.
+            let split_at = min(str_idx + 1, item.1.len());
+
+            // This will fail if `line_boundaries` is not sorted.
+            debug_assert!(split_at >= last_split);
+
+            // Skip splitting if the string slice would be empty.
+            if last_split != split_at {
+                result.push((item.0, &item.1[last_split..split_at]));
+                last_split = split_at;
+            }
+        }
+
+        // Now append the remainder. If the current item was not split, this will
+        // append the entire item.
+        if last_split != item.1.len() {
+            result.push((item.0, &item.1[last_split..]));
+        }
+    }
+
+    result
+}
+
+fn color_highlighted_lines(
+    data: &mut [(Style, &str)],
+    lines: &HashSet<usize>,
+    background: Color,
+) {
+    if lines.is_empty() {
+        return;
+    }
+
+    let mut current_line = 0;
+
+    for item in data {
+        if lines.contains(&current_line) {
+            item.0.background = background;
+        }
+
+        // We split the lines such that every newline is at the end of an item.
+        if item.1.ends_with('\n') {
+            current_line += 1;
+        }
+    }
+}

--- a/components/rendering/src/markdown/fence.rs
+++ b/components/rendering/src/markdown/fence.rs
@@ -1,0 +1,102 @@
+#[derive(Copy, Clone, Debug)]
+pub struct Range {
+    pub from: usize,
+    pub to: usize,
+}
+
+impl Range {
+    fn parse(s: &str) -> Option<Range> {
+        match s.find('-') {
+            Some(dash) => {
+                let mut from = s[..dash].parse().ok()?;
+                let mut to = s[dash+1..].parse().ok()?;
+                if to < from {
+                    std::mem::swap(&mut from, &mut to);
+                }
+                Some(Range {
+                    from,
+                    to,
+                })
+            },
+            None => {
+                let val = s.parse().ok()?;
+                Some(Range {
+                    from: val,
+                    to: val,
+                })
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FenceSettings<'a> {
+    pub language: Option<&'a str>,
+    pub line_numbers: bool,
+    pub highlight_lines: Vec<Range>,
+}
+impl<'a> FenceSettings<'a> {
+    pub fn new(fence_info: &'a str) -> Self {
+        let mut me = Self {
+            language: None,
+            line_numbers: false,
+            highlight_lines: Vec::new(),
+        };
+
+        for token in FenceIter::new(fence_info) {
+            match token {
+                FenceToken::Language(lang) => me.language = Some(lang),
+                FenceToken::EnableLineNumbers => me.line_numbers = true,
+                FenceToken::HighlightLines(lines) => me.highlight_lines.extend(lines),
+            }
+        }
+
+        me
+    }
+}
+
+#[derive(Debug)]
+enum FenceToken<'a> {
+    Language(&'a str),
+    EnableLineNumbers,
+    HighlightLines(Vec<Range>),
+}
+
+struct FenceIter<'a> {
+    split: std::str::Split<'a, char>,
+}
+impl<'a> FenceIter<'a> {
+    fn new(fence_info: &'a str) -> Self {
+        Self {
+            split: fence_info.split(','),
+        }
+    }
+}
+
+impl<'a> Iterator for FenceIter<'a> {
+    type Item = FenceToken<'a>;
+
+    fn next(&mut self) -> Option<FenceToken<'a>> {
+        loop {
+            let tok = self.split.next()?.trim();
+
+            let mut tok_split = tok.split('=');
+            match tok_split.next().unwrap_or("").trim() {
+                "" => continue,
+                "linenos" => return Some(FenceToken::EnableLineNumbers),
+                "hl_lines" => {
+                    let mut ranges = Vec::new();
+                    for range in tok_split.next().unwrap_or("").split(' ') {
+                        if let Some(range) = Range::parse(range) {
+                            ranges.push(range);
+                        }
+                    }
+                    return Some(FenceToken::HighlightLines(ranges));
+                },
+                lang => {
+                    return Some(FenceToken::Language(lang));
+                },
+            }
+        }
+    }
+}

--- a/components/rendering/src/shortcode.rs
+++ b/components/rendering/src/shortcode.rs
@@ -119,8 +119,9 @@ fn render_shortcode(
         template_name = format!("shortcodes/{}.html", name);
     }
 
-    let res = utils::templates::render_template(&template_name, &context.tera, tera_context, &None)
-        .map_err(|e| Error::chain(format!("Failed to render {} shortcode", name), e))?;
+    let res =
+        utils::templates::render_template(&template_name, &context.tera, &tera_context, &None)
+            .map_err(|e| Error::chain(format!("Failed to render {} shortcode", name), e))?;
 
     let res = OUTER_NEWLINE_RE.replace_all(&res, "");
 

--- a/components/rendering/src/shortcode.rs
+++ b/components/rendering/src/shortcode.rs
@@ -131,7 +131,7 @@ fn render_shortcode(
     // someone wants to include that comment in their content. This behaviour is unwanted in when
     // rendering markdown shortcodes.
     if template_name.ends_with(".html") {
-        Ok(res.replace('\n', "<!--\\n-->").to_string())
+        Ok(res.replace('\n', "<!--\\n-->"))
     } else {
         Ok(res.to_string())
     }
@@ -231,6 +231,7 @@ mod tests {
     use config::Config;
     use front_matter::InsertAnchor;
     use tera::Tera;
+    use unic_langid::langid;
 
     macro_rules! assert_lex_rule {
         ($rule: expr, $input: expr) => {
@@ -249,7 +250,8 @@ mod tests {
     fn render_shortcodes(code: &str, tera: &Tera) -> String {
         let config = Config::default();
         let permalinks = HashMap::new();
-        let context = RenderContext::new(&tera, &config, "", &permalinks, InsertAnchor::None);
+        let en = langid!("en");
+        let context = RenderContext::new(&tera, &config, "", &permalinks, InsertAnchor::None, &en);
         super::render_shortcodes(code, &context).unwrap()
     }
 

--- a/components/rendering/tests/codeblock_hl_lines.rs
+++ b/components/rendering/tests/codeblock_hl_lines.rs
@@ -1,0 +1,312 @@
+use std::collections::HashMap;
+
+use tera::Tera;
+
+use config::Config;
+use front_matter::InsertAnchor;
+use rendering::{render_content, RenderContext};
+use templates::ZOLA_TERA;
+use utils::slugs::SlugifyStrategy;
+
+macro_rules! colored_html_line {
+    ( @no $s:expr ) => {{
+        let mut result = "<span style=\"color:#c0c5ce;\">".to_string();
+        result.push_str($s);
+        result.push_str("\n</span>");
+        result
+    }};
+    ( @hl $s:expr ) => {{
+        let mut result = "<span style=\"background-color:#65737e30;color:#c0c5ce;\">".to_string();
+        result.push_str($s);
+        result.push_str("\n</span>");
+        result
+    }};
+}
+
+macro_rules! colored_html {
+    ( $(@$kind:tt $s:expr),* $(,)* ) => {{
+        let mut result = "<pre style=\"background-color:#2b303b;\">\n<code>".to_string();
+        $(
+            result.push_str(colored_html_line!(@$kind $s).as_str());
+        )*
+        result.push_str("</code></pre>");
+        result
+    }};
+}
+
+#[test]
+fn hl_lines_simple() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=2
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @no "foo",
+        @hl "bar",
+        @no "bar\nbaz",
+    ));
+}
+
+#[test]
+fn hl_lines_in_middle() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=2-3
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @no "foo",
+        @hl "bar\nbar",
+        @no "baz",
+    ));
+}
+
+#[test]
+fn hl_lines_all() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=1-4
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @hl "foo\nbar\nbar\nbaz",
+    ));
+}
+
+#[test]
+fn hl_lines_start_from_one() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=1-3
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @hl "foo\nbar\nbar",
+        @no "baz",
+    ));
+}
+
+#[test]
+fn hl_lines_start_from_zero() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=0-3
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @hl "foo\nbar\nbar",
+        @no "baz",
+    ));
+}
+
+#[test]
+fn hl_lines_end() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=3-4
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @no "foo\nbar",
+        @hl "bar\nbaz",
+    ));
+}
+
+#[test]
+fn hl_lines_end_out_of_bounds() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=3-4294967295
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @no "foo\nbar",
+        @hl "bar\nbaz",
+    ));
+}
+
+#[test]
+fn hl_lines_overlap() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=2-3 1-2
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @hl "foo\nbar\nbar",
+        @no "baz",
+    ));
+}
+#[test]
+fn hl_lines_multiple() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=2-3,hl_lines=1-2
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @hl "foo\nbar\nbar",
+        @no "baz",
+    ));
+}
+
+#[test]
+fn hl_lines_extra_spaces() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```     hl_lines     =       2 - 3      1    -       2
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @hl "foo\nbar\nbar",
+        @no "baz",
+    ));
+}
+
+#[test]
+fn hl_lines_int_and_range() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=1 3-4
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @hl "foo",
+        @no "bar",
+        @hl "bar\nbaz",
+    ));
+}
+
+#[test]
+fn hl_lines_single_line_range() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=2-2
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @no "foo",
+        @hl "bar",
+        @no "bar\nbaz",
+    ));
+}
+
+
+#[test]
+fn hl_lines_reverse_range() {
+    let tera_ctx = Tera::default();
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.highlight_code = true;
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content(r#"
+```hl_lines=3-2
+foo
+bar
+bar
+baz
+```
+    "#, &context).unwrap();
+    assert_eq!(res.body, colored_html!(
+        @no "foo",
+        @hl "bar\nbar",
+        @no "baz",
+    ));
+}

--- a/components/rendering/tests/codeblock_hl_lines.rs
+++ b/components/rendering/tests/codeblock_hl_lines.rs
@@ -1,12 +1,15 @@
 use std::collections::HashMap;
 
 use tera::Tera;
+use unic_langid::{langid, LanguageIdentifier};
 
 use config::Config;
 use front_matter::InsertAnchor;
 use rendering::{render_content, RenderContext};
 use templates::ZOLA_TERA;
 use utils::slugs::SlugifyStrategy;
+
+const EN: &LanguageIdentifier = &langid!("en");
 
 macro_rules! colored_html_line {
     ( @no $s:expr ) => {{
@@ -40,20 +43,28 @@ fn hl_lines_simple() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=2
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @no "foo",
-        @hl "bar",
-        @no "bar\nbaz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @no "foo",
+            @hl "bar",
+            @no "bar\nbaz",
+        )
+    );
 }
 
 #[test]
@@ -62,20 +73,28 @@ fn hl_lines_in_middle() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=2-3
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @no "foo",
-        @hl "bar\nbar",
-        @no "baz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @no "foo",
+            @hl "bar\nbar",
+            @no "baz",
+        )
+    );
 }
 
 #[test]
@@ -84,18 +103,26 @@ fn hl_lines_all() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=1-4
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @hl "foo\nbar\nbar\nbaz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @hl "foo\nbar\nbar\nbaz",
+        )
+    );
 }
 
 #[test]
@@ -104,19 +131,27 @@ fn hl_lines_start_from_one() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=1-3
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @hl "foo\nbar\nbar",
-        @no "baz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @hl "foo\nbar\nbar",
+            @no "baz",
+        )
+    );
 }
 
 #[test]
@@ -125,19 +160,27 @@ fn hl_lines_start_from_zero() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=0-3
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @hl "foo\nbar\nbar",
-        @no "baz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @hl "foo\nbar\nbar",
+            @no "baz",
+        )
+    );
 }
 
 #[test]
@@ -146,19 +189,27 @@ fn hl_lines_end() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=3-4
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @no "foo\nbar",
-        @hl "bar\nbaz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @no "foo\nbar",
+            @hl "bar\nbaz",
+        )
+    );
 }
 
 #[test]
@@ -167,19 +218,27 @@ fn hl_lines_end_out_of_bounds() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=3-4294967295
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @no "foo\nbar",
-        @hl "bar\nbaz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @no "foo\nbar",
+            @hl "bar\nbaz",
+        )
+    );
 }
 
 #[test]
@@ -188,19 +247,27 @@ fn hl_lines_overlap() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=2-3 1-2
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @hl "foo\nbar\nbar",
-        @no "baz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @hl "foo\nbar\nbar",
+            @no "baz",
+        )
+    );
 }
 #[test]
 fn hl_lines_multiple() {
@@ -208,19 +275,27 @@ fn hl_lines_multiple() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=2-3,hl_lines=1-2
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @hl "foo\nbar\nbar",
-        @no "baz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @hl "foo\nbar\nbar",
+            @no "baz",
+        )
+    );
 }
 
 #[test]
@@ -229,19 +304,27 @@ fn hl_lines_extra_spaces() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```     hl_lines     =       2 - 3      1    -       2
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @hl "foo\nbar\nbar",
-        @no "baz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @hl "foo\nbar\nbar",
+            @no "baz",
+        )
+    );
 }
 
 #[test]
@@ -250,20 +333,28 @@ fn hl_lines_int_and_range() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=1 3-4
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @hl "foo",
-        @no "bar",
-        @hl "bar\nbaz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @hl "foo",
+            @no "bar",
+            @hl "bar\nbaz",
+        )
+    );
 }
 
 #[test]
@@ -272,22 +363,29 @@ fn hl_lines_single_line_range() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=2-2
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @no "foo",
-        @hl "bar",
-        @no "bar\nbaz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @no "foo",
+            @hl "bar",
+            @no "bar\nbaz",
+        )
+    );
 }
-
 
 #[test]
 fn hl_lines_reverse_range() {
@@ -295,18 +393,26 @@ fn hl_lines_reverse_range() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
-    let res = render_content(r#"
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
+    let res = render_content(
+        r#"
 ```hl_lines=3-2
 foo
 bar
 bar
 baz
 ```
-    "#, &context).unwrap();
-    assert_eq!(res.body, colored_html!(
-        @no "foo",
-        @hl "bar\nbar",
-        @no "baz",
-    ));
+    "#,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(
+        res.body,
+        colored_html!(
+            @no "foo",
+            @hl "bar\nbar",
+            @no "baz",
+        )
+    );
 }

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use tera::Tera;
+use unic_langid::{langid, LanguageIdentifier};
 
 use config::Config;
 use front_matter::InsertAnchor;
@@ -8,12 +9,14 @@ use rendering::{render_content, RenderContext};
 use templates::ZOLA_TERA;
 use utils::slugs::SlugifyStrategy;
 
+const EN: &LanguageIdentifier = &langid!("en");
 #[test]
 fn can_do_render_content_simple() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("hello", &context).unwrap();
     assert_eq!(res.body, "<p>hello</p>\n");
 }
@@ -24,7 +27,8 @@ fn doesnt_highlight_code_block_with_highlighting_off() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = false;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("```\n$ gutenberg server\n```", &context).unwrap();
     assert_eq!(res.body, "<pre><code>$ gutenberg server\n</code></pre>\n");
 }
@@ -35,7 +39,8 @@ fn can_highlight_code_block_no_lang() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("```\n$ gutenberg server\n$ ping\n```", &context).unwrap();
     assert_eq!(
         res.body,
@@ -49,7 +54,8 @@ fn can_highlight_code_block_with_lang() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("```python\nlist.append(1)\n```", &context).unwrap();
     assert_eq!(
         res.body,
@@ -63,7 +69,8 @@ fn can_higlight_code_block_with_unknown_lang() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = true;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("```yolo\nlist.append(1)\n```", &context).unwrap();
     // defaults to plain text
     assert_eq!(
@@ -76,7 +83,8 @@ fn can_higlight_code_block_with_unknown_lang() {
 fn can_render_shortcode() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content(
         r#"
 Hello
@@ -94,7 +102,8 @@ Hello
 fn can_render_shortcode_with_markdown_char_in_args_name() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let input = vec!["name", "na_me", "n_a_me", "n1"];
     for i in input {
         let res =
@@ -107,7 +116,8 @@ fn can_render_shortcode_with_markdown_char_in_args_name() {
 fn can_render_shortcode_with_markdown_char_in_args_value() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let input = vec![
         "ub36ffWAqgQ-hey",
         "ub36ffWAqgQ_hey",
@@ -137,7 +147,8 @@ fn can_render_body_shortcode_with_markdown_char_in_name() {
             "<blockquote>{{ body }} - {{ author}}</blockquote>",
         )
         .unwrap();
-        let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+        let context =
+            RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
         let res =
             render_content(&format!("{{% {}(author=\"Bob\") %}}\nhey\n{{% end %}}", i), &context)
@@ -168,7 +179,7 @@ Here is another paragraph.
 
     tera.add_raw_template(&format!("shortcodes/{}.html", "figure"), shortcode).unwrap();
     let config = Config::default();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
     let res = render_content(markdown_string, &context).unwrap();
     println!("{:?}", res);
@@ -201,7 +212,7 @@ Here is another paragraph.
 
     tera.add_raw_template(&format!("shortcodes/{}.html", "figure"), shortcode).unwrap();
     let config = Config::default();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
     let res = render_content(markdown_string, &context).unwrap();
     println!("{:?}", res);
@@ -212,7 +223,8 @@ Here is another paragraph.
 fn can_render_several_shortcode_in_row() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content(
         r#"
 Hello
@@ -245,7 +257,8 @@ fn doesnt_render_ignored_shortcodes() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.highlight_code = false;
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content(r#"```{{/* youtube(id="w7Ft2ymGmfc") */}}```"#, &context).unwrap();
     assert_eq!(res.body, "<p><code>{{ youtube(id=&quot;w7Ft2ymGmfc&quot;) }}</code></p>\n");
 }
@@ -261,7 +274,7 @@ fn can_render_shortcode_with_body() {
     .unwrap();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
     let res = render_content(
         r#"
@@ -281,7 +294,8 @@ fn errors_rendering_unknown_shortcode() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("{{ hello(flash=true) }}", &context);
     assert!(res.is_err());
 }
@@ -292,7 +306,7 @@ fn can_make_valid_relative_link() {
     permalinks.insert("pages/about.md".to_string(), "https://vincent.is/about".to_string());
     let tera_ctx = Tera::default();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks, InsertAnchor::None);
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks, InsertAnchor::None, EN);
     let res = render_content(
         r#"[rel link](@/pages/about.md), [abs link](https://vincent.is/about)"#,
         &context,
@@ -310,7 +324,7 @@ fn can_make_relative_links_with_anchors() {
     permalinks.insert("pages/about.md".to_string(), "https://vincent.is/about".to_string());
     let tera_ctx = Tera::default();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks, InsertAnchor::None);
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks, InsertAnchor::None, EN);
     let res = render_content(r#"[rel link](@/pages/about.md#cv)"#, &context).unwrap();
 
     assert!(res.body.contains(r#"<p><a href="https://vincent.is/about#cv">rel link</a></p>"#));
@@ -321,7 +335,8 @@ fn errors_relative_link_inexistant() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("[rel link](@/pages/about.md)", &context);
     assert!(res.is_err());
 }
@@ -331,7 +346,8 @@ fn can_add_id_to_headings() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content(r#"# Hello"#, &context).unwrap();
     assert_eq!(res.body, "<h1 id=\"hello\">Hello</h1>\n");
 }
@@ -341,7 +357,8 @@ fn can_add_id_to_headings_same_slug() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("# Hello\n# Hello", &context).unwrap();
     assert_eq!(res.body, "<h1 id=\"hello\">Hello</h1>\n<h1 id=\"hello-1\">Hello</h1>\n");
 }
@@ -352,7 +369,8 @@ fn can_add_non_slug_id_to_headings() {
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default();
     config.slugify.anchors = SlugifyStrategy::Safe;
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content(r#"# L'écologie et vous"#, &context).unwrap();
     assert_eq!(res.body, "<h1 id=\"L'écologie_et_vous\">L'écologie et vous</h1>\n");
 }
@@ -362,7 +380,8 @@ fn can_handle_manual_ids_on_headings() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     // Tested things: manual IDs; whitespace flexibility; that automatic IDs avoid collision with
     // manual IDs; that duplicates are in fact permitted among manual IDs; that any non-plain-text
     // in the middle of `{#…}` will disrupt it from being acknowledged as a manual ID (that last
@@ -399,7 +418,8 @@ fn blank_headings() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("# \n#\n# {#hmm} \n# {#}", &context).unwrap();
     assert_eq!(
         res.body,
@@ -411,7 +431,8 @@ fn blank_headings() {
 fn can_insert_anchor_left() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Left);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Left, EN);
     let res = render_content("# Hello", &context).unwrap();
     assert_eq!(
         res.body,
@@ -423,7 +444,8 @@ fn can_insert_anchor_left() {
 fn can_insert_anchor_right() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Right);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Right, EN);
     let res = render_content("# Hello", &context).unwrap();
     assert_eq!(
         res.body,
@@ -435,7 +457,8 @@ fn can_insert_anchor_right() {
 fn can_insert_anchor_for_multi_heading() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Right);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Right, EN);
     let res = render_content("# Hello\n# World", &context).unwrap();
     assert_eq!(
         res.body,
@@ -449,7 +472,8 @@ fn can_insert_anchor_for_multi_heading() {
 fn can_insert_anchor_with_exclamation_mark() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Left);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Left, EN);
     let res = render_content("# Hello!", &context).unwrap();
     assert_eq!(
         res.body,
@@ -462,7 +486,8 @@ fn can_insert_anchor_with_exclamation_mark() {
 fn can_insert_anchor_with_link() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Left);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Left, EN);
     let res = render_content("## [Rust](https://rust-lang.org)", &context).unwrap();
     assert_eq!(
         res.body,
@@ -474,7 +499,8 @@ fn can_insert_anchor_with_link() {
 fn can_insert_anchor_with_other_special_chars() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Left);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::Left, EN);
     let res = render_content("# Hello*_()", &context).unwrap();
     assert_eq!(
         res.body,
@@ -492,6 +518,7 @@ fn can_make_toc() {
         "https://mysite.com/something",
         &permalinks_ctx,
         InsertAnchor::Left,
+        EN,
     );
 
     let res = render_content(
@@ -524,6 +551,7 @@ fn can_ignore_tags_in_toc() {
         "https://mysite.com/something",
         &permalinks_ctx,
         InsertAnchor::Left,
+        EN,
     );
 
     let res = render_content(
@@ -554,7 +582,8 @@ fn can_ignore_tags_in_toc() {
 fn can_understand_backtick_in_titles() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("# `Hello`", &context).unwrap();
     assert_eq!(res.body, "<h1 id=\"hello\"><code>Hello</code></h1>\n");
 }
@@ -563,7 +592,8 @@ fn can_understand_backtick_in_titles() {
 fn can_understand_backtick_in_paragraphs() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("Hello `world`", &context).unwrap();
     assert_eq!(res.body, "<p>Hello <code>world</code></p>\n");
 }
@@ -573,7 +603,8 @@ fn can_understand_backtick_in_paragraphs() {
 fn can_understand_links_in_heading() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("# [Rust](https://rust-lang.org)", &context).unwrap();
     assert_eq!(res.body, "<h1 id=\"rust\"><a href=\"https://rust-lang.org\">Rust</a></h1>\n");
 }
@@ -582,7 +613,8 @@ fn can_understand_links_in_heading() {
 fn can_understand_link_with_title_in_heading() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res =
         render_content("# [Rust](https://rust-lang.org \"Rust homepage\")", &context).unwrap();
     assert_eq!(
@@ -595,7 +627,8 @@ fn can_understand_link_with_title_in_heading() {
 fn can_understand_emphasis_in_heading() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("# *Emphasis* text", &context).unwrap();
     assert_eq!(res.body, "<h1 id=\"emphasis-text\"><em>Emphasis</em> text</h1>\n");
 }
@@ -604,7 +637,8 @@ fn can_understand_emphasis_in_heading() {
 fn can_understand_strong_in_heading() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("# **Strong** text", &context).unwrap();
     assert_eq!(res.body, "<h1 id=\"strong-text\"><strong>Strong</strong> text</h1>\n");
 }
@@ -613,7 +647,8 @@ fn can_understand_strong_in_heading() {
 fn can_understand_code_in_heading() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("# `Code` text", &context).unwrap();
     assert_eq!(res.body, "<h1 id=\"code-text\"><code>Code</code> text</h1>\n");
 }
@@ -623,7 +658,8 @@ fn can_understand_code_in_heading() {
 fn can_understand_footnote_in_heading() {
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content("# text [^1] there\n[^1]: footnote", &context).unwrap();
     assert_eq!(
         res.body,
@@ -641,7 +677,7 @@ fn can_make_valid_relative_link_in_heading() {
     permalinks.insert("pages/about.md".to_string(), "https://vincent.is/about/".to_string());
     let tera_ctx = Tera::default();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks, InsertAnchor::None);
+    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks, InsertAnchor::None, EN);
     let res = render_content(r#" # [rel link](@/pages/about.md)"#, &context).unwrap();
 
     assert_eq!(
@@ -660,6 +696,7 @@ fn can_make_permalinks_with_colocated_assets_for_link() {
         "https://vincent.is/about/",
         &permalinks_ctx,
         InsertAnchor::None,
+        EN,
     );
     let res = render_content("[an image](image.jpg)", &context).unwrap();
     assert_eq!(res.body, "<p><a href=\"https://vincent.is/about/image.jpg\">an image</a></p>\n");
@@ -675,6 +712,7 @@ fn can_make_permalinks_with_colocated_assets_for_image() {
         "https://vincent.is/about/",
         &permalinks_ctx,
         InsertAnchor::None,
+        EN,
     );
     let res = render_content("![alt text](image.jpg)", &context).unwrap();
     assert_eq!(
@@ -693,6 +731,7 @@ fn markdown_doesnt_wrap_html_in_paragraph() {
         "https://vincent.is/about/",
         &permalinks_ctx,
         InsertAnchor::None,
+        EN,
     );
     let res = render_content(
         r#"
@@ -725,6 +764,7 @@ fn correctly_captures_external_links() {
         "https://vincent.is/about/",
         &permalinks_ctx,
         InsertAnchor::None,
+        EN,
     );
     let content = "
 [a link](http://google.com)
@@ -744,7 +784,8 @@ fn can_handle_summaries() {
     let tera_ctx = Tera::default();
     let permalinks_ctx = HashMap::new();
     let config = Config::default();
-    let context = RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context =
+        RenderContext::new(&tera_ctx, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
     let res = render_content(
         r#"
 Hello [My site][world]
@@ -792,7 +833,7 @@ fn doesnt_try_to_highlight_content_from_shortcode() {
 
     tera.add_raw_template(&format!("shortcodes/{}.html", "figure"), shortcode).unwrap();
     let config = Config::default();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
     let res = render_content(markdown_string, &context).unwrap();
     assert_eq!(res.body, expected);
@@ -814,7 +855,7 @@ fn can_emit_newlines_and_whitespace_with_shortcode() {
 
     tera.add_raw_template(&format!("shortcodes/{}.html", "preformatted"), shortcode).unwrap();
     let config = Config::default();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
     let res = render_content(markdown_string, &context).unwrap();
     assert_eq!(res.body, expected);
@@ -842,7 +883,7 @@ fn can_emit_newlines_and_whitespace_with_shortcode() {
 //
 //    tera.add_raw_template(&format!("shortcodes/{}.html", "alert"), shortcode).unwrap();
 //    let config = Config::default();
-//    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+//    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 //
 //    let res = render_content(markdown_string, &context).unwrap();
 //    assert_eq!(res.body, expected);
@@ -869,6 +910,7 @@ fn leaves_custom_url_scheme_untouched() {
         "https://vincent.is/",
         &permalinks_ctx,
         InsertAnchor::None,
+        EN,
     );
 
     let res = render_content(content, &context).unwrap();
@@ -895,6 +937,7 @@ fn stops_with_an_error_on_an_empty_link() {
         "https://vincent.is/",
         &permalinks_ctx,
         InsertAnchor::None,
+        EN,
     );
 
     let res = render_content(content, &context);
@@ -939,7 +982,7 @@ Bla bla"#;
 
     tera.add_raw_template(&format!("shortcodes/{}.md", "quote"), shortcode).unwrap();
     let config = Config::default();
-    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None, EN);
 
     let res = render_content(markdown_string, &context).unwrap();
     println!("{:?}", res);

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -13,6 +13,9 @@ errors = { path = "../errors" }
 library = { path = "../library" }
 config = { path = "../config" }
 
+[dev-dependencies]
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
+
 [features]
 default = []
 indexing-zh = ["elasticlunr-rs/zh"]

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -8,7 +8,7 @@ include = ["src/**/*"]
 [dependencies]
 tera = "1"
 glob = "0.3"
-minify-html = "0.3.6"
+minify-html = "0.3.8"
 rayon = "1"
 serde = "1"
 serde_derive = "1"

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1"
 serde_derive = "1"
 sass-rs = "0.2"
 lazy_static = "1.1"
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
 
 errors = { path = "../errors" }
 config = { path = "../config" }

--- a/components/site/benches/gen.py
+++ b/components/site/benches/gen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 Generates test sites for use in benchmark.
 Tested with python3 and probably does not work on Windows.
@@ -100,7 +102,6 @@ def gen_skeleton(name, is_blog):
     os.makedirs(os.path.join(name, "content"))
 
     with open(os.path.join(name, "config.toml"), "w") as f:
-        if is_blog:
             f.write("""
 title = "My site"
 base_url = "https://replace-this-with-your-url.com"
@@ -110,15 +111,6 @@ taxonomies = [
  {name = "tags", feed = true}, 
  {name = "categories"}
 ]
-
-[extra.author]
-name = "Vincent Prouillet"
-""")
-        else:
-            f.write("""
-title = "My site"
-base_url = "https://replace-this-with-your-url.com"
-theme = "sample"
 
 [extra.author]
 name = "Vincent Prouillet"

--- a/components/site/benches/load.rs
+++ b/components/site/benches/load.rs
@@ -8,7 +8,7 @@ use site::Site;
 
 #[bench]
 fn bench_loading_small_blog(b: &mut test::Bencher) {
-    let mut path = env::current_dir().unwrap().to_path_buf();
+    let mut path = env::current_dir().unwrap();
     path.push("benches");
     path.push("small-blog");
     let config_file = path.join("config.toml");
@@ -19,7 +19,7 @@ fn bench_loading_small_blog(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_loading_small_blog_with_syntax_highlighting(b: &mut test::Bencher) {
-    let mut path = env::current_dir().unwrap().to_path_buf();
+    let mut path = env::current_dir().unwrap();
     path.push("benches");
     path.push("small-blog");
     let config_file = path.join("config.toml");
@@ -100,7 +100,7 @@ fn bench_loading_small_blog_with_syntax_highlighting(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_loading_small_kb(b: &mut test::Bencher) {
-    let mut path = env::current_dir().unwrap().to_path_buf();
+    let mut path = env::current_dir().unwrap();
     path.push("benches");
     path.push("small-kb");
     let config_file = path.join("config.toml");
@@ -111,7 +111,7 @@ fn bench_loading_small_kb(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_loading_small_kb_with_syntax_highlighting(b: &mut test::Bencher) {
-    let mut path = env::current_dir().unwrap().to_path_buf();
+    let mut path = env::current_dir().unwrap();
     path.push("benches");
     path.push("small-kb");
     let config_file = path.join("config.toml");

--- a/components/site/benches/site.rs
+++ b/components/site/benches/site.rs
@@ -71,7 +71,7 @@ fn bench_render_paginated(b: &mut test::Bencher) {
     let section = library.sections_values()[0];
     let paginator = Paginator::from_section(&section, &library);
 
-    b.iter(|| site.render_paginated(public, &paginator));
+    b.iter(|| site.render_paginated(&[], &paginator));
 }
 
 #[bench]

--- a/components/site/src/feed.rs
+++ b/components/site/src/feed.rs
@@ -86,7 +86,7 @@ pub fn render_feed(
     context = additional_context_fn(context);
 
     let tera = site.localized_tera.get(lang).expect("`lang` in `localized_tera`");
-    let feed = render_template(feed_filename, tera, context, &site.config.theme)?;
+    let feed = render_template(feed_filename, tera, &context, &site.config.theme)?;
 
     Ok(Some(feed))
 }

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -547,7 +547,7 @@ impl Site {
                     p.as_os_str().to_string_lossy().replace("public/", "/")
                 } else {
                     // TODO" remove unwrap
-                    let p = current_path.strip_prefix("public").unwrap();
+                    let p = current_path.strip_prefix(&self.output_path).unwrap();
                     p.as_os_str().to_string_lossy().into_owned()
                 }
                 .trim_end_matches('/')

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -262,7 +262,7 @@ impl Site {
         // taxonomy Tera fns are loaded in `register_early_global_fns`
         // so we do need to populate it first.
         self.populate_taxonomies()?;
-        tpls::register_early_global_fns(self);
+        tpls::register_early_global_fns(self)?;
         self.populate_sections();
         self.render_markdown()?;
         tpls::register_tera_global_fns(self);

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use glob::glob;
 use lazy_static::lazy_static;
-use minify_html::{truncate, Cfg};
+use minify_html::{with_friendly_error, Cfg};
 use rayon::prelude::*;
 use tera::{Context, Tera};
 
@@ -450,13 +450,13 @@ impl Site {
     fn minify(&self, html: String) -> Result<String> {
         let cfg = &Cfg { minify_js: false };
         let mut input_bytes = html.as_bytes().to_vec();
-        match truncate(&mut input_bytes, cfg) {
+        match with_friendly_error(&mut input_bytes, cfg) {
             Ok(_len) => match std::str::from_utf8(&mut input_bytes) {
                 Ok(result) => Ok(result.to_string()),
                 Err(err) => bail!("Failed to convert bytes to string : {}", err),
             },
             Err(minify_error) => {
-                bail!("Failed to truncate html at character {}:", minify_error.position);
+                bail!("Failed to truncate html at character {}: {} \n {}", minify_error.position, minify_error.message, minify_error.code_context);
             }
         }
     }

--- a/components/site/src/sass.rs
+++ b/components/site/src/sass.rs
@@ -44,14 +44,7 @@ fn compile_sass_glob(
     extension: &str,
     options: &Options,
 ) -> Result<Vec<(PathBuf, PathBuf)>> {
-    let glob_string = format!("{}/**/*.{}", sass_path.display(), extension);
-    let files = glob(&glob_string)
-        .expect("Invalid glob for sass")
-        .filter_map(|e| e.ok())
-        .filter(|entry| {
-            !entry.as_path().components().any(|c| c.as_os_str().to_string_lossy().starts_with('_'))
-        })
-        .collect::<Vec<_>>();
+    let files = get_non_partial_scss(sass_path, extension);
 
     let mut compiled_paths = Vec::new();
     for file in files {
@@ -70,4 +63,49 @@ fn compile_sass_glob(
     }
 
     Ok(compiled_paths)
+}
+
+fn get_non_partial_scss(sass_path: &Path, extension: &str) -> Vec<PathBuf> {
+    let glob_string = format!("{}/**/*.{}", sass_path.display(), extension);
+    glob(&glob_string)
+        .expect("Invalid glob for sass")
+        .filter_map(|e| e.ok())
+        .filter(|entry| {
+            !entry
+                .as_path()
+                .iter()
+                .last()
+                .map(|c| c.to_string_lossy().starts_with('_'))
+                .unwrap_or(true)
+        })
+        .collect::<Vec<_>>()
+}
+
+#[test]
+fn test_get_non_partial_scss() {
+    use std::env;
+
+    let mut path = env::current_dir().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
+    path.push("test_site");
+    path.push("sass");
+
+    let result = get_non_partial_scss(&path, "scss");
+
+    assert!(result.len() != 0);
+    assert!(result.iter().filter_map(|path| path.file_name()).any(|file| file == "scss.scss"))
+}
+#[test]
+fn test_get_non_partial_scss_underscores() {
+    use std::env;
+
+    let mut path = env::current_dir().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
+    path.push("test_site");
+    path.push("_dir_with_underscores");
+    path.push("..");
+    path.push("sass");
+
+    let result = get_non_partial_scss(&path, "scss");
+
+    assert!(result.len() != 0);
+    assert!(result.iter().filter_map(|path| path.file_name()).any(|file| file == "scss.scss"))
 }

--- a/components/site/src/sass.rs
+++ b/components/site/src/sass.rs
@@ -91,7 +91,7 @@ fn test_get_non_partial_scss() {
 
     let result = get_non_partial_scss(&path, "scss");
 
-    assert!(result.len() != 0);
+    assert!(!result.is_empty());
     assert!(result.iter().filter_map(|path| path.file_name()).any(|file| file == "scss.scss"))
 }
 #[test]
@@ -106,6 +106,6 @@ fn test_get_non_partial_scss_underscores() {
 
     let result = get_non_partial_scss(&path, "scss");
 
-    assert!(result.len() != 0);
+    assert!(!result.is_empty());
     assert!(result.iter().filter_map(|path| path.file_name()).any(|file| file == "scss.scss"))
 }

--- a/components/site/src/sitemap.rs
+++ b/components/site/src/sitemap.rs
@@ -85,7 +85,7 @@ pub fn find_entries<'a>(
         })
         .collect::<Vec<_>>();
 
-    for section in library.sections_values().iter() {
+    for section in library.sections_values() {
         if let Some(paginate_by) = section.paginate_by() {
             let number_pagers = (section.pages.len() as f64 / paginate_by as f64).ceil() as isize;
             for i in 1..=number_pagers {

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -50,7 +50,7 @@ pub fn load_tera(path: &Path, config: &Config) -> Result<Tera> {
 
 /// Adds global fns that are to be available to shortcodes while rendering markdown
 pub fn register_early_global_fns(site: &mut Site) -> Result<()> {
-    for (lang, tera) in site.localized_tera.iter_mut() {
+    for (lang, tera) in &mut site.localized_tera {
         // Split off in the hope that eventually it could be cheaply copied without re-parsing the
         // `.ftl` files, and saving allocation due to the `Arc`s. FIXME
         let loader = global_fns::construct_arc_loader(
@@ -105,7 +105,7 @@ pub fn register_early_global_fns(site: &mut Site) -> Result<()> {
 
 /// Functions filled once we have parsed all the pages/sections only, so not available in shortcodes
 pub fn register_tera_global_fns(site: &mut Site) {
-    for (lang, tera) in site.localized_tera.iter_mut() {
+    for (lang, tera) in &mut site.localized_tera {
         tera.register_function(
             "get_page",
             global_fns::GetPage::new(site.base_path.clone(), site.library.clone()),

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -529,12 +529,13 @@ fn can_build_site_with_pagination_for_index() {
 #[test]
 fn can_build_site_with_pagination_for_taxonomy() {
     let (_, _tmp_dir, public) = build_site_with_setup("test_site", |mut site| {
-        site.config.taxonomies.push(Taxonomy {
+        site.config.default_language_options.taxonomies.push(Taxonomy {
             name: "tags".to_string(),
             paginate_by: Some(2),
             paginate_path: None,
             feed: true,
             lang: site.config.default_language.clone(),
+            language_alias: site.config.default_language_options.language_alias.clone(),
         });
         site.load().unwrap();
         {
@@ -635,7 +636,7 @@ fn can_build_feeds() {
 #[test]
 fn can_build_search_index() {
     let (_, _tmp_dir, public) = build_site_with_setup("test_site", |mut site| {
-        site.config.build_search_index = true;
+        site.config.default_language_options.build_search_index = Some(true);
         (site, true)
     });
 

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -15,6 +15,7 @@ image = "0.23"
 serde_json = "1.0"
 sha2 = "0.9"
 url = "2"
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 sha2 = "0.9"
 url = "2"
 unic-langid = { version = "0.9", features = ["serde", "macros"] }
+fluent-templates = { version = "0.5", features = ["tera"] }
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/templates/src/global_fns/mod.rs
+++ b/components/templates/src/global_fns/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 use std::{fs, io, result};
 
@@ -51,7 +51,7 @@ impl TeraFn for Trans {
 
         let term = self
             .config
-            .get_translation(lang, key)
+            .get_translation(&lang, &key)
             .map_err(|e| Error::chain("Failed to retreive term translation", e))?;
 
         Ok(to_value(term).unwrap())
@@ -437,8 +437,8 @@ pub struct GetSection {
     library: Arc<RwLock<Library>>,
 }
 impl GetSection {
-    pub fn new(base_path: PathBuf, library: Arc<RwLock<Library>>) -> Self {
-        Self { base_path: base_path.join("content"), library }
+    pub fn new<P: AsRef<Path>>(base_path: P, library: Arc<RwLock<Library>>) -> Self {
+        Self { base_path: base_path.as_ref().join("content"), library }
     }
 }
 impl TeraFn for GetSection {
@@ -531,7 +531,7 @@ impl TeraFn for Fluent {
     }
 }
 
-/// Creates an ArchLoader if the `locales` directory exists for either the site or its theme.
+/// Creates an ArcLoader if the `locales` directory exists for either the site or its theme.
 ///
 /// Otherwise, returns None. If there were any problems, an Err is returned.
 ///
@@ -665,18 +665,13 @@ mod tests {
             ..TaxonomyConfig::default()
         };
         let library = Arc::new(RwLock::new(Library::new(0, 0, false)));
-        let tag = TaxonomyItem::new(
-            "Programming",
-            &taxo_config,
-            &config,
-            vec![],
-            &library.read().unwrap(),
-        );
+        let tag =
+            TaxonomyItem::new("Programming", &taxo_config, &config, &[], &library.read().unwrap());
         let tag_fr = TaxonomyItem::new(
             "Programmation",
             &taxo_config_fr,
             &config,
-            vec![],
+            &[],
             &library.read().unwrap(),
         );
         let tags = Taxonomy { kind: taxo_config, items: vec![tag] };
@@ -745,8 +740,8 @@ mod tests {
             ..TaxonomyConfig::default()
         };
         let library = Library::new(0, 0, false);
-        let tag = TaxonomyItem::new("Programming", &taxo_config, &config, vec![], &library);
-        let tag_fr = TaxonomyItem::new("Programmation", &taxo_config_fr, &config, vec![], &library);
+        let tag = TaxonomyItem::new("Programming", &taxo_config, &config, &[], &library);
+        let tag_fr = TaxonomyItem::new("Programmation", &taxo_config_fr, &config, &[], &library);
         let tags = Taxonomy { kind: taxo_config, items: vec![tag] };
         let tags_fr = Taxonomy { kind: taxo_config_fr, items: vec![tag_fr] };
 

--- a/components/utils/src/templates.rs
+++ b/components/utils/src/templates.rs
@@ -22,7 +22,7 @@ macro_rules! render_default_tpl {
 pub fn render_template(
     name: &str,
     tera: &Tera,
-    context: Context,
+    context: &Context,
     theme: &Option<String>,
 ) -> Result<String> {
     // check if it is in the templates

--- a/docs/content/documentation/content/multilingual.md
+++ b/docs/content/documentation/content/multilingual.md
@@ -6,19 +6,63 @@ weight = 130
 Zola supports having a site in multiple languages.
 
 ## Configuration
-To get started, you will need to add the languages you want to support
+To get started, you need to add a default language and any other languages you want to support
 to your `config.toml`. For example:
 
 ```toml
-languages = [
-    {code = "fr", feed = true}, # there will be a feed for French content
-    {code = "fr", search = true}, # there will be a Search Index for French content
-    {code = "it"}, # there won't be a feed for Italian content
+base_url = "mywebsite.com"
+
+# The default language must be set if you put other languages in the config
+default_language = "en"
+
+# Put any options for the default language here
+title = "My multilingual site"
+taxonomies = [
+  { name = "author" }
 ]
+
+# Languages are set as sub-tables of a top-level `languages` table
+[languages]
+
+  # Write the code of the language after the dot
+  [languages.fr]
+  # Some settings can be overridden for each language
+  title = "Mon site multilingue"
+
+  # Taxonomies are defined on a per-language basis
+  taxonomies = [
+    { name = "auteur" }
+  ]
+
+  # You can specify language variants, too
+  [languages."de-AT"]
+  language_alias = "german"  # And then set a friendly name for them
 ```
 
-If you want to use per-language taxonomies, ensure you set the `lang` field in their
-configuration.
+The configuration above creates
+- an English version at `mywebsite.com/` with the title "My multilingual site" and a single
+  "author" taxonomy,
+- a French version at `mywebsite.com/fr" with the title <span lang="fr">"Mon site multilingue"</span>
+  and a single <span lang="fr">"auteur"</span> taxonomy, and
+- an Austrian German version at `mywebsite.com/german", with no title set and no taxonomies.
+
+Languages are identified by [the type of code](https://en.wikipedia.org/wiki/IETF_language_tag)
+that's used in HTML. You can specify an exact language variant, so themes will be in the right
+spelling (e.g. *light colors* for `en-US` vs. *light colours* for `en-GB`), and screen readers will
+use the right dialect. Note that these are canonicalized, so `en_gb` becomes `en-GB` internally.
+Setting an invalid code will result in an error.
+
+Language aliases let you optionally assign a "friendly" name to a language. These will be used for
+URLs and in file names. If your site used a previous version of Zola or a different static site
+generator in multilingual mode, set these to the language names used by them, to avoid breaking
+links to your site. It defaults to the [canonicalized form](https://tools.ietf.org/html/bcp47#section-4.5)
+of the language's code.
+
+Language aliases aren't slugified, so URL- and path-safe characters **must** be used.
+
+The default language is configured with the top-level variables. Most of these can be overridden
+for each language. Refer to the [`config.toml` options](@/documentation/getting-started/configuration.md)
+for specifics.
 
 Note: By default, Chinese and Japanese search indexing is not included. You can include
 the support by building `zola` using `cargo build --features search/indexing-ja search/indexing-zh`.
@@ -33,12 +77,17 @@ uses the filename to detect the language:
 - `content/an-article.md`: this will be the default language
 - `content/an-article.fr.md`: this will be in French
 
-If the language code in the filename does not correspond to one of the languages configured,
-an error will be shown.
+If the language code in the filename does not correspond to any of the aliases, an error will be
+shown.
 
-If your default language has an `_index.md` in a directory, you will need to add an `_index.{code}.md`
-file with the desired front-matter options as there is no language fallback.
+If your default language has an `_index.md` in a directory, you will need to add an
+`_index.{language_alias}.md` file with the desired front-matter options as there is no
+language fallback.
 
 ## Output
-Zola outputs the translated content with a base URL of `{base_url}/{code}/`.
-The only exception to this is if you are setting a translated page `path` directly in the front matter.
+For the translations, Zola outputs the content with a base URL of `{base_url}/{language_alias}/`.
+
+An exception is if you set a path in the front matter, that path will be used.
+
+## In themes
+TODO

--- a/docs/content/documentation/content/overview.md
+++ b/docs/content/documentation/content/overview.md
@@ -113,6 +113,6 @@ To add an image to the `https://mywebsite.com/blog/configuration` page, you have
  static directory rather than in the content directory. The choice depends on your organizational needs.
  *  Or you could save the image to some arbitrary directory within the static directory. For example,
  you could save all images to `static/images`.  Using this approach, you can no longer use relative links. Instead,
- you must use an absolute link to `images/[filename]` to access your
+ you must use an absolute link to `images/{filename}` to access your
  image. This might be preferable for small sites or for sites that associate images with
  multiple pages (e.g., logo images that appear on every page).

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -3,43 +3,37 @@ title = "Page"
 weight = 30
 +++
 
-A page is any file ending with `.md` in the `content` directory, except files
-named `_index.md`.
+A page is any file ending with `.md` in the `content` directory, except for `_index.md`
+[section definitions](@/documentation/content/section.md).
 
-If a file ending with `.md` is named `index.md`, it will generate a page
-with the name of its directory (for example, `/content/about/index.md` would
-create a page at `[base_url]/about`). (Note the lack of an underscore; if the file
-were named `_index.md`, then it would create a **section** at `[base_url]/about`, as
-discussed in a previous part of this documentation.  In contrast, naming the file `index.md` will
-create a **page** at `[base_url]/about`).
+If a file is named `index.md`, it will generate a page with the name of its containing directory.
+This is equivalent to creating a `.md` file with the same name as the parent directory, but also
+allows you to use asset co-location, as discussed in the
+[overview](@/documentation/content/overview.md#asset-colocation) section.
+For example, both `content/about.md` and `content/about/index.md` produce a page at `{base_url}/about`.
+This also means you can't have both of these files at the same time.
 
 If the file is given any name *other* than `index.md` or `_index.md`, then it will
 create a page with that name (without the `.md`). For example, naming a file in the root of your
-content directory `about.md` would create a page at `[base_url]/about`.
-Another exception to this rule is that a filename starting with a datetime (YYYY-mm-dd or [an RFC3339 datetime](https://www.ietf.org/rfc/rfc3339.txt)) followed by
-an underscore (`_`) or a dash (`-`) will use that date as the page date, unless already set
-in the front matter. The page name will be anything after `_`/`-`, so the file `2018-10-10-hello-world.md` will
-be available at `[base_url]/hello-world`. Note that the full RFC3339 datetime contains colons, which is not a valid
-character in a filename on Windows.
+content directory `about.md` will create a page at `{base_url}/about`. Filenames containing
+special characters are optionally sanitized as described [below](#output-paths). Filenames should
+**not** contain dots, because the part after the last dot will be treated a language name, and
+so will be removed.
 
-As you can see, creating an `about.md` file is equivalent to creating an
-`about/index.md` file.  The only difference between the two methods is that creating
-the `about` directory allows you to use asset co-location, as discussed in the
-[overview](@/documentation/content/overview.md#asset-colocation) section.
+Filenames beginning with a date followed by an underscore (`_`) or dash (`-`), or ending with a
+dot (`.`) followed by a language name are treated specially. These tell information to Zola
+about the page, similarly to the front matter, and are stripped from the output. See
+[below](#path-from-filename) how to use these.
 
 ## Output paths
 
-For any page within your content folder, its output path will be defined by either:
-
-- its `slug` frontmatter key
+For any page within your content folder, its output path will be defined by either
+- its `slug` frontmatter key if set, or
 - its filename
 
-Either way, these proposed path will be sanitized before being used.
-If `slugify.paths` is set to `"on"` in the site's config - the default - paths are [slugified](https://en.wikipedia.org/wiki/Clean_URL#Slug). 
-If it is set to `"safe"`, only sanitation is performed, with the following characters being removed: `<`, `>`, `:`, `/`, `|`, `?`, `*`, `#`, `\\`, `(`, `)`, `[`, `]` as well as newlines and tabulations. This ensures that the path can be represented on all operating systems.
-Additionally, trailing whitespace and dots are removed and whitespaces are replaced by `_`.
-
-If `slugify.paths` is set to `"off"`, no modifications are made.
+Either way, these proposed path will be sanitized before being used. See the
+[configuration documentation](@/documentation/getting-started/configuration.md#slugification-strategies)
+for how it's done.
 
 If you want URLs containing non-ASCII characters, `slugify.paths` needs to be set to `"safe"` or `"off"`.
 
@@ -57,20 +51,32 @@ slug = "femmes-libres-libération-kurde"
 This is my article.
 ```
 
-This frontmatter will output the article to `[base_url]/zines/femmes-libres-libération-kurde` with `slugify.paths` set to `"safe"` or `"off"`, and to `[base_url]/zines/femmes-libres-liberation-kurde` with the default value for `slugify.paths` of `"on"`.
+This frontmatter will output the article to `{base_url}/zines/femmes-libres-libération-kurde` with
+`slugify.paths` set to `"safe"` or `"off"`, and to `{base_url}/zines/femmes-libres-liberation-kurde`
+with the default value for `slugify.paths` of `"on"`.
 
 ### Path from filename
 
-When the article's output path is not specified in the frontmatter, it is extracted from the file's path in the content folder. Consider a file `content/foo/bar/thing.md`. The output path is constructed:
+When the article's output path is not specified in the frontmatter, it is extracted from the file's
+path in the content folder.
+Consider a file `content/foo/bar/thing.md`. The output path is constructed:
 - if the filename is `index.md`, its parent folder name (`bar`) is used as output path
-- otherwise, the output path is extracted from `thing` (the filename without the `.md` extension)
+- otherwise, the output path is extracted from `thing` path (the filename without the `.md` extension)
 
-If the path found starts with a datetime string (`YYYY-mm-dd` or [a RFC3339 datetime](https://www.ietf.org/rfc/rfc3339.txt)) followed by an underscore (`_`) or a dash (`-`), this date is removed from the output path and will be used as the page date (unless already set in the front-matter). Note that the full RFC3339 datetime contains colons, which is not a valid character in a filename on Windows.
+If the path found starts with a datetime string (`YYYY-mm-dd` or [a RFC3339 datetime](https://www.ietf.org/rfc/rfc3339.txt))
+followed by an underscore (`_`) or a dash (`-`), this date is removed from the output path and
+will be used as the page date, unless already set in the front-matter. Note that the full RFC3339
+datetime contains colons, which is not a valid character in a filename on Windows.
 
-The output path extracted from the file path is then slugified or not, depending on the `slugify.paths` config, as explained previously.
+If a filename contains a dot (beside the one for `.md`), the part after the dot is removed, and will
+be set as the page's language. This must match one of the `language_alias`es or language codes
+set in the [configuration](@/documentation/content/multilingual.md#configuration).
+
+The output path extracted from the file path is then optionally slugified, depending on the `slugify.paths`
+config, as explained previously.
 
 **Example:**
-The file `content/blog/2018-10-10-hello-world.md` will yield a page at `[base_url]/blog/hello-world`.
+The file `content/blog/2018-10-10-hello-world.md` will yield a page at `{base_url}/blog/hello-world`.
 
 ## Front matter
 
@@ -129,7 +135,7 @@ in_search_index = true
 template = "page.html"
 
 # The taxonomies for this page. The keys need to be the same as the taxonomy
-# names configured in `config.toml` and the values are an array of String objects. For example,
+# names configured in `config.toml` and the terms are an arry of Strings. For example,
 # tags = ["rust", "web"].
 [taxonomies]
 

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -14,6 +14,9 @@ not have any content or metadata.  If you would like to add content or metadata,
 `_index.md` file at the root of the `content` directory and edit it just as you would edit any other
 `_index.md` file; your `index.html` template will then have access to that content and metadata.
 
+Just like with pages, you can set a language via the filename (e.g. `_index.en.md`). Dates, however,
+aren't applicable to sections.
+
 Any non-Markdown file in a section directory is added to the `assets` collection of the section, as explained in the
 [content overview](@/documentation/content/overview.md#asset-colocation). These files are then available in the
 Markdown file using relative links.

--- a/docs/content/documentation/content/taxonomies.md
+++ b/docs/content/documentation/content/taxonomies.md
@@ -3,42 +3,67 @@ title = "Taxonomies"
 weight = 90
 +++
 
-Zola has built-in support for taxonomies.
+Zola has built-in support for *taxonomies*.
+
+Taxonomies are user-defined groupings of content. Each page and section can belong to zero or more
+*terms* in a taxonomy. This is different from [sections](@/documentation/content/section.md) where
+it can belong to only one.
+
+On most sites, you might come across two taxonomies: `tags` and `categories`. Usually, a page can
+have a single category, and can have multiple tags. However, this is not a requirement.
 
 ## Configuration
 
-A taxonomy has five variables:
+A taxonomy has four variables:
 
-- `name`: a required string that will be used in the URLs, usually the plural version (i.e., tags, categories, etc.)
+- `name`: a required string that will be used in the URLs, usually the plural form (i.e., tags, categories, etc.)
 - `paginate_by`: if this is set to a number, each term page will be paginated by this much.
 - `paginate_path`: if set, this path will be used by the paginated page and the page number will be appended after it.
 For example the default would be page/1.
-- `feed`: if set to `true`, a feed (atom by default) will be generated for each term.
-- `lang`: only set this if you are making a multilingual site and want to indicate which language this taxonomy is for
+- `feed`: if set to `true`, a feed (Atom by default) will be generated for each term.
 
-Insert into the configuration file (config.toml):
+Taxonomies only apply to pages in a particular language. Multilingual sites can have different
+taxonomies for each language. These are defined in the corresponding `[languages.{code}]` section.
+
+Insert into the configuration file (`config.toml`):
 
 ⚠️ Place the taxonomies key in the main section and not in the `[extra]` section
 
 **Example 1:** (one language)
 
 ```toml
-taxonomies = [ name = "categories", rss = true ]
+taxonomies = [
+    {name = "categories", feed = true},
+    {name = "tags"}
+]
 ```
 
 **Example 2:** (multilingual site)
 
 ```toml
+default_language = "en"
+
 taxonomies = [
-    {name = "tags", lang = "fr"},
-    {name = "tags", lang = "eo"},
-    {name = "tags", lang = "en"},
+    {name = "tags"}
+]
+
+[langugages]
+
+    [languages.fr]
+    taxonomies = [
+        {name = "tags"}
+    ]
+
+    [languages."de-AT"]
+    taxonomies = [
+        {name = "tags"}
+    ]
 ]
 ```
 
 ## Using taxonomies
 
-Once the configuration is done, you can then set taxonomies in your content and Zola will pick them up:
+Once the configuration is done, you can then set taxonomies in the front matter and Zola will pick them up:
 
 **Example:**
 
@@ -46,6 +71,7 @@ Once the configuration is done, you can then set taxonomies in your content and 
 +++
 title = "Writing a static-site generator in Rust"
 date = 2019-08-15
+
 [taxonomies]
 tags = ["rust", "web"]
 categories = ["programming"]
@@ -54,14 +80,17 @@ categories = ["programming"]
 
 ## Output paths
 
-In a similar manner to how section and pages calculate their output path:
-- the taxonomy name is never slugified
-- the taxonomy term (e.g. as specific tag) is slugified when `slugify.taxonomies` is enabled (`"on"`, the default) in the configuration
+Similarly to how sections and pages compute their path,
+- the taxonomy name is **not** slugified
+- the taxonomy term (e.g. as specific tag) is slugified when `slugify.taxonomies` is enabled
+  (`"on"` by default) in the configuration
 
 The taxonomy pages are then available at the following paths:
 
 ```plain
-$BASE_URL/$NAME/ (taxonomy)
-$BASE_URL/$NAME/$SLUG (taxonomy entry)
+{base_url}/{name}/        (taxonomy)
+{base_url}/{name}/{term}  (taxonomy entry)
 ```
-Note that taxonomies are case insensitive so terms that have the same slug will get merged, e.g. sections and pages containing the tag "example" will be shown in the same taxonomy page as ones containing "Example" 
+Note that taxonomies are case insensitive so terms that have the same slug will get merged.
+For example, sections and pages with the tag "example" will be shown in the same taxonomy page
+as those with "Example".

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -82,7 +82,8 @@ taxonomies = []
 #
 languages = []
 
-# When set to "true", the Sass files in the `sass` directory are compiled.
+# When set to "true", the Sass files in the `sass` directory in the site root are compiled.
+# Sass files in theme directories are always compiled.
 compile_sass = false
 
 # A list of glob patterns specifying asset files to ignore when the content

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -16,8 +16,8 @@ Here are the current `config.toml` sections:
 2. link_checker
 3. slugify
 4. search
-5. translations
-6. extra
+5. extra
+6. languages
 
 **Only the `base_url` variable is mandatory**. Everything else is optional. All configuration variables
 used by Zola as well as their default values are listed below:
@@ -27,11 +27,18 @@ used by Zola as well as their default values are listed below:
 base_url = "mywebsite.com"
 
 # The site title and description; used in feeds by default.
+# Can be set for each language separately.
 title = ""
 description = ""
 
 # The default language; used in feeds.
+# Must be a valid language identifier, similarly to HTML's lang attribute.
 default_language = "en"
+# A "friendly" name for the language. Useful for setting a shorter name or
+# keeping old links that did not use valid language codes working.
+# URLs for translations will use this name. Can be set for each language.
+# See "Multilingual sites" for more information.
+language_alias = ""
 
 # The site theme to use.
 theme = ""
@@ -44,6 +51,7 @@ highlight_code = false
 highlight_theme = "base16-ocean-dark"
 
 # When set to "true", a feed is automatically generated.
+# Can be set for each language separately.
 generate_feed = false
 
 # The filename to use for the feed. Used as the template filename, too.
@@ -53,6 +61,7 @@ generate_feed = false
 
 # The number of articles to include in the feed. All items are included if
 # this limit is not set (the default).
+# Can be set for each language separately.
 # feed_limit = 20
 
 # When set to "true", files in the `static` directory are hard-linked. Useful for large
@@ -62,25 +71,15 @@ generate_feed = false
 # hard_link_static = false
 
 # The taxonomies to be rendered for the site and their configuration.
+# Set for each language separately.
 # Example:
 #     taxonomies = [
 #       {name = "tags", feed = true}, # each tag will have its own feed
-#       {name = "tags", lang = "fr"}, # you can have taxonomies with the same name in multiple languages
 #       {name = "categories", paginate_by = 5},  # 5 items per page for a term
 #       {name = "authors"}, # Basic definition: no feed or pagination
 #     ]
 #
 taxonomies = []
-
-# The additional languages for the site.
-# Example:
-#     languages = [
-#       {code = "fr", feed = true}, # there will be a feed for French content
-#       {code = "fr", search = true}, # there will be a Search Index for French content
-#       {code = "it"}, # there won't be a feed for Italian content
-#     ]
-#
-languages = []
 
 # When set to "true", the Sass files in the `sass` directory in the site root are compiled.
 # Sass files in theme directories are always compiled.
@@ -116,43 +115,78 @@ taxonomies = "on"
 anchors = "on"
 
 # When set to "true", a search index is built from the pages and section
-# content for `default_language`.
+# content. Can be set for each language separately.
 build_search_index = false
 
+# Configures how search indexes will be generated if `build_search_index` is set
+# Can be set for each language separately.
 [search]
-# Whether to include the title of the page/section in the index
+# Whether to include the title of the page/section
 include_title = true
-# Whether to include the description of the page/section in the index
+# Whether to include the description of the page/section
 include_description = false
-# Whether to include the rendered content of the page/section in the index
+# Whether to include the rendered content of the page/section
 include_content = true
-# At which character to truncate the content to. Useful if you have a lot of pages and the index would
-# become too big to load on the site. Defaults to not being set.
+# At which character to truncate the content to. Useful if you have a lot of pages and
+# the index would become too big to load on the site. Defaults to not being set.
 # truncate_content_length = 100
 
-# Optional translation object. Keys should be language codes.
-# Optional translation object. The key if present should be a language code.
-# Example:
-#     default_language = "fr"
+# You can put any kind of data here. The data will be accessible in all templates.
 #
-#     [translations]
-#     [translations.fr]
-#     title = "Un titre"
+# Can be set for each language separately. If a key is not present for a specific
+# language, the value from the default language will be used.
 #
-#     [translations.en]
-#     title = "A title"
-#
-[translations]
-
-# You can put any kind of data here. The data
-# will be accessible in all templates
 # Example:
 #     [extra]
 #     author = "Famous author"
+#     # other types are allowed, too
+#     pi = 3.14
+#     release_date = "<add in the future>"
+#
+#     # nested tables are allowed, too
+#     [extra.social]
+#         github = "Keats"
 #
 # author value will be available using {{ config.extra.author }} in templates
-#
+# github will be available using {{ config.extra.social.github }} in templates
 [extra]
+
+# Settings that can be set for each language separately.
+#
+# See the description of variables above to see what can be set here, and how they fall back
+# when not set for a specific language.
+#
+# It is a table of tables, where the keys are language codes. See "Multilingual sites" for
+# more information.
+#
+# Below is a non-exhaustive example:
+#     [languages]
+#         [languages."de-AT"]
+#         language_alias = "german"
+#
+#         title = "Eine mehrsprachige Seite"
+#         description = ""
+#
+#         taxonomies = [
+#             {name = "kategorie", feed = "false" }
+#         ]
+#
+#         generate_feed = true
+#         feed_limit = 20
+#
+#         build_search_index = false
+#         [languages."de-AT".search]
+#             truncate_content_length - 100
+#
+#         [languages."de-AT".extra]
+#             author = "beruehmter Autor"
+#
+#         [languages.fr]
+#
+# Templates can access these values for translated pages just as if these were set for
+# the default language. Themes and templates do not have to take extra measures for
+# working with translated content.
+[languages]
 ```
 
 ## Syntax highlighting
@@ -204,11 +238,13 @@ If you want a theme not listed above, please open an issue or a pull request on 
 
 ## Slugification strategies
 
-By default, Zola will turn every path, taxonomies and anchors to a slug, an ASCII representation with no special characters.
-You can however change that strategy for each kind of item, if you want UTF-8 characters in your URLs for example. There are 3 strategies:
+By default, Zola will turn every path, taxonomy and anchor to a slug, an ASCII representation with no special characters.
+You can however change that strategy for each kind of item; for example, to have UTF-8 characters in your URLs.
+There are 3 strategies:
 
-- `on`: the default one, everything is turned into a slug
-- `safe`: characters that cannot exist in files on Windows (`<>:"/\|?*`) or Unix (`/`) are removed, everything else stays
+- `on`: the default one, everything is turned into a [slug](https://en.wikipedia.org/wiki/Clean_URL#Slug)
+- `safe`: characters that cannot exist in filenames on some systems are removed. These are: `<`, `>`, `:`, `/`, `|`, `?`,
+  `*`, `#`, <code>\\</code>, `(`, `)`, `[`, `]`, newlines, and tabulations. Any leading spaces and dots (`.`) are removed.
 - `off`: nothing is changed, your site might not build on some OS and/or break various URL parsers
 
 Since there are no filename issues with anchors, the `safe` and `off` strategies are identical in their case: the only change

--- a/docs/content/documentation/getting-started/directory-structure.md
+++ b/docs/content/documentation/getting-started/directory-structure.md
@@ -10,12 +10,13 @@ After running `zola init`, you should see the following structure in your direct
 .
 ├── config.toml
 ├── content
+├── locales
 ├── sass
 ├── static
 ├── templates
 └── themes
 
-5 directories, 1 file
+6 directories, 1 file
 ```
 
 Here's a high-level overview of each of these directories and `config.toml`.
@@ -30,6 +31,14 @@ Each child directory of the `content` directory represents a [section](@/documen
 that contains [pages](@/documentation/content/page.md) (your `.md` files).
 
 To learn more, read the [content overview page](@/documentation/content/overview.md).
+
+## `locales`
+Contains optional [Fluent](https://www.projectfluent.org/) localization resources. Users may replace a theme's locales
+with the files contained here. If it exists, `core.ftl` will be loaded for all locales. Resources from subdirectories
+are only loaded if the directory's name matches or is a variant (different region or script) of the page/section's
+language.
+
+To learn more, read the [multilingual site documentation](@/documentation/content/multilingual.md).
 
 ## `sass`
 Contains the [Sass](http://sass-lang.com) files to be compiled. Non-Sass files will be ignored.

--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -30,6 +30,13 @@ Zola has been available in the official repositories since Fedora 29.
 $ sudo dnf install zola
 ```
 
+### Void Linux
+Zola is available in the official Void Linux repositories.
+
+```sh
+$ sudo xbps-install zola
+```
+
 ### FreeBSD
 
 Zola is available in the official package repository.

--- a/docs/content/documentation/getting-started/overview.md
+++ b/docs/content/documentation/getting-started/overview.md
@@ -39,6 +39,7 @@ You will be asked a few questions.
 ```bash
 ├── config.toml
 ├── content
+├── locales
 ├── sass
 ├── static
 ├── templates

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -87,7 +87,7 @@ async fn handle_request(req: Request<Body>, root: PathBuf) -> Result<Response<Bo
     match result {
         ResolveResult::MethodNotMatched => return Ok(method_not_allowed()),
         ResolveResult::NotFound | ResolveResult::UriNotMatched => {
-            let content_404 = SITE_CONTENT.read().unwrap().get("404.html").map(|x| x.clone());
+            let content_404 = SITE_CONTENT.read().unwrap().get("404.html").cloned();
             return Ok(not_found(content_404));
         }
         _ => (),

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -255,7 +255,7 @@ pub fn serve(
         if should_watch {
             watcher
                 .watch(root_dir.join(entry), RecursiveMode::Recursive)
-                .map_err(|e| ZolaError::chain(format!("Can't watch `{}` for changes in folder `{}`. Do you have correct permissions?", entry, root_dir.display()), e))?;
+                .map_err(|e| ZolaError::chain(format!("Can't watch `{}` for changes in folder `{}`. Does it exist, and do you have correct permissions?", entry, root_dir.display()), e))?;
             watchers.push(entry.to_string());
         }
     }

--- a/test_site/templates/index.html
+++ b/test_site/templates/index.html
@@ -8,6 +8,8 @@
             </article>
         {% endfor %}
     </div>
+    <!-- Next line is meant to test inner html chars (see https://github.com/getzola/zola/issues/1152) -->
+    <p> <<< </p>
 {% endblock content %}
 
 {% block script %}

--- a/test_site_i18n/config.toml
+++ b/test_site_i18n/config.toml
@@ -17,15 +17,21 @@ generate_feed = true
 
 taxonomies = [
     {name = "authors", feed = true},
-    {name = "auteurs", lang = "fr"},
     {name = "tags"},
-    {name = "tags", lang = "fr"},
 ]
 
-languages = [
- {code = "fr", feed = true},
- {code = "it", feed = false, search = true },
+[languages.fr]
+generate_feed = true
+build_search_index = false
+taxonomies = [
+    {name = "auteurs"},
+    {name = "tags"},
 ]
+
+
+[languages.it]
+generate_feed = false
+build_search_index = true
 
 [extra]
 # Put all your custom variables here


### PR DESCRIPTION
This pull request implements the redesigned localization system as described in my [forum post].

In summary, the goal is to be transparent towards templates, but customizable and explicit towards users. A [Project Fluent]-based string translation system will eventually be introduced that's similar to #1040 by @XAMPPRocky.

See the commit messages for an in-depth changelog.

# To-do
- [X] Refactor existing code
- [ ] Merge `extra` from page/section header?? + language in front matter
- [x] Add proper linking in doc comments
- [ ] Add more tests
- [x] Add fluent function
- [ ] Load locales from both site and theme
- [ ] Generate Fluent stuff on init
- [ ] Reduce the amount of `clone()`s (kind of done)
- [ ] User testing
- [X] Add user documentation
- [ ] Add template API documentation
- [ ] Create a demo theme or internationalize an existing theme

[forum post]: https://zola.discourse.group/t/rfc-internationalization-system-rework/546
[Project Fluent]: https://www.projectfluent.org/