### PR TITLE
Remove blog page content enclosing paragraph tags in Overview

### DIFF
--- a/docs/content/documentation/getting-started/overview.md
+++ b/docs/content/documentation/getting-started/overview.md
@@ -173,7 +173,7 @@ We now need to make the `blog-page.html` template. In the `templates` directory,
   {{ page.title }}
 </h1>
 <p class="subtitle"><strong>{{ page.date }}</strong></p>
-<p>{{ page.content | safe }}</p>
+{{ page.content | safe }}
 {% endblock content %}
 ```
 


### PR DESCRIPTION
`page.content` is itself html with its own `<p>` tags.  If you really need a tag there you can make it a `<div>`.

### Before
```
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="utf-8">
  <title>MyBlog</title>
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.0/css/bulma.min.css">
</head>

<body>
  <section class="section">
    <div class="container">
      
<h1 class="title">
  My first post
</h1>
<p class="subtitle"><strong>2019-11-27</strong></p>
<p><p>This is my first blog post.</p>
</p>

    </div>
  </section>
<script src="/livereload.js?port=1024&amp;mindelay=10"></script></body>

</html>
```

### After
```
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="utf-8">
  <title>MyBlog</title>
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.0/css/bulma.min.css">
</head>

<body>
  <section class="section">
    <div class="container">
      
<h1 class="title">
  My first post
</h1>
<p class="subtitle"><strong>2019-11-27</strong></p>
<p>This is my first blog post.</p>


    </div>
  </section>
<script src="/livereload.js?port=1024&amp;mindelay=10"></script></body>

</html>
```
