### PR TITLE
Add CORS header

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -128,7 +128,11 @@ async fn handle_request(req: Request<Body>, mut root: PathBuf) -> Result<Respons
 
     Ok(Response::builder()
         .status(StatusCode::OK)
-        .header("Content-Type", mimetype_from_path(&root).first_or_octet_stream().essence_str())
+        .header(
+            header::CONTENT_TYPE,
+            mimetype_from_path(&root).first_or_octet_stream().essence_str(),
+        )
+        .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .body(Body::from(contents))
         .unwrap())
 }


### PR DESCRIPTION
I was having an issue with `zola serve` where the browser was not
fetching fonts on account of it not sending a CORS header with the
fonts

I've added a CORS header specifying the host that is printed out at the
command line.

