### PR TITLE
Fix a crash when --output_dir is used with serve

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -547,7 +547,7 @@ impl Site {
                     p.as_os_str().to_string_lossy().replace("public/", "/")
                 } else {
                     // TODO" remove unwrap
-                    let p = current_path.strip_prefix("public").unwrap();
+                    let p = current_path.strip_prefix(&self.output_path).unwrap();
                     p.as_os_str().to_string_lossy().into_owned()
                 }
                 .trim_end_matches('/')


### PR DESCRIPTION
This is a breakage from 0.11 to 0.12

Output before (crashes):
```
$ cargo run -- -r test_site serve --output-dir /tmp/output
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/zola -r test_site serve --output-dir /tmp/output`
Building site...
-> Creating 32 pages (1 orphan), 11 sections, and processing 0 images
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: StripPrefixError(())', components/site/src/lib.rs:550:65
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Output after (serves page):
```
$ cargo run -- -r test_site serve --output-dir /tmp/output
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/zola -r test_site serve --output-dir /tmp/output`
Building site...
-> Creating 32 pages (1 orphan), 11 sections, and processing 0 images
Done in 1.1s.

Listening for changes in /home/holy/tmp/zola/test_site{config.toml, content, sass, static, templates, themes}
Press Ctrl+C to stop

Web server is available at http://127.0.0.1:1111

```

In the memory mode, currently "public" is hardcoded as the prefix, which is not correct.

Slightly above my change, there is another instance of "public/" being hardcoded. Should we change that too?

I do not have a page which triggers that code path, so could not test that.

Is there a test which runs the whole binary in serve mode which I could extend to also check this not to regress again in the CI?

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

* [x] Are you doing the PR on the `next` branch?


