### PR TITLE
Fix #1165, improve situation for compile_sass errors

### DIFF
--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -82,7 +82,8 @@ taxonomies = []
 #
 languages = []
 
-# When set to "true", the Sass files in the `sass` directory are compiled.
+# When set to "true", the Sass files in the `sass` directory in the site root are compiled.
+# Sass files in theme directories are always compiled.
 compile_sass = false
 
 # A list of glob patterns specifying asset files to ignore when the content

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -255,7 +255,7 @@ pub fn serve(
         if should_watch {
             watcher
                 .watch(root_dir.join(entry), RecursiveMode::Recursive)
-                .map_err(|e| ZolaError::chain(format!("Can't watch `{}` for changes in folder `{}`. Do you have correct permissions?", entry, root_dir.display()), e))?;
+                .map_err(|e| ZolaError::chain(format!("Can't watch `{}` for changes in folder `{}`. Does it exist, and do you have correct permissions?", entry, root_dir.display()), e))?;
             watchers.push(entry.to_string());
         }
     }


### PR DESCRIPTION
This attempts to improve the situation for the issue in #1165.

- Updated `compile_sass` documentation.
- Update file watch failure message, add 'Does it exist?' notice.

Fixes #1165

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

