### PR TITLE
fix `get_taxonomy_url` to handle merged taxonomies properly

### DIFF
--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -68,7 +68,11 @@ pub fn register_early_global_fns(site: &mut Site) {
     site.tera.register_function("trans", global_fns::Trans::new(site.config.clone()));
     site.tera.register_function(
         "get_taxonomy_url",
-        global_fns::GetTaxonomyUrl::new(&site.config.default_language, &site.taxonomies),
+        global_fns::GetTaxonomyUrl::new(
+            &site.config.default_language,
+            &site.taxonomies,
+            site.config.slugify.taxonomies,
+        ),
     );
     site.tera.register_function(
         "get_file_hash",


### PR DESCRIPTION
This is a small bug fix. The `get_taxonomy_url` wasn't handling the newly merged taxonomies properly, this PR fixes that, and adds a test for it. Prior to this fix, Zola will crash on taxonomies that would be merged if `get_taxonomy_url` is used. 
