### PR TITLE
Fix "serve" subcommand for URL encoded static files

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -109,7 +109,7 @@ async fn handle_request(req: Request<Body>, mut root: PathBuf) -> Result<Respons
 
     // Remove the trailing slash from the request path
     // otherwise `PathBuf` will interpret it as an absolute path
-    root.push(&req.uri().path()[1..]);
+    root.push(&decoded[1..]);
     let result = tokio::fs::read(&root).await;
 
     let contents = match result {


### PR DESCRIPTION
There is a bug in `zola serve` for static files. If the filename contains something that will be changed after URL encoding (e.g. CJK), then I can't access it with the builtin dev server.

For example, if I put a file like `static/測試.png` in the project.
Before:
```
http://localhost:1111/測試.png -> 404 Not Found
```
After:
```
http://localhost:1111/測試.png -> get PNG image
```

Not sure if there is more concern for this PR, but this change solves my issue.

----

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?



