### PR TITLE
Update minify-html dependency to version 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "minify-html"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345dcbf4663db7d3a78a6e6b6c279c8bb6c32d6365cd98da977d7f7543b6c167"
+checksum = "d7af79ea8ac719a1cc299787058518a12018700af7ec7be4b789930526e1a1ab"
 dependencies = [
  "aho-corasick",
  "lazy_static",

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = "1"
 slug = "0.1"
 percent-encoding = "2"
 filetime = "0.2.12"
-minify-html = "0.4"
+minify-html = "0.4.2"
 
 errors = { path = "../errors" }
 

--- a/components/utils/src/minify.rs
+++ b/components/utils/src/minify.rs
@@ -59,4 +59,35 @@ mod tests {
         let res = html(input.to_owned()).unwrap();
         assert_eq!(res, expected);
     }
+
+    // https://github.com/getzola/zola/issues/1300
+    #[test]
+    fn can_minify_and_preserve_whitespace_in_pre_elements() {
+        let input = r#"
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+  <pre><code>fn main() {
+    println!("Hello, world!");
+    <span>loop {
+      println!("Hello, world!");
+    }</span>
+  }
+  </code></pre>
+</body>
+</html>
+"#;
+        let expected = r#"<!doctype html><html><head><meta charset=utf-8><body><pre><code>fn main() {
+    println!("Hello, world!");
+    <span>loop {
+      println!("Hello, world!");
+    }</span>
+  }
+  </code></pre>"#;
+        let res = html(input.to_owned()).unwrap();
+        assert_eq!(res, expected);
+    }
 }


### PR DESCRIPTION
This fixes #1300. See also the [upstream issue](https://github.com/wilsonzlin/minify-html/issues/21) and commits [55eab19b](https://github.com/wilsonzlin/minify-html/commit/55eab19bbeb284b2b93b68e25d124a07fac504ab) and [0bfb8d86](https://github.com/wilsonzlin/minify-html/commit/0bfb8d86d70d163ba0421c8221efb8130d94031e) in the minify-html repo.

Sanity check:

* [x] Have you checked to ensure there aren't other open [pull requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?
