### PR TITLE
Official zola.386 theme's demo page corrected

### DIFF
--- a/docs/content/themes/zola.386/index.md
+++ b/docs/content/themes/zola.386/index.md
@@ -12,7 +12,7 @@ repository = "https://github.com/lopes/zola.386"
 homepage = "https://github.com/lopes/zola.386"
 minimum_version = "0.10.1"
 license = "MIT"
-demo = "https://zola-386.netlify.com"
+demo = "https://zola386.netlify.app/"
 
 [extra.author]
 name = "José Lopes"


### PR DESCRIPTION
Official zola.386 theme's demo page corrected as per their own documentation at https://github.com/lopes/zola.386

Sanity check:

* [*] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?





