### PR TITLE
Strip unc if it exists, fix #1110 #1129

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
               rustup_toolchain: stable
             linux-pinned:
               imageName: 'ubuntu-16.04'
-              rustup_toolchain: 1.43.0
+              rustup_toolchain: 1.45.2
         pool:
           vmImage: $(imageName)
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
               rustup_toolchain: stable
             linux-pinned:
               imageName: 'ubuntu-16.04'
-              rustup_toolchain: 1.45.2
+              rustup_toolchain: 1.45
         pool:
           vmImage: $(imageName)
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
               rustup_toolchain: stable
             linux-pinned:
               imageName: 'ubuntu-16.04'
-              rustup_toolchain: 1.45
+              rustup_toolchain: 1.45.0
         pool:
           vmImage: $(imageName)
         steps:

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -285,7 +285,7 @@ mod tests {
         }
         create_dir(&dir).expect("Could not create test directory");
         assert_eq!(
-            &canonicalize(Path::new(&dir)).unwrap(),
+            canonicalize(Path::new(&dir)).unwrap().to_str().unwrap(),
             "\\\\?\\C:\\Users\\VssAdministrator\\AppData\\Local\\Temp\\new_project"
         );
 


### PR DESCRIPTION
Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
* [X] Are you doing the PR on the `next` branch?

Explanation:
Remove unc on windows platform see #1110 .
Sorry I mistakenly closed the previous PR on that topic #1129 .
 
So here is the new one I did 3 things:
* Bump to rust 1.45 version which is the minimal one required.
* Put a comment as requested on the LOCAL_UNC const.
* Add a new test that will fail as soon as the canonicalize function will be fixed by the rust team. So this workaround will have to be removed.

