### PR TITLE
Add live reload tip for serving site with docker

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -94,6 +94,10 @@ $ docker run -u "$(id -u):$(id -g)" -v $PWD:/app --workdir /app -p 8080:8080 bal
 
 You can now browse http://localhost:8080.
 
+> To enable live browser reload, you may have to bind to port 1024. Zola searches for an open
+> port between 1024 and 9000 for live reload. The new docker command would be
+> `$ docker run -u "$(id -u):$(id -g)" -v $PWD:/app --workdir /app -p 8080:8080 -p 1024:1024 balthek/zola:0.13.0 serve --interface 0.0.0.0 --port 8080 --base-url localhost`
+
 ## Windows
 
 Zola is available on [Scoop](https://scoop.sh):


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Documentation changes

Feel free to suggesting better wording or sentence structure. I wanted to keep it shorter, but felt like I had to add the second sentence for you to review. If you think we should get rid of it just let me know. I can also see the sentence being:

> You may have to bind to port 1024 to enable live browser reload. The new docker command would be
> `$ docker run -u "$(id -u):$(id -g)" -v $PWD:/app --workdir /app -p 8080:8080 -p 1024:1024 balthek/zola:0.13.0 serve --interface 0.0.0.0 --port 8080 --base-url localhost`

fixes #1345 


