### PR TITLE
bugfix: serve command respects mime types (closes #1308)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minify-html"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3254,6 +3264,7 @@ dependencies = [
  "globset",
  "hyper",
  "lazy_static",
+ "mime_guess",
  "notify",
  "open",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ open = "1.2"
 globset = "0.4"
 relative-path = "1"
 serde_json = "1.0"
+# For mimetype detection in serve mode
+mime_guess = "2.0"
 
 site = { path = "components/site" }
 errors = { path = "components/errors" }


### PR DESCRIPTION
This is pretty straightforward i don't know if you want to reuse hyper-staticfile @Keats but in the meantime here's a quickpatch :) 