### PR TITLE
Gitlab Pages CI : Get zola from alpine community repository

### DIFF
--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -46,8 +46,8 @@ variables:
 
 pages:
   script:
-    # Install the zola package from the alpine testing repositories
-    - apk add --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ zola
+    # Install the zola package from the alpine community repositories
+    - apk add --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ zola
     # Execute zola build
     - zola build
     


### PR DESCRIPTION
Zola is not available in Alpine's `testing` repository, and we should be getting it from `community` instead

Sanity check:

* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

