### PR TITLE
Documentation: Clarify where exactly to define the theme in the .toml file

### DIFF
--- a/docs/content/documentation/themes/installing-and-using-themes.md
+++ b/docs/content/documentation/themes/installing-and-using-themes.md
@@ -27,7 +27,8 @@ Zola to use it by setting the `theme` variable in the
 [configuration file](@/documentation/getting-started/configuration.md). The theme
 name has to be the name of the directory you cloned the theme in.
 For example, if you cloned a theme in `themes/simple-blog`, the theme name to use
-in the configuration file is `simple-blog`.
+in the configuration file is `simple-blog`. Also make sure to place the variable in the top level of the 
+`.toml` hierarchy and not after a dict like [extra] or [markdown].
 
 ## Customizing a theme
 


### PR DESCRIPTION
It was not immediately clear for me (as a first time .toml user) that the user has to place the theme variable in the top level of the config file. I had an issue with that and would like to save some time for fellow zola users. 
[Others](https://zola.discourse.group/t/i-am-missing-something-to-start-using-the-product/423/12) have encountered this as well.

The only thing I would like you to think about is: Is this a general rule or theme dependent? If the latter, then I have to rephrase oc. 

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?