### PR TITLE
Support embed YouTube playlist

### DIFF
--- a/components/templates/src/builtins/shortcodes/youtube.html
+++ b/components/templates/src/builtins/shortcodes/youtube.html
@@ -1,3 +1,3 @@
 <div {% if class %}class="{{class}}"{% endif %}>
-    <iframe src="https://www.youtube-nocookie.com/embed/{{id}}{% if autoplay %}?autoplay=1{% endif %}" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/{{id}}{% if playlist %}?list={{playlist}}{% endif %}{% if autoplay %}?autoplay=1{% endif %}" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 </div>

--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -164,6 +164,7 @@ Embed a responsive player for a YouTube video.
 The arguments are:
 
 - `id`: the video id (mandatory)
+- `playlist: the playlist id (optional)
 - `class`: a class to add to the `<div>` surrounding the iframe
 - `autoplay`: when set to "true", the video autoplays on load
 
@@ -171,6 +172,8 @@ Usage example:
 
 ```md
 {{/* youtube(id="dQw4w9WgXcQ") */}}
+
+{{/* youtube(id="dQw4w9WgXcQ", playlist="RDdQw4w9WgXcQ") */}}
 
 {{/* youtube(id="dQw4w9WgXcQ", autoplay=true) */}}
 


### PR DESCRIPTION
This is a tiny modification in shortcode. Let me know if it still need to go through discussion on forum.

This PR adds an extra paramter to YouTube shortcode for including playlist. One can easily use current `id` parameter to do the same thing, but it looks more like a hack. Adding a `playlist` parameter seems to be more clear.

To include playlist with `youtube` shortcode before PR (more like a hack):

```
{{ youtube(id="dQw4w9WgXcQ?list=RDdQw4w9WgXcQ") }}
```

After PR:

```
{{ youtube(id="dQw4w9WgXcQ", playlist="RDdQw4w9WgXcQ") }}
```

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?