### PR TITLE
load_data() template function takes a `required` boolean flag (closes #1209)

### DIFF
--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -415,6 +415,17 @@ mod tests {
     }
 
     #[test]
+    fn doesnt_fail_when_missing_file_is_not_required() {
+        let static_fn = LoadData::new(PathBuf::from("../utils"));
+        let mut args = HashMap::new();
+        args.insert("path".to_string(), to_value("../../../READMEE.md").unwrap());
+        args.insert("required".to_string(), to_value(false).unwrap());
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), tera::Value::Null);
+    }
+
+    #[test]
     fn cant_load_outside_content_dir() {
         let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
         let mut args = HashMap::new();
@@ -511,6 +522,26 @@ mod tests {
             format!("Failed to request {}: 404 Not Found", url)
         );
     }
+
+    #[test]
+    fn doesnt_fail_when_request_404s_is_not_required() {
+        let _m = mock("GET", "/aazeow0kog")
+            .with_status(404)
+            .with_header("content-type", "text/plain")
+            .with_body("Not Found")
+            .create();
+
+        let url = format!("{}{}", mockito::server_url(), "/aazeow0kog");
+        let static_fn = LoadData::new(PathBuf::new());
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), to_value(&url).unwrap());
+        args.insert("format".to_string(), to_value("json").unwrap());
+        args.insert("required".to_string(), to_value(false).unwrap());
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), tera::Value::Null);
+    }
+
 
     #[test]
     fn set_default_user_agent() {

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -673,6 +673,28 @@ mod tests {
     }
 
     #[test]
+    fn bad_csv_should_result_in_error_even_when_not_required() {
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"));
+        let mut args = HashMap::new();
+        args.insert("path".to_string(), to_value("uneven_rows.csv").unwrap());
+        args.insert("required".to_string(), to_value(false).unwrap());
+        let result = static_fn.call(&args.clone());
+
+        assert!(result.is_err());
+
+        let error_kind = result.err().unwrap().kind;
+        match error_kind {
+            tera::ErrorKind::Msg(msg) => {
+                if msg != String::from("Error encountered when parsing csv records") {
+                    panic!("Error message is wrong. Perhaps wrong error is being returned?");
+                }
+            }
+            _ => panic!("Error encountered was not expected CSV error"),
+        }
+    }
+
+
+    #[test]
     fn can_load_json() {
         let static_fn = LoadData::new(PathBuf::from("../utils/test-files"));
         let mut args = HashMap::new();

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -97,7 +97,7 @@ impl DataSource {
         if let Some(url) = url_arg {
             return Url::parse(&url)
                 .map(DataSource::Url)
-                .map(|x| { Some(x) })
+                .map(|x| Some(x))
                 .map_err(|e| format!("Failed to parse {} as url: {}", url, e).into());
         }
 

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -212,9 +212,19 @@ As a security precaution, if this file is outside the main site directory, your 
 {% set data = load_data(path="content/blog/story/data.toml") %}
 ```
 
+The optional `required` boolean argument can be set to false so that missing data does not produce an error, but returns a null value instead. For URLs, all HTTP errors are discarded. For local paths, missing file errors are discarded, but permissions errors are kept. In both cases, invalid data that could not be parsed to the requested data format will still produce an error.
+
+The snippet below outputs the HTML from a Wikipedia page, or "No data found" if the page was not reachable, or did not return a successful HTTP code:
+
+```jinja2
+{% set data = load_data(path="https://en.wikipedia.org/wiki/Commune_of_Paris", required=false %}
+{% if data %}{{ data | safe }}{% else %}No data found{% endif %}
+```
+
 The optional `format` argument allows you to specify and override which data type is contained
 within the file specified in the `path` argument. Valid entries are `toml`, `json`, `csv`, `bibtex`
 or `plain`. If the `format` argument isn't specified, then the path extension is used.
+
 
 ```jinja2
 {% set data = load_data(path="content/blog/story/data.txt", format="json") %}

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -212,12 +212,12 @@ As a security precaution, if this file is outside the main site directory, your 
 {% set data = load_data(path="content/blog/story/data.toml") %}
 ```
 
-The optional `required` boolean argument can be set to false so that missing data does not produce an error, but returns a null value instead. For URLs, all HTTP errors are discarded. For local paths, missing file errors are discarded, but permissions errors are kept. In both cases, invalid data that could not be parsed to the requested data format will still produce an error.
+The optional `required` boolean argument can be set to false so that missing data (HTTP error or local file not found) does not produce an error, but returns a null value instead. However, permission issues with a local file and invalid data that could not be parsed to the requested data format will still produce an error even with `required=false`.
 
 The snippet below outputs the HTML from a Wikipedia page, or "No data found" if the page was not reachable, or did not return a successful HTTP code:
 
 ```jinja2
-{% set data = load_data(path="https://en.wikipedia.org/wiki/Commune_of_Paris", required=false %}
+{% set data = load_data(path="https://en.wikipedia.org/wiki/Commune_of_Paris", required=false) %}
 {% if data %}{{ data | safe }}{% else %}No data found{% endif %}
 ```
 


### PR DESCRIPTION
load_data() now takes an optional `required` boolean flag (defaults to true). Docs have been udpated and tests also.

I'm not too happy with the implementation because it's not too expressive. It uses a Result<Option<DataSource>> where Err are hard error and None is only used for missing file. I'd be happier with typed Errors from which we could discard specific variants depending on context but that would be a lot more work. Maybe error handling could use some love in the coming versions, but this is not the concern here?

Also i don't know of a way to test in a cross-platform manner that a permissions problem still produces error when `required` is false. I would read from `/etc/passwd` but it's outside of basedir, and also would not work on Windows. So i didn't write a test case for that.