### PR TITLE
Add Void Linux installation instructions

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -30,6 +30,13 @@ Zola has been available in the official repositories since Fedora 29.
 $ sudo dnf install zola
 ```
 
+### Void Linux
+Zola is available in the official Void Linux repositories.
+
+```sh
+$ sudo xbps-install zola
+```
+
 ### FreeBSD
 
 Zola is available in the official package repository.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

It appears that Void Linux installation instructions were removed from the docs when the project was renamed, presumably because Void hadn't update its package to reflect the change at the time. 

