### PR TITLE
Fix serve command when used with config option

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -689,36 +689,48 @@ mod tests {
                 (ChangeKind::Templates, PathBuf::from("/templates/hello.html")),
                 Path::new("/home/vincent/site"),
                 Path::new("/home/vincent/site/templates/hello.html"),
+                "config.toml",
             ),
             (
                 (ChangeKind::Themes, PathBuf::from("/themes/hello.html")),
                 Path::new("/home/vincent/site"),
                 Path::new("/home/vincent/site/themes/hello.html"),
+                "config.toml",
             ),
             (
                 (ChangeKind::StaticFiles, PathBuf::from("/static/site.css")),
                 Path::new("/home/vincent/site"),
                 Path::new("/home/vincent/site/static/site.css"),
+                "config.toml",
             ),
             (
                 (ChangeKind::Content, PathBuf::from("/content/posts/hello.md")),
                 Path::new("/home/vincent/site"),
                 Path::new("/home/vincent/site/content/posts/hello.md"),
+                "config.toml",
             ),
             (
                 (ChangeKind::Sass, PathBuf::from("/sass/print.scss")),
                 Path::new("/home/vincent/site"),
                 Path::new("/home/vincent/site/sass/print.scss"),
+                "config.toml",
             ),
             (
                 (ChangeKind::Config, PathBuf::from("/config.toml")),
                 Path::new("/home/vincent/site"),
                 Path::new("/home/vincent/site/config.toml"),
+                "config.toml",
+            ),
+            (
+                (ChangeKind::Config, PathBuf::from("/config.staging.toml")),
+                Path::new("/home/vincent/site"),
+                Path::new("/home/vincent/site/config.staging.toml"),
+                "config.staging.toml",
             ),
         ];
 
-        for (expected, pwd, path) in test_cases {
-            assert_eq!(expected, detect_change_kind(&pwd, &path));
+        for (expected, pwd, path, config_filename) in test_cases {
+            assert_eq!(expected, detect_change_kind(&pwd, &path, &config_filename));
         }
     }
 
@@ -728,7 +740,8 @@ mod tests {
         let expected = (ChangeKind::Templates, PathBuf::from("/templates/hello.html"));
         let pwd = Path::new(r#"C:\\Users\johan\site"#);
         let path = Path::new(r#"C:\\Users\johan\site\templates\hello.html"#);
-        assert_eq!(expected, detect_change_kind(pwd, path));
+        let config_filename = "config.toml";
+        assert_eq!(expected, detect_change_kind(pwd, path, config_filename));
     }
 
     #[test]
@@ -736,6 +749,7 @@ mod tests {
         let expected = (ChangeKind::Templates, PathBuf::from("/templates/hello.html"));
         let pwd = Path::new("/home/johan/site");
         let path = Path::new("templates/hello.html");
-        assert_eq!(expected, detect_change_kind(pwd, path));
+        let config_filename = "config.toml";
+        assert_eq!(expected, detect_change_kind(pwd, path, config_filename));
     }
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -270,10 +270,16 @@ pub fn serve(
         return Err(format!("Cannot start server on address {}.", address).into());
     }
 
+    let config_filename = config_file
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap_or("config.toml");
+
     // An array of (path, bool, bool) where the path should be watched for changes, and the boolean value
     // indicates whether this file/folder must exist for zola serve to operate
     let watch_this = vec![
-        ("config.toml", WatchMode::Required),
+        (config_filename, WatchMode::Required),
         ("content", WatchMode::Required),
         ("sass", WatchMode::Condition(site.config.compile_sass)),
         ("static", WatchMode::Optional),
@@ -631,7 +637,7 @@ fn detect_change_kind(pwd: &Path, path: &Path) -> (ChangeKind, PathBuf) {
         ChangeKind::StaticFiles
     } else if partial_path.starts_with("/sass") {
         ChangeKind::Sass
-    } else if partial_path == Path::new("/config.toml") {
+    } else if partial_path.extension().unwrap() == "toml" {
         ChangeKind::Config
     } else {
         unreachable!("Got a change in an unexpected path: {}", partial_path.display());

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -497,7 +497,7 @@ pub fn serve(
                         );
 
                         let start = Instant::now();
-                        match detect_change_kind(&root_dir, &path) {
+                        match detect_change_kind(&root_dir, &path, &config_filename) {
                             (ChangeKind::Content, _) => {
                                 console::info(&format!("-> Content changed {}", path.display()));
 
@@ -623,9 +623,12 @@ fn is_temp_file(path: &Path) -> bool {
 
 /// Detect what changed from the given path so we have an idea what needs
 /// to be reloaded
-fn detect_change_kind(pwd: &Path, path: &Path) -> (ChangeKind, PathBuf) {
+fn detect_change_kind(pwd: &Path, path: &Path, config_filename: &str) -> (ChangeKind, PathBuf) {
     let mut partial_path = PathBuf::from("/");
     partial_path.push(path.strip_prefix(pwd).unwrap_or(path));
+
+    let mut partial_config_path = PathBuf::from("/");
+    partial_config_path.push(config_filename);
 
     let change_kind = if partial_path.starts_with("/templates") {
         ChangeKind::Templates
@@ -637,7 +640,7 @@ fn detect_change_kind(pwd: &Path, path: &Path) -> (ChangeKind, PathBuf) {
         ChangeKind::StaticFiles
     } else if partial_path.starts_with("/sass") {
         ChangeKind::Sass
-    } else if partial_path.extension().unwrap() == "toml" {
+    } else if partial_path == partial_config_path {
         ChangeKind::Config
     } else {
         unreachable!("Got a change in an unexpected path: {}", partial_path.display());


### PR DESCRIPTION
Hi there!

I noticed that the `serve` command isn't working as expected when used together with the `--config` option.

When I run `zola -c ./config.prod.toml serve`, I expect `config.prod.toml` (assuming `config.prod.toml` is the only config file I have) to be watched and a website to be built, but I was getting this:

```sh
❯ zola -c ./config.prod.toml serve
Building site...
-> Creating 0 pages (0 orphan), 0 sections, and processing 0 images
Done in 44ms.

Error: Can't watch `config.toml` for changes in folder `...`. Does it exist, and do you have correct permissions?
Reason: entity not found
```

The quick fix is to create an empty `config.toml` file. That no longer yields an error, but `config.prod.toml` still isn't watched.

Similar issue was reported and fixed a couple of years ago (see #294).

I have no prior Rust experience, so code adjustments and comments are very much appreciated.

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



