### PR TITLE
Feature: allow spaces between dashes in filename for page

### DIFF
--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -25,7 +25,7 @@ lazy_static! {
     // Based on https://regex101.com/r/H2n38Z/1/tests
     // A regex parsing RFC3339 date followed by {_,-}, some characters and ended by .md
     static ref RFC3339_DATE: Regex = Regex::new(
-        r"^(?P<datetime>(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)([01][0-9]|2[0-3]):([0-5][0-9])))?)(_|-)(?P<slug>.+$)"
+        r"^(?P<datetime>(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)([01][0-9]|2[0-3]):([0-5][0-9])))?)\s?(_|-)(?P<slug>.+$)"
     ).unwrap();
 }
 
@@ -701,6 +701,23 @@ Hello world
 
         assert_eq!(page.meta.date, Some("2018-10-08".to_string()));
         assert_eq!(page.slug, " こんにちは");
+    }
+
+    #[test]
+    fn can_get_date_from_filename_with_spaces() {
+        let config = Config::default();
+        let content = r#"
++++
++++
+Hello world
+<!-- more -->"#
+            .to_string();
+        let res = Page::parse(Path::new("2018-10-08 - hello.md"), &content, &config, &PathBuf::new());
+        assert!(res.is_ok());
+        let page = res.unwrap();
+
+        assert_eq!(page.meta.date, Some("2018-10-08".to_string()));
+        assert_eq!(page.slug, "hello");
     }
 
     #[test]

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -721,6 +721,24 @@ Hello world
     }
 
     #[test]
+    fn can_get_date_from_filename_with_spaces_respects_slugification() {
+        let mut config = Config::default();
+        config.slugify.paths = SlugifyStrategy::Off;
+        let content = r#"
++++
++++
+Hello world
+<!-- more -->"#
+            .to_string();
+        let res = Page::parse(Path::new("2018-10-08 - hello.md"), &content, &config, &PathBuf::new());
+        assert!(res.is_ok());
+        let page = res.unwrap();
+
+        assert_eq!(page.meta.date, Some("2018-10-08".to_string()));
+        assert_eq!(page.slug, " hello");
+    }
+
+    #[test]
     fn can_get_date_from_full_rfc3339_date_in_filename() {
         let config = Config::default();
         let content = r#"

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -65,12 +65,12 @@ When the article's output path is not specified in the frontmatter, it is extrac
 - if the filename is `index.md`, its parent folder name (`bar`) is used as output path
 - otherwise, the output path is extracted from `thing` (the filename without the `.md` extension)
 
-If the path found starts with a datetime string (`YYYY-mm-dd` or [a RFC3339 datetime](https://www.ietf.org/rfc/rfc3339.txt)) followed by an underscore (`_`) or a dash (`-`), this date is removed from the output path and will be used as the page date (unless already set in the front-matter). Note that the full RFC3339 datetime contains colons, which is not a valid character in a filename on Windows.
+If the path found starts with a datetime string (`YYYY-mm-dd` or [a RFC3339 datetime](https://www.ietf.org/rfc/rfc3339.txt)) followed by optional whitespace and then an underscore (`_`) or a dash (`-`), this date is removed from the output path and will be used as the page date (unless already set in the front-matter). Note that the full RFC3339 datetime contains colons, which is not a valid character in a filename on Windows.
 
 The output path extracted from the file path is then slugified or not, depending on the `slugify.paths` config, as explained previously.
 
 **Example:**
-The file `content/blog/2018-10-10-hello-world.md` will yield a page at `[base_url]/blog/hello-world`.
+The file `content/blog/2018-10-10-hello-world.md` will yield a page at `[base_url]/blog/hello-world`. With optional whitespace, the file `content/blog/2021-01-23 -hello new world.md` will yield a page at `[base_url]/blog/hello-new-world`
 
 ## Front matter
 


### PR DESCRIPTION
Apologies for creating a PR without asking/discussing it first. I needed this for a site I am migrating, as I didn't want to rename all the files and lose easy access to history in git. I hope this small change will be accepted.

This change allows files named:

```
2021-01-23 - hello new world.md
```

to be treated the same as files named

```
2021-01-23-hello-new-world.md
```

And have the date stripped from the slug that is generated.

## Code changes

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?

