### PR TITLE
Copyright date always ending on current year

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -99,7 +99,7 @@
             {% endblock content %}
         </div>
         <footer>
-            ©2017-2020 — <a class="white" href="http://vincentprouillet.com">Vincent Prouillet</a> and <a class="white" href="https://github.com/getzola/zola/graphs/contributors">contributors</a>
+            ©2017-{{ now() | date(format="%Y") }} — <a class="white" href="https://vincentprouillet.com">Vincent Prouillet</a> and <a class="white" href="https://github.com/getzola/zola/graphs/contributors">contributors</a>
         </footer>
 
         <script type="text/javascript" src="{{ get_url(path="elasticlunr.min.js") }}"></script>


### PR DESCRIPTION
Hi @Keats 

a small patch so the documentation shows "copyright 2017 to {current year}" in the footer

wdy?

thanks for Zola!

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?
