### PR TITLE
Internal links are supported in markdown filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Features
+
+- internal links are now resolved in the `markdown` filter in the templates (#1296 #1316)
+
 ## 0.13.0 (2021-01-09)
 
 - Enable HTML minification

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -50,7 +50,7 @@ pub fn load_tera(path: &Path, config: &Config) -> Result<Tera> {
 
 /// Adds global fns that are to be available to shortcodes while rendering markdown
 pub fn register_early_global_fns(site: &mut Site) {
-    site.tera.register_filter("markdown", filters::MarkdownFilter::new(site.config.clone()));
+    site.tera.register_filter("markdown", filters::MarkdownFilter::new(site.config.clone(), site.permalinks.clone()));
 
     site.tera.register_function(
         "get_url",

--- a/components/templates/src/filters.rs
+++ b/components/templates/src/filters.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::hash::BuildHasher;
+use std::borrow::Cow;
 
 use base64::{decode, encode};
 use config::Config;
@@ -9,17 +10,19 @@ use tera::{to_value, try_get_value, Filter as TeraFilter, Result as TeraResult, 
 #[derive(Debug)]
 pub struct MarkdownFilter {
     config: Config,
+    permalinks: HashMap<String, String>,
 }
 
 impl MarkdownFilter {
-    pub fn new(config: Config) -> Self {
-        Self { config }
+    pub fn new(config: Config, permalinks: HashMap<String, String>) -> Self {
+        Self { config, permalinks }
     }
 }
 
 impl TeraFilter for MarkdownFilter {
     fn filter(&self, value: &Value, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let context = RenderContext::from_config(&self.config);
+        let mut context = RenderContext::from_config(&self.config);
+        context.permalinks = Cow::Borrowed(&self.permalinks);
         let s = try_get_value!("markdown", "value", String, value);
         let inline = match args.get("inline") {
             Some(val) => try_get_value!("markdown", "inline", bool, val),

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -64,9 +64,7 @@ Zola adds a few filters in addition to [those](https://tera.netlify.com/docs/#fi
 in Tera.
 
 ### markdown
-Converts the given variable to HTML using Markdown. This doesn't apply any of the
-features that Zola adds to Markdown; for example, internal links and shortcodes won't work.
-
+Converts the given variable to HTML using Markdown. Shortcodes won't work within this filter.
 By default, the filter will wrap all text in a paragraph. To disable this behaviour, you can
 pass `true` to the inline argument:
 


### PR DESCRIPTION
I went the easy way not bothering with lifetimes and simply cloning (as is done with config, though permalinks is potentially a lot bigger) is that ok?

docs are updated and the change is documented in CHANGELOG.md, and there's a corresponding test

#1296 #1316 