### PR TITLE
Use trim_start_matches instead of strip_prefix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
               rustup_toolchain: stable
             linux-pinned:
               imageName: 'ubuntu-16.04'
-              rustup_toolchain: 1.45.0
+              rustup_toolchain: 1.43.0
         pool:
           vmImage: $(imageName)
         steps:

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -69,10 +69,7 @@ pub fn is_directory_quasi_empty(path: &Path) -> Result<bool> {
 // Remove the unc part of a windows path
 fn strip_unc(path: &PathBuf) -> String {
     let path_to_refine = path.to_str().unwrap();
-    match path_to_refine.strip_prefix(LOCAL_UNC) {
-        Some(path_stripped) => path_stripped.to_string(),
-        None => path_to_refine.to_string(),
-    }
+    path_to_refine.trim_start_matches(LOCAL_UNC).to_string()
 }
 
 pub fn create_new_project(name: &str, force: bool) -> Result<()> {


### PR DESCRIPTION
Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [NA] Have you created/updated the relevant documentation page(s)?

Explanations:
- This allow to not bump the pinned version to 1.45.0.
- Change this, despite trim_start_matches returns a &str and not an Option, which I
  like less.

