### PR TITLE
Add Location HTTP header to pages used to redirect to documentation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,13 @@
 
 [context.deploy-preview]
     command = "zola build --base-url $DEPLOY_PRIME_URL"
+
+[[redirects]]
+  from = "/documentation/"
+  to = "/documentation/getting-started/overview/"
+  status = 302
+
+[[redirects]]
+  from = "/documentation/getting-started/"
+  to = "/documentation/getting-started/overview/"
+  status = 302


### PR DESCRIPTION
The URL used for Zola's documentation is https://www.getzola.org/documentation/, but that currently redirects to https://www.getzola.org/documentation/getting-started/, which then redirects to https://www.getzola.org/documentation/getting-started/overview/. The redirection is done using `<meta http-equiv="refresh">` HTML elements rather than using HTTP headers. The result is that the documentation is tad slow to appear after clicking the docs link on https://www.getzola.org/, and the redirect pages flash up on screen before the documentation appears.

This pull request adds [rewrite rules](https://docs.netlify.com/routing/redirects/#syntax-for-the-netlify-configuration-file) to the Netlify config file so that a `Location` HTTP header is added to the server responses. This will remove the flash of content and make the docs appear faster. The original HTML `<meta>` redirects are still there in case the docs ever move away from Netlify.

(This is on the `master` branch because it only affects the documentation.)