### PR TITLE
Make sections draftable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,10 +2205,12 @@ dependencies = [
  "search",
  "serde",
  "serde_derive",
+ "slotmap",
  "tempfile",
  "templates",
  "tera",
  "utils",
+ "walkdir",
 ]
 
 [[package]]

--- a/components/front_matter/src/section.rs
+++ b/components/front_matter/src/section.rs
@@ -22,6 +22,8 @@ pub struct SectionFrontMatter {
     /// Higher values means it will be at the end. Defaults to `0`
     #[serde(skip_serializing)]
     pub weight: usize,
+    /// whether the section is a draft
+    pub draft: bool,
     /// Optional template, if we want to specify which template to render for that section
     #[serde(skip_serializing)]
     pub template: Option<String>,
@@ -114,6 +116,7 @@ impl Default for SectionFrontMatter {
             aliases: Vec::new(),
             generate_feed: false,
             extra: Map::new(),
+            draft: false,
         }
     }
 }

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -8,6 +8,7 @@ include = ["src/**/*"]
 [dependencies]
 tera = "1"
 glob = "0.3"
+walkdir = "2"
 minify-html = "0.3.8"
 rayon = "1"
 serde = "1"
@@ -15,6 +16,7 @@ serde_derive = "1"
 sass-rs = "0.2"
 lazy_static = "1.1"
 relative-path = "1"
+slotmap = "0.4"
 
 errors = { path = "../errors" }
 config = { path = "../config" }

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -177,6 +177,9 @@ fn can_build_site_without_live_reload() {
     assert!(file_exists!(public, "nested_sass/sass.css"));
     assert!(file_exists!(public, "nested_sass/scss.css"));
 
+    assert!(!file_exists!(public, "secret_section/index.html"));
+    assert!(!file_exists!(public, "secret_section/page.html"));
+    assert!(!file_exists!(public, "secret_section/secret_sub_section/hello.html"));
     // no live reload code
     assert_eq!(
         file_contains!(public, "index.html", "/livereload.js?port=1112&amp;mindelay=10"),
@@ -210,7 +213,7 @@ fn can_build_site_without_live_reload() {
 
 #[test]
 fn can_build_site_with_live_reload_and_drafts() {
-    let (_, _tmp_dir, public) = build_site_with_setup("test_site", |mut site| {
+    let (site, _tmp_dir, public) = build_site_with_setup("test_site", |mut site| {
         site.enable_live_reload(1000);
         site.include_drafts();
         (site, true)
@@ -254,6 +257,15 @@ fn can_build_site_with_live_reload_and_drafts() {
     // Drafts are included
     assert!(file_exists!(public, "posts/draft/index.html"));
     assert!(file_contains!(public, "sitemap.xml", "draft"));
+
+    // drafted sections are included
+    let library = site.library.read().unwrap();
+    assert_eq!(library.sections().len(), 14);
+
+    assert!(file_exists!(public, "secret_section/index.html"));
+    assert!(file_exists!(public, "secret_section/draft-page/index.html"));
+    assert!(file_exists!(public, "secret_section/page/index.html"));
+    assert!(file_exists!(public, "secret_section/secret_sub_section/hello/index.html"));
 }
 
 #[test]

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -18,6 +18,9 @@ Any non-Markdown file in a section directory is added to the `assets` collection
 [content overview](@/documentation/content/overview.md#asset-colocation). These files are then available in the
 Markdown file using relative links.
 
+## Drafting
+Just like pages sections can be drafted by setting the `draft` option in the front matter. By default this is not done. When a section is drafted it's descendants like pages, subsections and assets will not be processed unless the `--drafts` flag is passed. Note that even pages that don't have a `draft` status will not be processed if one of their parent sections is drafted. 
+
 ## Front matter
 
 The `_index.md` file within a directory defines the content and metadata for that section.  To set
@@ -38,6 +41,9 @@ default values.
 title = ""
 
 description = ""
+
+# A draft section is only loaded if the `--drafts` flag is passed to `zola build`, `zola serve` or `zola check`.
+draft = false
 
 # Used to sort pages by "date", "weight" or "none". See below for more information.
 sort_by = "none"

--- a/test_site/content/secret_section/_index.md
+++ b/test_site/content/secret_section/_index.md
@@ -1,0 +1,4 @@
++++
+title="Drafted section"
+draft=true
++++

--- a/test_site/content/secret_section/draft-page.md
+++ b/test_site/content/secret_section/draft-page.md
@@ -1,0 +1,4 @@
++++
+title="drafted page in drafted section"
+draft=true
++++

--- a/test_site/content/secret_section/page.md
+++ b/test_site/content/secret_section/page.md
@@ -1,0 +1,3 @@
++++
+title="non draft page"
++++

--- a/test_site/content/secret_section/secret_sub_section/_index.md
+++ b/test_site/content/secret_section/secret_sub_section/_index.md
@@ -1,0 +1,3 @@
++++
+title="subsection of a secret section"
++++

--- a/test_site/content/secret_section/secret_sub_section/hello.md
+++ b/test_site/content/secret_section/secret_sub_section/hello.md
@@ -1,0 +1,3 @@
++++
+title="Is anyone ever going to read this?"
++++


### PR DESCRIPTION
This PR is in response to #927. With the current implementation the content directory is processed in a recursive infix order (basically like a classic tree walk). This did require a bit of an ugly loop, but has the added benefit that it skips processing drafted sections entirely which is a nice free performance save. It also has no impact on the default cases so almost all the tests could remain unchanged. 

Addition to the docs about this is quite short, but not sure how much else would be needed. Open to feedback.  I implemented this because I use an `unpublished` folder in my content for WIPs that I wanted to make a draft to make sure none of those would ever end up in the published website. Could add this as an example if that seems useful to people. 

Checklist:
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?
* [x] Have you created/updated the relevant documentation page(s)?



