### PR TITLE
Add shortcode 'invocation' variable to allow a shortcode to track how…

### DIFF
--- a/components/rendering/src/shortcode.rs
+++ b/components/rendering/src/shortcode.rs
@@ -114,7 +114,7 @@ fn render_shortcode(
         // Trimming right to avoid most shortcodes with bodies ending up with a HTML new line
         tera_context.insert("body", b.trim_end());
     }
-    tera_context.insert("invocation", &invocation_count);
+    tera_context.insert("nth", &invocation_count);
     tera_context.extend(context.tera_context.clone());
 
     let mut template_name = format!("shortcodes/{}.md", name);

--- a/components/rendering/src/shortcode.rs
+++ b/components/rendering/src/shortcode.rs
@@ -140,22 +140,14 @@ fn render_shortcode(
     }
 }
 
-struct InvocationTracker(HashMap<String, u32>);
-
-impl InvocationTracker {
-    fn new() -> Self {
-        InvocationTracker(HashMap::new())
-    }
-    fn get(&mut self, name: &str) -> u32 {
-        let invocation_number = self.0.entry(String::from(name)).or_insert(0);
-        *invocation_number += 1;
-        *invocation_number
-    }
-}
-
 pub fn render_shortcodes(content: &str, context: &RenderContext) -> Result<String> {
     let mut res = String::with_capacity(content.len());
-    let mut invocation_counts = InvocationTracker::new();
+    let mut invocation_map: HashMap<String, u32> = HashMap::new();
+    let mut get_invocation_count = |name: &str| {
+        let invocation_number = invocation_map.entry(String::from(name)).or_insert(0);
+        *invocation_number += 1;
+        *invocation_number
+    };
 
     let mut pairs = match ContentParser::parse(Rule::page, content) {
         Ok(p) => p,
@@ -205,7 +197,7 @@ pub fn render_shortcodes(content: &str, context: &RenderContext) -> Result<Strin
                     &name,
                     &args,
                     context,
-                    invocation_counts.get(&name),
+                    get_invocation_count(&name),
                     None,
                 )?);
             }
@@ -219,7 +211,7 @@ pub fn render_shortcodes(content: &str, context: &RenderContext) -> Result<Strin
                     &name,
                     &args,
                     context,
-                    invocation_counts.get(&name),
+                    get_invocation_count(&name),
                     Some(body),
                 )?);
             }

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -1061,3 +1061,33 @@ fn emoji_aliases_are_ignored_when_disabled_in_config() {
         "<p>Hello, World! :smile:</p>\n"
     );
 }
+
+#[test]
+fn invocation_count_increments_in_shortcode() {
+    let permalinks_ctx = HashMap::new();
+    let mut tera = Tera::default();
+    tera.extend(&ZOLA_TERA).unwrap();
+
+    let shortcode_template_a = r#"<p>a: {{ invocation }}</p>"#;
+    let shortcode_template_b = r#"<p>b: {{ invocation }}</p>"#;
+
+    let markdown_string = r#"{{ a() }}
+{{ b() }}
+{{ a() }}
+{{ b() }}
+"#;
+
+    let expected = r#"<p>a: 1</p>
+<p>b: 1</p>
+<p>a: 2</p>
+<p>b: 2</p>
+"#;
+
+    tera.add_raw_template("shortcodes/a.html", shortcode_template_a).unwrap();
+    tera.add_raw_template("shortcodes/b.html", shortcode_template_b).unwrap();
+    let config = Config::default();
+    let context = RenderContext::new(&tera, &config, "", &permalinks_ctx, InsertAnchor::None);
+
+    let res = render_content(markdown_string, &context).unwrap();
+    assert_eq!(res.body, expected);
+}

--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -1065,8 +1065,8 @@ fn invocation_count_increments_in_shortcode() {
     let mut tera = Tera::default();
     tera.extend(&ZOLA_TERA).unwrap();
 
-    let shortcode_template_a = r#"<p>a: {{ invocation }}</p>"#;
-    let shortcode_template_b = r#"<p>b: {{ invocation }}</p>"#;
+    let shortcode_template_a = r#"<p>a: {{ nth }}</p>"#;
+    let shortcode_template_b = r#"<p>b: {{ nth }}</p>"#;
 
     let markdown_string = r#"{{ a() }}
 {{ b() }}

--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -136,11 +136,11 @@ anything else until the closing tag.
 
 ### Invocation Count
 
-Every shortcode context is passed in a variable named `invocation` that tracks how many times a particular shortcode has
+Every shortcode context is passed in a variable named `nth` that tracks how many times a particular shortcode has
 been invoked in a Markdown file. Given a shortcode `true_statement.html` template:
 
 ```jinja2
-<p id="number{{ invocation }}">{{ value }} is equal to {{ invocation }}.</p>
+<p id="number{{ nth }}">{{ value }} is equal to {{ nth }}.</p>
 ```
 
 It could be used in our Markdown as follows:

--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -134,6 +134,24 @@ If you want to have some content that looks like a shortcode but not have Zola t
 you will need to escape it by using `{%/*` and `*/%}` instead of `{%` and `%}`. You won't need to escape
 anything else until the closing tag.
 
+### Invocation Count
+
+Every shortcode context is passed in a variable named `invocation` that tracks how many times a particular shortcode has
+been invoked in a Markdown file. Given a shortcode `true_statement.html` template:
+
+```jinja2
+<p id="number{{ invocation }}">{{ value }} is equal to {{ invocation }}.</p>
+```
+
+It could be used in our Markdown as follows:
+
+```md
+{{/* true_statement(value=1) */}}
+{{/* true_statement(value=2) */}}
+```
+
+This is useful when implementing custom markup for features such as sidenotes or end notes.
+
 ## Built-in shortcodes
 
 Zola comes with a few built-in shortcodes. If you want to override a default shortcode template,


### PR DESCRIPTION
… many times it has been invoked in a given Markdown file., as per [this Discourse topic](https://zola.discourse.group/t/can-shortlinks-get-an-invocation-count-variable/671).

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [X] Have you created/updated the relevant documentation page(s)?



