### PR TITLE
Allow site path to contain underscores

### DIFF
--- a/components/site/src/sass.rs
+++ b/components/site/src/sass.rs
@@ -44,19 +44,7 @@ fn compile_sass_glob(
     extension: &str,
     options: &Options,
 ) -> Result<Vec<(PathBuf, PathBuf)>> {
-    let glob_string = format!("{}/**/*.{}", sass_path.display(), extension);
-    let files = glob(&glob_string)
-        .expect("Invalid glob for sass")
-        .filter_map(|e| e.ok())
-        .filter(|entry| {
-            !entry
-                .as_path()
-                .iter()
-                .last()
-                .map(|c| c.to_string_lossy().starts_with('_'))
-                .unwrap_or(false)
-        })
-        .collect::<Vec<_>>();
+    let files = get_non_partial_scss(sass_path, extension);
 
     let mut compiled_paths = Vec::new();
     for file in files {
@@ -75,4 +63,49 @@ fn compile_sass_glob(
     }
 
     Ok(compiled_paths)
+}
+
+fn get_non_partial_scss(sass_path: &Path, extension: &str) -> Vec<PathBuf> {
+    let glob_string = format!("{}/**/*.{}", sass_path.display(), extension);
+    glob(&glob_string)
+        .expect("Invalid glob for sass")
+        .filter_map(|e| e.ok())
+        .filter(|entry| {
+            !entry
+                .as_path()
+                .iter()
+                .last()
+                .map(|c| c.to_string_lossy().starts_with('_'))
+                .unwrap_or(true)
+        })
+        .collect::<Vec<_>>()
+}
+
+#[test]
+fn test_get_non_partial_scss() {
+    use std::env;
+
+    let mut path = env::current_dir().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
+    path.push("test_site");
+    path.push("sass");
+
+    let result = get_non_partial_scss(&path, "scss");
+
+    assert!(result.len() != 0);
+    assert!(result.iter().filter_map(|path| path.file_name()).any(|file| file == "scss.scss"))
+}
+#[test]
+fn test_get_non_partial_scss_underscores() {
+    use std::env;
+
+    let mut path = env::current_dir().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
+    path.push("test_site");
+    path.push("_dir_with_underscores");
+    path.push("..");
+    path.push("sass");
+
+    let result = get_non_partial_scss(&path, "scss");
+
+    assert!(result.len() != 0);
+    assert!(result.iter().filter_map(|path| path.file_name()).any(|file| file == "scss.scss"))
 }

--- a/components/site/src/sass.rs
+++ b/components/site/src/sass.rs
@@ -49,7 +49,12 @@ fn compile_sass_glob(
         .expect("Invalid glob for sass")
         .filter_map(|e| e.ok())
         .filter(|entry| {
-            !entry.as_path().components().any(|c| c.as_os_str().to_string_lossy().starts_with('_'))
+            !entry
+                .as_path()
+                .iter()
+                .last()
+                .map(|c| c.to_string_lossy().starts_with('_'))
+                .unwrap_or(false)
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
This fixes a regression introduced in `0.12`.
My path to the zola site looks something like `~/projects/_personal/blog`
Because of the `_personal` contains underscore, `site.css` is not generated.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?

