### PR TITLE
Implemented emoji aliases support in markdown files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gh-emoji"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17a050b7eb420553344e1cf1db648e8b584c79e98b74e6e6d119eeedd9ddcbc"
+dependencies = [
+ "phf",
+ "regex",
+]
+
+[[package]]
 name = "gif"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +1947,7 @@ dependencies = [
  "config",
  "errors",
  "front_matter",
+ "gh-emoji",
  "lazy_static",
  "link_checker",
  "pest",

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -104,6 +104,9 @@ pub struct Config {
     /// The search config, telling what to include in the search index
     pub search: search::Search,
 
+    /// Whether to render emoji aliases (e.g.: :smile: => 😄) in the markdown files
+    pub emoji_rendering: bool,
+
     /// All user params set in [extra] in the config
     pub extra: HashMap<String, Toml>,
 }
@@ -337,6 +340,7 @@ impl Default for Config {
             slugify: slugify::Slugify::default(),
             search: search::Search::default(),
             extra: HashMap::new(),
+            emoji_rendering: false,
         }
     }
 }

--- a/components/rendering/Cargo.toml
+++ b/components/rendering/Cargo.toml
@@ -15,6 +15,7 @@ pest = "2"
 pest_derive = "2"
 regex = "1"
 lazy_static = "1"
+gh-emoji = "1.0"
 
 errors = { path = "../errors" }
 front_matter = { path = "../front_matter" }

--- a/components/rendering/benches/all.rs
+++ b/components/rendering/benches/all.rs
@@ -17,12 +17,12 @@ Lorem markdownum litora, care ponto nomina, et ut aspicit gelidas sui et
 purpureo genuit. Tamen colla venientis [delphina](http://nil-sol.com/ecquis)
 Tusci et temptata citaeque curam isto ubi vult vulnere reppulit.
 
-- Seque vidit flendoque de quodam
-- Dabit minimos deiecto caputque noctis pluma
-- Leti coniunx est Helicen
-- Illius pulvereumque Icare inpositos
-- Vivunt pereo pluvio tot ramos Olenios gelidis
-- Quater teretes natura inde
+- :one: Seque vidit flendoque de quodam
+- :two: Dabit minimos deiecto caputque noctis pluma
+- :three: Leti coniunx est Helicen
+- :four: Illius pulvereumque Icare inpositos
+- :five: Vivunt pereo pluvio tot ramos Olenios gelidis
+- :six: Quater teretes natura inde
 
 ### A subsection
 
@@ -35,7 +35,7 @@ granum captantur potuisse Minervae, frugum.
 > Clivo sub inprovisoque nostrum minus fama est, discordia patrem petebat precatur
 absumitur, poena per sit. Foramina *tamen cupidine* memor supplex tollentes
 dictum unam orbem, Anubis caecae. Viderat formosior tegebat satis, Aethiopasque
-sit submisso coniuge tristis ubi!
+sit submisso coniuge tristis ubi! :exclamation:
 
 ## Praeceps Corinthus totidem quem crus vultum cape
 
@@ -68,7 +68,7 @@ And a shortcode:
 ### Another subsection
 Gotta make the toc do a little bit of work
 
-# A big title
+# A big title :fire:
 
 - hello
 - world
@@ -122,4 +122,17 @@ fn bench_render_shortcodes_one_present(b: &mut test::Bencher) {
     let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
 
     b.iter(|| render_shortcodes(CONTENT, &context));
+}
+
+#[bench]
+fn bench_render_content_no_shortcode_with_emoji(b: &mut test::Bencher) {
+    let tera = Tera::default();
+    let content2 = CONTENT.replace(r#"{{ youtube(id="my_youtube_id") }}"#, "");
+    let mut config = Config::default();
+    config.highlight_code = false;
+    config.emoji_rendering = true;
+    let permalinks_ctx = HashMap::new();
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+
+    b.iter(|| render_content(&content2, &context).unwrap());
 }

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -1036,3 +1036,28 @@ Again more text"#;
     let res = render_content(markdown_string, &context).unwrap();
     assert_eq!(res.body, expected);
 }
+
+#[test]
+fn can_render_emoji_alias() {
+    let permalinks_ctx = HashMap::new();
+    let mut config = Config::default();
+    config.emoji_rendering = true;
+    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content("Hello, World! :smile:", &context).unwrap();
+    assert_eq!(
+        res.body,
+        "<p>Hello, World! 😄</p>\n"
+    );
+}
+
+#[test]
+fn emoji_aliases_are_ignored_when_disabled_in_config() {
+    let permalinks_ctx = HashMap::new();
+    let config = Config::default();
+    let context = RenderContext::new(&ZOLA_TERA, &config, "", &permalinks_ctx, InsertAnchor::None);
+    let res = render_content("Hello, World! :smile:", &context).unwrap();
+    assert_eq!(
+        res.body,
+        "<p>Hello, World! :smile:</p>\n"
+    );
+}

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -61,6 +61,10 @@ generate_feed = false
 # files are always copied, regardless of this setting.
 # hard_link_static = false
 
+# When set to "true", emoji aliases translated to their corresponding
+# Unicode emoji equivalent in the rendered Markdown files. (e.g.: :smile: => 😄)
+# emoji_rendering = false
+
 # The taxonomies to be rendered for the site and their configuration.
 # Example:
 #     taxonomies = [


### PR DESCRIPTION
## Code changes
- Implemented emoji aliases substitution based on gh-emoji crate
- Added config option to control emoji substitution logic (_emoji_rendering_ bool value)
- Update documentation page with the emoji_rendering option description

Fixes #292



