### PR TITLE
test_site: Add test page for Markdown Footnote feature

### DIFF
--- a/test_site/content/footnote/_index.md
+++ b/test_site/content/footnote/_index.md
@@ -1,0 +1,5 @@
++++
+template = "section_footnote.html"
++++
+
+Section with pages containing footnotes:

--- a/test_site/content/footnote/example.md
+++ b/test_site/content/footnote/example.md
@@ -1,0 +1,12 @@
++++
++++
+
+This page has footnotes, here's one. [^1]
+
+<!-- more -->
+
+And here's another. [^2]
+
+[^1]: This is the first footnote.
+
+[^2]: This is the second footnote.

--- a/test_site/templates/section_footnote.html
+++ b/test_site/templates/section_footnote.html
@@ -1,0 +1,17 @@
+{% extends "page.html" %}
+
+{% block content %}
+
+    <div>
+        {{ section.content | safe }}
+    </div>
+
+
+    {% for page in section.pages %}
+        <div>
+            The summary of this page:
+            <div>{{ page.summary | safe }}</div>
+        </div>
+    {% endfor %}
+
+{% endblock content %}


### PR DESCRIPTION
This makes rendering of Footnotes better visible, specialy for the case
of the Footnote anchor being inside the Summary section of the page,
which may leave its link target incorrect/broken.

New pages:
- http://127.0.0.1:1025/footnote/ (with Page Summary rendering)
- http://127.0.0.1:1025/footnote/example (whole Page Content rendering)

See https://github.com/getzola/zola/issues/1282 for more context.

----

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [ ] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?