### PR TITLE
Fix fallback to syntax highlighting theme (closes #1309)

### DIFF
--- a/components/config/src/highlighting.rs
+++ b/components/config/src/highlighting.rs
@@ -40,7 +40,10 @@ pub fn get_highlighter(language: Option<&str>, config: &Config) -> (HighlightLin
             let hacked_lang = if *lang == "js" || *lang == "javascript" { "ts" } else { lang };
             SYNTAX_SET.find_syntax_by_token(hacked_lang)
         }
-        .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text());
+        .unwrap_or_else(|| {
+            eprintln!("Warning: No highlight theme found for language: {}", lang);
+            SYNTAX_SET.find_syntax_plain_text()
+        });
         (HighlightLines::new(syntax, theme), in_extra)
     } else {
         (HighlightLines::new(SYNTAX_SET.find_syntax_plain_text(), theme), false)

--- a/components/config/src/highlighting.rs
+++ b/components/config/src/highlighting.rs
@@ -16,36 +16,34 @@ lazy_static! {
         from_binary(include_bytes!("../../../sublime/themes/all.themedump"));
 }
 
+pub enum HighlightSource {
+    Theme,
+    Extra,
+    Plain,
+    NotFound,
+}
+
 /// Returns the highlighter and whether it was found in the extra or not
-pub fn get_highlighter(language: Option<&str>, config: &Config) -> (HighlightLines<'static>, bool) {
+pub fn get_highlighter(language: Option<&str>, config: &Config) -> (HighlightLines<'static>, HighlightSource) {
     let theme = &THEME_SET.themes[config.highlight_theme()];
-    let mut in_extra = false;
 
     if let Some(ref lang) = language {
-        let syntax = if let Some(ref extra) = config.markdown.extra_syntax_set {
-            let s = extra.find_syntax_by_token(lang);
-            if s.is_some() {
-                in_extra = true;
-                s
-            } else {
-                // Copied from below
-                let hacked_lang = if *lang == "js" || *lang == "javascript" { "ts" } else { lang };
-                SYNTAX_SET.find_syntax_by_token(hacked_lang)
+        if let Some(ref extra_syntaxes) = config.markdown.extra_syntax_set {
+            if let Some(syntax) = extra_syntaxes.find_syntax_by_token(lang) {
+                return (HighlightLines::new(syntax, theme), HighlightSource::Extra);
             }
-        } else {
-            // The JS syntax hangs a lot... the TS syntax is probably better anyway.
-            // https://github.com/getzola/zola/issues/1241
-            // https://github.com/getzola/zola/issues/1211
-            // https://github.com/getzola/zola/issues/1174
-            let hacked_lang = if *lang == "js" || *lang == "javascript" { "ts" } else { lang };
-            SYNTAX_SET.find_syntax_by_token(hacked_lang)
         }
-        .unwrap_or_else(|| {
-            eprintln!("Warning: No highlight theme found for language: {}", lang);
-            SYNTAX_SET.find_syntax_plain_text()
-        });
-        (HighlightLines::new(syntax, theme), in_extra)
+        // The JS syntax hangs a lot... the TS syntax is probably better anyway.
+        // https://github.com/getzola/zola/issues/1241
+        // https://github.com/getzola/zola/issues/1211
+        // https://github.com/getzola/zola/issues/1174
+        let hacked_lang = if *lang == "js" || *lang == "javascript" { "ts" } else { lang };
+        if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(hacked_lang) {
+            (HighlightLines::new(syntax, theme), HighlightSource::Theme)
+        } else {
+            (HighlightLines::new(SYNTAX_SET.find_syntax_plain_text(), theme), HighlightSource::NotFound)
+        }
     } else {
-        (HighlightLines::new(SYNTAX_SET.find_syntax_plain_text(), theme), false)
+        (HighlightLines::new(SYNTAX_SET.find_syntax_plain_text(), theme), HighlightSource::Plain)
     }
 }

--- a/components/config/src/highlighting.rs
+++ b/components/config/src/highlighting.rs
@@ -26,8 +26,12 @@ pub fn get_highlighter(language: Option<&str>, config: &Config) -> (HighlightLin
             let s = extra.find_syntax_by_token(lang);
             if s.is_some() {
                 in_extra = true;
+                s
+            } else {
+                // Copied from below
+                let hacked_lang = if *lang == "js" || *lang == "javascript" { "ts" } else { lang };
+                SYNTAX_SET.find_syntax_by_token(hacked_lang)
             }
-            s
         } else {
             // The JS syntax hangs a lot... the TS syntax is probably better anyway.
             // https://github.com/getzola/zola/issues/1241

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -242,6 +242,7 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
                                     fence_info,
                                     &context.config,
                                     IncludeBackground::IfDifferent(color),
+                                    context.tera_context.get("page").or(context.tera_context.get("section")).map(|x| x.as_object().unwrap().get("relative_path").unwrap().as_str().unwrap())
                                 ));
                             }
                         };

--- a/components/rendering/src/markdown/codeblock.rs
+++ b/components/rendering/src/markdown/codeblock.rs
@@ -1,4 +1,4 @@
-use config::highlighting::{get_highlighter, SYNTAX_SET, THEME_SET};
+use config::highlighting::{get_highlighter, HighlightSource, SYNTAX_SET, THEME_SET};
 use config::Config;
 use std::cmp::min;
 use std::collections::HashSet;
@@ -22,16 +22,27 @@ pub struct CodeBlock<'config> {
 }
 
 impl<'config> CodeBlock<'config> {
-    pub fn new(fence_info: &str, config: &'config Config, background: IncludeBackground) -> Self {
+    pub fn new(fence_info: &str, config: &'config Config, background: IncludeBackground, path: Option<&'config str>) -> Self {
         let fence_info = FenceSettings::new(fence_info);
         let theme = &THEME_SET.themes[config.highlight_theme()];
-        let (highlighter, in_extra) = get_highlighter(fence_info.language, config);
+        let (highlighter, highlight_source) = get_highlighter(fence_info.language, config);
+        let extra_syntax_set = match highlight_source {
+            HighlightSource::Extra => config.markdown.extra_syntax_set.as_ref(),
+            HighlightSource::NotFound => {
+                // Language was not found, so it exists (safe unwrap)
+                let lang = fence_info.language.unwrap();
+                if let Some(path) = path {
+                    eprintln!("Warning: Highlight language {} not found in {}", lang, path);
+                } else {
+                    eprintln!("Warning: Highlight language {} not found", lang);
+                }
+                None
+            },
+            _ => None,
+        };
         Self {
             highlighter,
-            extra_syntax_set: match in_extra {
-                true => config.markdown.extra_syntax_set.as_ref(),
-                false => None,
-            },
+            extra_syntax_set,
             background,
             theme,
 


### PR DESCRIPTION
As suggested in the discussion there, i also added a warning for an unrecognized language so issues are easier to diagnose. Maybe some people won't like that? It would be useful to have configuration for something like this to be either an error, a warning, or ignored entirely, don't you think?