### PR TITLE
Fix RSS block example in documentation

### DIFF
--- a/docs/content/documentation/templates/feeds/index.md
+++ b/docs/content/documentation/templates/feeds/index.md
@@ -48,7 +48,7 @@ As an example this is how it looks like using [Firefox](https://en.wikipedia.org
 You can enable posts autodiscovery modifying your blog `base.html` template adding the following code in between the `<head>` tags.
 ```html
 {% block rss %}
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml", trailing_slash=false) }}">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{/* get_url(path="rss.xml", trailing_slash=false) */}}">
 {% endblock %}
 ```
 You can as well use an Atom feed using `type="application/atom+xml"` and `path="atom.xml"`.
@@ -59,7 +59,7 @@ In order to enable the tag feeds as well, you can overload the `block rss` using
 ```html
 {% block rss %}
   {% set rss_path = "tags/" ~ term.name ~ "/rss.xml" %}
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path=rss_path, trailing_slash=false) }}">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{/* get_url(path=rss_path, trailing_slash=false) */}}">
 {% endblock rss %}
 ```
 Each tag page will refer to it's dedicated feed.


### PR DESCRIPTION
Copying the commit message here:

> This commit fixes a bug in the documentation for the feeds page which
> shows how to use the RSS block to enable feed autodiscovery.
> 
> The bug used an em space character instead of a space in one part of the
> code snippet. If a user were to copy the code snippet into their code as
> directed, the Zola build would fail with a parse error. The em space
> appears identical to a regular space in monospaced fonts, making the
> error seem mysterious or incorrect.
> 
> I believe the em space was used in order to prevent the shortcode from
> rendering, as the code snippet is just meant to show what the shortcode
> looks like. However, it is possible to escape the shortcode so that it
> renders correctly without causing confusion for the user who expects to
> be able to copy and paste it.
> 
> This commit replaces the em space in both code snippets with regular
> spaces and escapes the shortcodes.

I actually looked through the parser code and compared older Zola versions before I realised the problem was just a rogue space haha. Hopefully this will save others the confusion.

--

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?



