### PR TITLE
move translation population and path collision checking to insert stage

### DIFF
--- a/components/errors/src/lib.rs
+++ b/components/errors/src/lib.rs
@@ -57,7 +57,7 @@ impl Error {
     }
 
     /// Create an error from a list of path collisions, formatting the output
-    pub fn from_collisions(collisions: Vec<(&str, Vec<String>)>) -> Self {
+    pub fn from_collisions(collisions: Vec<(String, Vec<String>)>) -> Self {
         let mut msg = String::from("Found path collisions:\n");
 
         for (path, filepaths) in collisions {

--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -56,8 +56,6 @@ pub struct Section {
     /// The language of that section. Equal to the default lang if the user doesn't setup `languages` in config.
     /// Corresponds to the lang in the _index.{lang}.md file scheme
     pub lang: String,
-    /// Contains all the translated version of that section
-    pub translations: Vec<DefaultKey>,
     /// Contains the internal links that have an anchor: we can only check the anchor
     /// after all pages have been built and their ToC compiled. The page itself should exist otherwise
     /// it would have errored before getting there

--- a/components/library/src/content/ser.rs
+++ b/components/library/src/content/ser.rs
@@ -1,5 +1,6 @@
 //! What we are sending to the templates when rendering them
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
 
 use serde_derive::Serialize;
@@ -24,7 +25,13 @@ impl<'a> TranslatedContent<'a> {
     pub fn find_all_sections(section: &'a Section, library: &'a Library) -> Vec<Self> {
         let mut translations = vec![];
 
-        for key in &section.translations {
+        for key in library
+            .translations
+            .get(&section.file.canonical)
+            .or(Some(&HashSet::new()))
+            .unwrap()
+            .iter()
+        {
             let other = library.get_section_by_key(*key);
             translations.push(TranslatedContent {
                 lang: &other.lang,
@@ -40,7 +47,9 @@ impl<'a> TranslatedContent<'a> {
     pub fn find_all_pages(page: &'a Page, library: &'a Library) -> Vec<Self> {
         let mut translations = vec![];
 
-        for key in &page.translations {
+        for key in
+            library.translations.get(&page.file.canonical).or(Some(&HashSet::new())).unwrap().iter()
+        {
             let other = library.get_page_by_key(*key);
             translations.push(TranslatedContent {
                 lang: &other.lang,


### PR DESCRIPTION
PR in response to #1112. 

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?
* [x] Have you created/updated the relevant documentation page(s)?

## Code changes
I moved the path collision checking and the translation population to the insertion into the library stage. This is to save a few iterations across pages and sections. It did necessitate extra indices for the library, but for aliases and translations, I think that is acceptable since it should be relatively slim in most cases. I have some comments about other possible improvements but I'll add those to the issue discussion itself


