### PR TITLE
Add AVIF support to resize_image()

### DIFF
--- a/components/imageproc/Cargo.toml
+++ b/components/imageproc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 lazy_static = "1"
 regex = "1.0"
 tera = "1"
-image = "0.23"
+image = { version = "0.23.13", features = ["avif"] }
 rayon = "1"
 
 errors = { path = "../errors" }

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -28,10 +28,11 @@ resize_image(path, width, height, op, format, quality)
     - `"auto"`
     - `"jpg"`
     - `"png"`
+    - `"avif"`
 
   The default is `"auto"`, this means that the format is chosen based on input image format.
   JPEG is chosen for JPEGs and other lossy formats, and PNG is chosen for PNGs and other lossless formats.
-- `quality` (_optional_): JPEG quality of the resized image, in percent. Only used when encoding JPEGs; default value is `75`.
+- `quality` (_optional_): Quality of the resized image, in percent. Only used when encoding JPEGs or AVIFs; default value is `75`.
 
 ### Image processing and return value
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?

---
This pr adds support for AVIF images to the `resize_image()` function, closing #1202. As `image` does not currently allow setting the speed and quality parameters via the `write_to()` method this manually creates an encoder and writes the result out to a file.

There are 2 caveats to this implementation:
1. The `speed` parameter is hardcoded. This currently uses the same default as the `cavif-rs` crate (which `image` uses for avif encoding). This encoding speed can be very slow, so it might be nice to allow changing this. I did not add it as another argument to `resize_image()` as I felt it would start to get unwieldy. Perhaps eventually this could be overriden in `config.toml`?
2. AVIFs quality levels, while accepting the same range as jpeg are very different. The default value of 75 actually results in a file slighty bigger than the equivalent jpeg. I do not know how AVIF SSIM values compare to jpeg for different quality settings, but it might be nice to choose a different default for AVIF that has a similar SSIM to jpegs 75 quality level.

