### PR TITLE
Fixed site component benches compilation

### DIFF
--- a/components/site/benches/site.rs
+++ b/components/site/benches/site.rs
@@ -71,7 +71,7 @@ fn bench_render_paginated(b: &mut test::Bencher) {
     let section = library.sections_values()[0];
     let paginator = Paginator::from_section(&section, &library);
 
-    b.iter(|| site.render_paginated(public, &paginator));
+    b.iter(|| site.render_paginated(Vec::new(), &paginator));
 }
 
 #[bench]


### PR DESCRIPTION
Fixed site benches compilation. It was failing due to the wrong first render_paginated argument.
This was a simple fix and the issues itself is a non-critical issue so I didn't bother to create the separate GitHub issue.

Fixed error message is:
```
error[E0308]: mismatched types
  --> components\site\benches\site.rs:74:37
   |
74 |     b.iter(|| site.render_paginated(public, &paginator));
   |                                     ^^^^^^ expected struct `Vec`, found `&PathBuf`
   |
   = note: expected struct `Vec<&str>`
           found reference `&PathBuf`

error: aborting due to previous error
```