### PR TITLE
Add HTTP POST capability to load_data()

### DIFF
--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -209,7 +209,7 @@ impl TeraFn for LoadData {
         let path_arg = optional_arg!(String, args.get("path"), GET_DATA_ARGUMENT_ERROR_MESSAGE);
         let url_arg = optional_arg!(String, args.get("url"), GET_DATA_ARGUMENT_ERROR_MESSAGE);
 		let post_body_arg = optional_arg!(String, args.get("body"), "`load_data` body must be a string, if set.");
-		let post_content_type = optional_arg!(String, args.get("contenttype"), "`load_data` contenttype must be a string, if set.");
+		let post_content_type = optional_arg!(String, args.get("content_type"), "`load_data` content_type must be a string, if set.");
 		let method_arg = optional_arg!(String, args.get("method"), "`load_data` method must either be POST or GET.");
 		let method = match method_arg {
 			Some(method_str) => {

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -24,6 +24,7 @@ enum DataSource {
     Path(PathBuf),
 }
 
+#[derive(Debug,PartialEq,Clone,Copy,Hash)]
 enum Method {
 	Post,
 	Get,

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -110,9 +110,12 @@ impl DataSource {
         Err(GET_DATA_ARGUMENT_ERROR_MESSAGE.into())
     }
 
-    fn get_cache_key(&self, format: &OutputFormat) -> u64 {
+    fn get_cache_key(&self, format: &OutputFormat, method_arg: Option<String>, method_post_body: Option<String>, method_post_contenttype: Option<String>) -> u64 {
         let mut hasher = DefaultHasher::new();
         format.hash(&mut hasher);
+		method_arg.hash(&mut hasher);
+		method_post_body.hash(&mut hasher);
+		method_post_contenttype.hash(&mut hasher);
         self.hash(&mut hasher);
         hasher.finish()
     }
@@ -210,7 +213,7 @@ impl TeraFn for LoadData {
 		let post_body_arg = optional_arg!(String, args.get("body"), "`load_data` body must be a string, if set.");
 		let post_content_type = optional_arg!(String, args.get("contenttype"), "`load_data` contenttype must be a string, if set.");
 		let method_arg = optional_arg!(String, args.get("method"), "`load_data` method must either be POST or GET.");
-		let method = match method_arg {
+		let method = match method_arg.clone() {
 			Some(method_str) => {
 				if method_str.to_lowercase() == "post"{
 				Method::Post
@@ -241,7 +244,7 @@ impl TeraFn for LoadData {
         }
         let data_source = data_source.unwrap();
         let file_format = get_output_format_from_args(&args, &data_source)?;
-        let cache_key = data_source.get_cache_key(&file_format);
+        let cache_key = data_source.get_cache_key(&file_format,method_arg,post_body_arg.clone(),post_content_type.clone());
 
         let mut cache = self.result_cache.lock().expect("result cache lock");
         let response_client = self.client.lock().expect("response client lock");
@@ -534,6 +537,69 @@ mod tests {
 	}
 	
 	#[test]
+	fn is_load_remote_data_using_post_method_with_different_body_not_cached(){
+		let _mjson = mock("POST", "/kr1zdgbm4y3")
+            .with_header("content-type", "application/json")
+            .with_body("{i_am:'json'}")
+			.expect(2)
+            .create();
+		let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y3");
+		
+		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
+        let mut args = HashMap::new();
+		args.insert("url".to_string(), to_value(&url).unwrap());
+		args.insert("format".to_string(), to_value("plain").unwrap());
+		args.insert("method".to_string(), to_value("post").unwrap());
+		args.insert("contenttype".to_string(), to_value("text/plain").unwrap());
+		args.insert("body".to_string(), to_value("this is a match").unwrap());
+		let result = static_fn.call(&args);
+		assert!(result.is_ok());
+		
+		let mut args2 = HashMap::new();
+		args2.insert("url".to_string(), to_value(&url).unwrap());
+		args2.insert("format".to_string(), to_value("plain").unwrap());
+		args2.insert("method".to_string(), to_value("post").unwrap());
+		args2.insert("contenttype".to_string(), to_value("text/plain").unwrap());
+		args2.insert("body".to_string(), to_value("this is a match2").unwrap());
+		let result2 = static_fn.call(&args2);
+		assert!(result2.is_ok());
+		
+		_mjson.assert();	
+	}
+	
+	#[test]
+	fn is_load_remote_data_using_post_method_with_same_body_cached(){
+		let _mjson = mock("POST", "/kr1zdgbm4y2")
+			.match_body("this is a match")
+            .with_header("content-type", "application/json")
+            .with_body("{i_am:'json'}")
+			.expect(1)
+            .create();
+		let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y2");
+		
+		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
+        let mut args = HashMap::new();
+		args.insert("url".to_string(), to_value(&url).unwrap());
+		args.insert("format".to_string(), to_value("plain").unwrap());
+		args.insert("method".to_string(), to_value("post").unwrap());
+		args.insert("contenttype".to_string(), to_value("text/plain").unwrap());
+		args.insert("body".to_string(), to_value("this is a match").unwrap());
+		let result = static_fn.call(&args);
+		assert!(result.is_ok());
+		
+		let mut args2 = HashMap::new();
+		args2.insert("url".to_string(), to_value(&url).unwrap());
+		args2.insert("format".to_string(), to_value("plain").unwrap());
+		args2.insert("method".to_string(), to_value("post").unwrap());
+		args2.insert("contenttype".to_string(), to_value("text/plain").unwrap());
+		args2.insert("body".to_string(), to_value("this is a match").unwrap());
+		let result2 = static_fn.call(&args2);
+		assert!(result2.is_ok());
+		
+		_mjson.assert();	
+	}
+	
+	#[test]
 	fn can_load_remote_data_using_post_method_with_body(){
 		let _mjson = mock("POST", "/kr1zdgbm4y")
 			.match_body("qwerty")
@@ -602,9 +668,9 @@ mod tests {
     fn calculates_cache_key_for_path() {
         // We can't test against a fixed value, due to the fact the cache key is built from the absolute path
         let cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
         let cache_key_2 =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
         assert_eq!(cache_key, cache_key_2);
     }
 
@@ -616,25 +682,25 @@ mod tests {
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y");
-        let cache_key = DataSource::Url(url.parse().unwrap()).get_cache_key(&OutputFormat::Plain);
-        assert_eq!(cache_key, 425638486551656875);
+        let cache_key = DataSource::Url(url.parse().unwrap()).get_cache_key(&OutputFormat::Plain,None,None,None);
+        assert_eq!(cache_key, 16044537454280534951);
     }
 
     #[test]
     fn different_cache_key_per_filename() {
         let toml_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
         let json_cache_key =
-            DataSource::Path(get_test_file("test.json")).get_cache_key(&OutputFormat::Toml);
+            DataSource::Path(get_test_file("test.json")).get_cache_key(&OutputFormat::Toml,None,None,None);
         assert_ne!(toml_cache_key, json_cache_key);
     }
 
     #[test]
     fn different_cache_key_per_format() {
         let toml_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
         let json_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Json);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Json,None,None,None);
         assert_ne!(toml_cache_key, json_cache_key);
     }
 

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -34,12 +34,10 @@ impl FromStr for Method {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        if s.to_lowercase() == "post" {
-            Ok(Method::Post)
-        } else if s.to_lowercase() == "get" {
-            Ok(Method::Get)
-        } else {
-            return Err("`load_data` method must either be POST or GET.".into());
+        match s.to_lowercase().as_ref() {
+            "post" => Ok(Method::Post),
+            "get" => Ok(Method::Get),
+            _ => Err("`load_data` method must either be POST or GET.".into()),
         }
     }
 }

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -609,7 +609,7 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result, ".hello {}\r\n",);
+            assert_eq!(result, ".hello {}\n",);
         } else {
             assert_eq!(result, ".hello {}\n",);
         };
@@ -624,7 +624,7 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result, "Number,Title\r\n1,Gutenberg\r\n2,Printing",);
+            assert_eq!(result, "Number,Title\n1,Gutenberg\n2,Printing",);
         } else {
             assert_eq!(result, "Number,Title\n1,Gutenberg\n2,Printing",);
         };
@@ -639,7 +639,7 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result, ".hello {}\r\n",);
+            assert_eq!(result, ".hello {}\n",);
         } else {
             assert_eq!(result, ".hello {}\n",);
         };

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -110,12 +110,9 @@ impl DataSource {
         Err(GET_DATA_ARGUMENT_ERROR_MESSAGE.into())
     }
 
-    fn get_cache_key(&self, format: &OutputFormat, method_arg: Option<String>, method_post_body: Option<String>, method_post_contenttype: Option<String>) -> u64 {
+    fn get_cache_key(&self, format: &OutputFormat) -> u64 {
         let mut hasher = DefaultHasher::new();
         format.hash(&mut hasher);
-		method_arg.hash(&mut hasher);
-		method_post_body.hash(&mut hasher);
-		method_post_contenttype.hash(&mut hasher);
         self.hash(&mut hasher);
         hasher.finish()
     }
@@ -213,7 +210,7 @@ impl TeraFn for LoadData {
 		let post_body_arg = optional_arg!(String, args.get("body"), "`load_data` body must be a string, if set.");
 		let post_content_type = optional_arg!(String, args.get("contenttype"), "`load_data` contenttype must be a string, if set.");
 		let method_arg = optional_arg!(String, args.get("method"), "`load_data` method must either be POST or GET.");
-		let method = match method_arg.clone() {
+		let method = match method_arg {
 			Some(method_str) => {
 				if method_str.to_lowercase() == "post"{
 				Method::Post
@@ -244,7 +241,7 @@ impl TeraFn for LoadData {
         }
         let data_source = data_source.unwrap();
         let file_format = get_output_format_from_args(&args, &data_source)?;
-        let cache_key = data_source.get_cache_key(&file_format,method_arg,post_body_arg.clone(),post_content_type.clone());
+        let cache_key = data_source.get_cache_key(&file_format);
 
         let mut cache = self.result_cache.lock().expect("result cache lock");
         let response_client = self.client.lock().expect("response client lock");
@@ -537,69 +534,6 @@ mod tests {
 	}
 	
 	#[test]
-	fn is_load_remote_data_using_post_method_with_different_body_not_cached(){
-		let _mjson = mock("POST", "/kr1zdgbm4y3")
-            .with_header("content-type", "application/json")
-            .with_body("{i_am:'json'}")
-			.expect(2)
-            .create();
-		let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y3");
-		
-		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
-        let mut args = HashMap::new();
-		args.insert("url".to_string(), to_value(&url).unwrap());
-		args.insert("format".to_string(), to_value("plain").unwrap());
-		args.insert("method".to_string(), to_value("post").unwrap());
-		args.insert("contenttype".to_string(), to_value("text/plain").unwrap());
-		args.insert("body".to_string(), to_value("this is a match").unwrap());
-		let result = static_fn.call(&args);
-		assert!(result.is_ok());
-		
-		let mut args2 = HashMap::new();
-		args2.insert("url".to_string(), to_value(&url).unwrap());
-		args2.insert("format".to_string(), to_value("plain").unwrap());
-		args2.insert("method".to_string(), to_value("post").unwrap());
-		args2.insert("contenttype".to_string(), to_value("text/plain").unwrap());
-		args2.insert("body".to_string(), to_value("this is a match2").unwrap());
-		let result2 = static_fn.call(&args2);
-		assert!(result2.is_ok());
-		
-		_mjson.assert();	
-	}
-	
-	#[test]
-	fn is_load_remote_data_using_post_method_with_same_body_cached(){
-		let _mjson = mock("POST", "/kr1zdgbm4y2")
-			.match_body("this is a match")
-            .with_header("content-type", "application/json")
-            .with_body("{i_am:'json'}")
-			.expect(1)
-            .create();
-		let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y2");
-		
-		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
-        let mut args = HashMap::new();
-		args.insert("url".to_string(), to_value(&url).unwrap());
-		args.insert("format".to_string(), to_value("plain").unwrap());
-		args.insert("method".to_string(), to_value("post").unwrap());
-		args.insert("contenttype".to_string(), to_value("text/plain").unwrap());
-		args.insert("body".to_string(), to_value("this is a match").unwrap());
-		let result = static_fn.call(&args);
-		assert!(result.is_ok());
-		
-		let mut args2 = HashMap::new();
-		args2.insert("url".to_string(), to_value(&url).unwrap());
-		args2.insert("format".to_string(), to_value("plain").unwrap());
-		args2.insert("method".to_string(), to_value("post").unwrap());
-		args2.insert("contenttype".to_string(), to_value("text/plain").unwrap());
-		args2.insert("body".to_string(), to_value("this is a match").unwrap());
-		let result2 = static_fn.call(&args2);
-		assert!(result2.is_ok());
-		
-		_mjson.assert();	
-	}
-	
-	#[test]
 	fn can_load_remote_data_using_post_method_with_body(){
 		let _mjson = mock("POST", "/kr1zdgbm4y")
 			.match_body("qwerty")
@@ -668,9 +602,9 @@ mod tests {
     fn calculates_cache_key_for_path() {
         // We can't test against a fixed value, due to the fact the cache key is built from the absolute path
         let cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml);
         let cache_key_2 =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml);
         assert_eq!(cache_key, cache_key_2);
     }
 
@@ -682,25 +616,25 @@ mod tests {
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y");
-        let cache_key = DataSource::Url(url.parse().unwrap()).get_cache_key(&OutputFormat::Plain,None,None,None);
-        assert_eq!(cache_key, 16044537454280534951);
+        let cache_key = DataSource::Url(url.parse().unwrap()).get_cache_key(&OutputFormat::Plain);
+        assert_eq!(cache_key, 425638486551656875);
     }
 
     #[test]
     fn different_cache_key_per_filename() {
         let toml_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml);
         let json_cache_key =
-            DataSource::Path(get_test_file("test.json")).get_cache_key(&OutputFormat::Toml,None,None,None);
+            DataSource::Path(get_test_file("test.json")).get_cache_key(&OutputFormat::Toml);
         assert_ne!(toml_cache_key, json_cache_key);
     }
 
     #[test]
     fn different_cache_key_per_format() {
         let toml_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml);
         let json_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Json,None,None,None);
+            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Json);
         assert_ne!(toml_cache_key, json_cache_key);
     }
 

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -754,7 +754,7 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result, ".hello {}\n",);
+            assert_eq!(result.as_str().unwrap().replace("\r\n","\n"), ".hello {}\n",);
         } else {
             assert_eq!(result, ".hello {}\n",);
         };
@@ -769,7 +769,7 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result, "Number,Title\n1,Gutenberg\n2,Printing",);
+            assert_eq!(result.as_str().unwrap().replace("\r\n","\n"), "Number,Title\n1,Gutenberg\n2,Printing",);
         } else {
             assert_eq!(result, "Number,Title\n1,Gutenberg\n2,Printing",);
         };
@@ -784,7 +784,7 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result, ".hello {}\n",);
+            assert_eq!(result.as_str().unwrap().replace("\r\n","\n"), ".hello {}\n",);
         } else {
             assert_eq!(result, ".hello {}\n",);
         };

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -1,8 +1,8 @@
 use utils::de::fix_toml_dates;
 use utils::fs::{get_file_time, is_path_in_directory, read_file};
 
+use reqwest::header::{HeaderValue, CONTENT_TYPE};
 use reqwest::{blocking::Client, header};
-use reqwest::header::{CONTENT_TYPE,HeaderValue};
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -24,22 +24,24 @@ enum DataSource {
     Path(PathBuf),
 }
 
-#[derive(Debug,PartialEq,Clone,Copy,Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash)]
 enum Method {
-	Post,
-	Get,
+    Post,
+    Get,
 }
 
 impl FromStr for Method {
-	type Err = Error;
-	
-	fn from_str(s: &str) -> Result<Self> {
-		if s.to_lowercase() == "post"{
-			Ok(Method::Post)
-		} else if s.to_lowercase() == "get" {
-			Ok(Method::Get)
-		} else {return Err("`load_data` method must either be POST or GET.".into())}
-	}
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if s.to_lowercase() == "post" {
+            Ok(Method::Post)
+        } else if s.to_lowercase() == "get" {
+            Ok(Method::Get)
+        } else {
+            return Err("`load_data` method must either be POST or GET.".into());
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -123,12 +125,18 @@ impl DataSource {
         Err(GET_DATA_ARGUMENT_ERROR_MESSAGE.into())
     }
 
-    fn get_cache_key(&self, format: &OutputFormat, method_arg: Option<String>, method_post_body: Option<String>, method_post_contenttype: Option<String>) -> u64 {
+    fn get_cache_key(
+        &self,
+        format: &OutputFormat,
+        method_arg: Option<String>,
+        method_post_body: Option<String>,
+        method_post_contenttype: Option<String>,
+    ) -> u64 {
         let mut hasher = DefaultHasher::new();
         format.hash(&mut hasher);
-		method_arg.hash(&mut hasher);
-		method_post_body.hash(&mut hasher);
-		method_post_contenttype.hash(&mut hasher);
+        method_arg.hash(&mut hasher);
+        method_post_body.hash(&mut hasher);
+        method_post_contenttype.hash(&mut hasher);
         self.hash(&mut hasher);
         hasher.finish()
     }
@@ -223,18 +231,25 @@ impl TeraFn for LoadData {
         };
         let path_arg = optional_arg!(String, args.get("path"), GET_DATA_ARGUMENT_ERROR_MESSAGE);
         let url_arg = optional_arg!(String, args.get("url"), GET_DATA_ARGUMENT_ERROR_MESSAGE);
-		let post_body_arg = optional_arg!(String, args.get("body"), "`load_data` body must be a string, if set.");
-		let post_content_type = optional_arg!(String, args.get("content_type"), "`load_data` content_type must be a string, if set.");
-		let method_arg = optional_arg!(String, args.get("method"), "`load_data` method must either be POST or GET.");
-		let method = match method_arg {
-			Some(ref method_str) => {
-				match Method::from_str(&method_str) {
-					Ok(m) => {m}
-					Err(e) => {return Err(e)}					
-				}
-			}
-			_ => Method::Get
-		};
+        let post_body_arg =
+            optional_arg!(String, args.get("body"), "`load_data` body must be a string, if set.");
+        let post_content_type = optional_arg!(
+            String,
+            args.get("content_type"),
+            "`load_data` content_type must be a string, if set."
+        );
+        let method_arg = optional_arg!(
+            String,
+            args.get("method"),
+            "`load_data` method must either be POST or GET."
+        );
+        let method = match method_arg {
+            Some(ref method_str) => match Method::from_str(&method_str) {
+                Ok(m) => m,
+                Err(e) => return Err(e),
+            },
+            _ => Method::Get,
+        };
         let data_source = DataSource::from_args(path_arg.clone(), url_arg, &self.base_path)?;
 
         // If the file doesn't exist, source is None
@@ -256,7 +271,12 @@ impl TeraFn for LoadData {
         }
         let data_source = data_source.unwrap();
         let file_format = get_output_format_from_args(&args, &data_source)?;
-        let cache_key = data_source.get_cache_key(&file_format,method_arg,post_body_arg.clone(),post_content_type.clone());
+        let cache_key = data_source.get_cache_key(
+            &file_format,
+            method_arg,
+            post_body_arg.clone(),
+            post_content_type.clone(),
+        );
 
         let mut cache = self.result_cache.lock().expect("result cache lock");
         let response_client = self.client.lock().expect("response client lock");
@@ -267,38 +287,40 @@ impl TeraFn for LoadData {
         let data = match data_source {
             DataSource::Path(path) => read_data_file(&self.base_path, path),
             DataSource::Url(url) => {
-				let req = match method {
-					Method::Get => {
-						response_client
-						.get(url.as_str())
-						.header(header::ACCEPT, file_format.as_accept_header())
-					}
-					Method::Post => {
-						let mut resp = response_client
-						.post(url.as_str())
-						.header(header::ACCEPT, file_format.as_accept_header());
-						match post_content_type {
-							Some(content_type) => {
-									match HeaderValue::from_str(&content_type) {
-										Ok(c) => {resp = resp.header(CONTENT_TYPE,c );}
-										Err(_) => {return Err(format!("{} is an illegal contenttype",&content_type).into());}
-									}
-									
-								}
-							_ => {}
-						};
-						match post_body_arg {
-							Some(body) => {resp = resp.body(body);}
-							_ => {}
-						};
-						resp
-					}
-				};
-			
-                match 
-                    req.send()
-                    .and_then(|res| res.error_for_status())
-                {
+                let req = match method {
+                    Method::Get => response_client
+                        .get(url.as_str())
+                        .header(header::ACCEPT, file_format.as_accept_header()),
+                    Method::Post => {
+                        let mut resp = response_client
+                            .post(url.as_str())
+                            .header(header::ACCEPT, file_format.as_accept_header());
+                        match post_content_type {
+                            Some(content_type) => match HeaderValue::from_str(&content_type) {
+                                Ok(c) => {
+                                    resp = resp.header(CONTENT_TYPE, c);
+                                }
+                                Err(_) => {
+                                    return Err(format!(
+                                        "{} is an illegal contenttype",
+                                        &content_type
+                                    )
+                                    .into());
+                                }
+                            },
+                            _ => {}
+                        };
+                        match post_body_arg {
+                            Some(body) => {
+                                resp = resp.body(body);
+                            }
+                            _ => {}
+                        };
+                        resp
+                    }
+                };
+
+                match req.send().and_then(|res| res.error_for_status()) {
                     Ok(r) => r.text().map_err(|e| {
                         format!("Failed to parse response from {}: {:?}", url, e).into()
                     }),
@@ -477,106 +499,106 @@ mod tests {
         let test_files = PathBuf::from("../utils/test-files").canonicalize().unwrap();
         return test_files.join(filename);
     }
-	
-	#[test]
-	fn fails_illegal_method_parameter() {
-		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
+
+    #[test]
+    fn fails_illegal_method_parameter() {
+        let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value("https://example.com").unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
-		args.insert("method".to_string(), to_value("illegalmethod").unwrap());
+        args.insert("method".to_string(), to_value("illegalmethod").unwrap());
         let result = static_fn.call(&args);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
             .to_string()
             .contains("`load_data` method must either be POST or GET."));
-	}
-	
-	#[test]
-	fn can_load_remote_data_using_post_method(){
-		let _mg = mock("GET", "/kr1zdgbm4y")
+    }
+
+    #[test]
+    fn can_load_remote_data_using_post_method() {
+        let _mg = mock("GET", "/kr1zdgbm4y")
             .with_header("content-type", "text/plain")
             .with_body("GET response")
-			.expect(0)
+            .expect(0)
             .create();
-		let _mp = mock("POST", "/kr1zdgbm4y")
+        let _mp = mock("POST", "/kr1zdgbm4y")
             .with_header("content-type", "text/plain")
             .with_body("POST response")
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y");
-		
-		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
+
+        let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
         let mut args = HashMap::new();
-		args.insert("url".to_string(), to_value(url).unwrap());
-		args.insert("format".to_string(), to_value("plain").unwrap());
-		args.insert("method".to_string(), to_value("post").unwrap());
-		let result = static_fn.call(&args);
-		assert!(result.is_ok());
-		assert_eq!(result.unwrap(),"POST response");
-		_mg.assert();
-		_mp.assert();
-	}
-	
-	#[test]
-	fn can_load_remote_data_using_post_method_with_content_type_header(){
-		let _mjson = mock("POST", "/kr1zdgbm4yw")
-			.match_header("content-type", "application/json")
+        args.insert("url".to_string(), to_value(url).unwrap());
+        args.insert("format".to_string(), to_value("plain").unwrap());
+        args.insert("method".to_string(), to_value("post").unwrap());
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "POST response");
+        _mg.assert();
+        _mp.assert();
+    }
+
+    #[test]
+    fn can_load_remote_data_using_post_method_with_content_type_header() {
+        let _mjson = mock("POST", "/kr1zdgbm4yw")
+            .match_header("content-type", "application/json")
             .with_header("content-type", "application/json")
             .with_body("{i_am:'json'}")
-			.expect(0)
+            .expect(0)
             .create();
-		let _mtext = mock("POST", "/kr1zdgbm4yw")
-			.match_header("content-type", "text/plain")
+        let _mtext = mock("POST", "/kr1zdgbm4yw")
+            .match_header("content-type", "text/plain")
             .with_header("content-type", "text/plain")
             .with_body("POST response text")
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4yw");
-		
-		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
+
+        let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
         let mut args = HashMap::new();
-		args.insert("url".to_string(), to_value(url).unwrap());
-		args.insert("format".to_string(), to_value("plain").unwrap());
-		args.insert("method".to_string(), to_value("post").unwrap());
-		args.insert("content_type".to_string(), to_value("text/plain").unwrap());
-		let result = static_fn.call(&args);
-		assert!(result.is_ok());
-		assert_eq!(result.unwrap(),"POST response text");
-		_mjson.assert();
-		_mtext.assert();
-	}
-	
-	#[test]
-	fn can_load_remote_data_using_post_method_with_body(){
-		let _mjson = mock("POST", "/kr1zdgbm4y")
-			.match_body("qwerty")
+        args.insert("url".to_string(), to_value(url).unwrap());
+        args.insert("format".to_string(), to_value("plain").unwrap());
+        args.insert("method".to_string(), to_value("post").unwrap());
+        args.insert("content_type".to_string(), to_value("text/plain").unwrap());
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "POST response text");
+        _mjson.assert();
+        _mtext.assert();
+    }
+
+    #[test]
+    fn can_load_remote_data_using_post_method_with_body() {
+        let _mjson = mock("POST", "/kr1zdgbm4y")
+            .match_body("qwerty")
             .with_header("content-type", "application/json")
             .with_body("{i_am:'json'}")
-			.expect(0)
+            .expect(0)
             .create();
-		let _mtext = mock("POST", "/kr1zdgbm4y")
-			.match_body("this is a match")
+        let _mtext = mock("POST", "/kr1zdgbm4y")
+            .match_body("this is a match")
             .with_header("content-type", "text/plain")
             .with_body("POST response text")
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y");
-		
-		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
+
+        let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
         let mut args = HashMap::new();
-		args.insert("url".to_string(), to_value(url).unwrap());
-		args.insert("format".to_string(), to_value("plain").unwrap());
-		args.insert("method".to_string(), to_value("post").unwrap());
-		args.insert("content_type".to_string(), to_value("text/plain").unwrap());
-		args.insert("body".to_string(), to_value("this is a match").unwrap());
-		let result = static_fn.call(&args);
-		assert!(result.is_ok());
-		assert_eq!(result.unwrap(),"POST response text");
-		_mjson.assert();
-		_mtext.assert();
-	}
+        args.insert("url".to_string(), to_value(url).unwrap());
+        args.insert("format".to_string(), to_value("plain").unwrap());
+        args.insert("method".to_string(), to_value("post").unwrap());
+        args.insert("content_type".to_string(), to_value("text/plain").unwrap());
+        args.insert("body".to_string(), to_value("this is a match").unwrap());
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "POST response text");
+        _mjson.assert();
+        _mtext.assert();
+    }
 
     #[test]
     fn fails_when_missing_file() {
@@ -616,10 +638,18 @@ mod tests {
     #[test]
     fn calculates_cache_key_for_path() {
         // We can't test against a fixed value, due to the fact the cache key is built from the absolute path
-        let cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
-        let cache_key_2 =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
+        let cache_key = DataSource::Path(get_test_file("test.toml")).get_cache_key(
+            &OutputFormat::Toml,
+            None,
+            None,
+            None,
+        );
+        let cache_key_2 = DataSource::Path(get_test_file("test.toml")).get_cache_key(
+            &OutputFormat::Toml,
+            None,
+            None,
+            None,
+        );
         assert_eq!(cache_key, cache_key_2);
     }
 
@@ -631,25 +661,46 @@ mod tests {
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y");
-        let cache_key = DataSource::Url(url.parse().unwrap()).get_cache_key(&OutputFormat::Plain,None,None,None);
+        let cache_key = DataSource::Url(url.parse().unwrap()).get_cache_key(
+            &OutputFormat::Plain,
+            None,
+            None,
+            None,
+        );
         assert_eq!(cache_key, 16044537454280534951);
     }
 
     #[test]
     fn different_cache_key_per_filename() {
-        let toml_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
-        let json_cache_key =
-            DataSource::Path(get_test_file("test.json")).get_cache_key(&OutputFormat::Toml,None,None,None);
+        let toml_cache_key = DataSource::Path(get_test_file("test.toml")).get_cache_key(
+            &OutputFormat::Toml,
+            None,
+            None,
+            None,
+        );
+        let json_cache_key = DataSource::Path(get_test_file("test.json")).get_cache_key(
+            &OutputFormat::Toml,
+            None,
+            None,
+            None,
+        );
         assert_ne!(toml_cache_key, json_cache_key);
     }
 
     #[test]
     fn different_cache_key_per_format() {
-        let toml_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Toml,None,None,None);
-        let json_cache_key =
-            DataSource::Path(get_test_file("test.toml")).get_cache_key(&OutputFormat::Json,None,None,None);
+        let toml_cache_key = DataSource::Path(get_test_file("test.toml")).get_cache_key(
+            &OutputFormat::Toml,
+            None,
+            None,
+            None,
+        );
+        let json_cache_key = DataSource::Path(get_test_file("test.toml")).get_cache_key(
+            &OutputFormat::Json,
+            None,
+            None,
+            None,
+        );
         assert_ne!(toml_cache_key, json_cache_key);
     }
 
@@ -769,7 +820,7 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result.as_str().unwrap().replace("\r\n","\n"), ".hello {}\n",);
+            assert_eq!(result.as_str().unwrap().replace("\r\n", "\n"), ".hello {}\n",);
         } else {
             assert_eq!(result, ".hello {}\n",);
         };
@@ -784,7 +835,10 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result.as_str().unwrap().replace("\r\n","\n"), "Number,Title\n1,Gutenberg\n2,Printing",);
+            assert_eq!(
+                result.as_str().unwrap().replace("\r\n", "\n"),
+                "Number,Title\n1,Gutenberg\n2,Printing",
+            );
         } else {
             assert_eq!(result, "Number,Title\n1,Gutenberg\n2,Printing",);
         };
@@ -799,7 +853,7 @@ mod tests {
         let result = static_fn.call(&args.clone()).unwrap();
 
         if cfg!(windows) {
-            assert_eq!(result.as_str().unwrap().replace("\r\n","\n"), ".hello {}\n",);
+            assert_eq!(result.as_str().unwrap().replace("\r\n", "\n"), ".hello {}\n",);
         } else {
             assert_eq!(result, ".hello {}\n",);
         };
@@ -884,67 +938,67 @@ mod tests {
             })
         )
     }
-	
-	#[test]
-	fn is_load_remote_data_using_post_method_with_different_body_not_cached(){
-		let _mjson = mock("POST", "/kr1zdgbm4y3")
+
+    #[test]
+    fn is_load_remote_data_using_post_method_with_different_body_not_cached() {
+        let _mjson = mock("POST", "/kr1zdgbm4y3")
             .with_header("content-type", "application/json")
             .with_body("{i_am:'json'}")
-			.expect(2)
+            .expect(2)
             .create();
-		let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y3");
+        let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y3");
 
-		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
+        let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
         let mut args = HashMap::new();
-		args.insert("url".to_string(), to_value(&url).unwrap());
-		args.insert("format".to_string(), to_value("plain").unwrap());
-		args.insert("method".to_string(), to_value("post").unwrap());
-		args.insert("contenttype".to_string(), to_value("text/plain").unwrap());
-		args.insert("body".to_string(), to_value("this is a match").unwrap());
-		let result = static_fn.call(&args);
-		assert!(result.is_ok());
+        args.insert("url".to_string(), to_value(&url).unwrap());
+        args.insert("format".to_string(), to_value("plain").unwrap());
+        args.insert("method".to_string(), to_value("post").unwrap());
+        args.insert("contenttype".to_string(), to_value("text/plain").unwrap());
+        args.insert("body".to_string(), to_value("this is a match").unwrap());
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
 
-		let mut args2 = HashMap::new();
-		args2.insert("url".to_string(), to_value(&url).unwrap());
-		args2.insert("format".to_string(), to_value("plain").unwrap());
-		args2.insert("method".to_string(), to_value("post").unwrap());
-		args2.insert("contenttype".to_string(), to_value("text/plain").unwrap());
-		args2.insert("body".to_string(), to_value("this is a match2").unwrap());
-		let result2 = static_fn.call(&args2);
-		assert!(result2.is_ok());
+        let mut args2 = HashMap::new();
+        args2.insert("url".to_string(), to_value(&url).unwrap());
+        args2.insert("format".to_string(), to_value("plain").unwrap());
+        args2.insert("method".to_string(), to_value("post").unwrap());
+        args2.insert("contenttype".to_string(), to_value("text/plain").unwrap());
+        args2.insert("body".to_string(), to_value("this is a match2").unwrap());
+        let result2 = static_fn.call(&args2);
+        assert!(result2.is_ok());
 
-		_mjson.assert();	
-	}
+        _mjson.assert();
+    }
 
-	#[test]
-	fn is_load_remote_data_using_post_method_with_same_body_cached(){
-		let _mjson = mock("POST", "/kr1zdgbm4y2")
-			.match_body("this is a match")
+    #[test]
+    fn is_load_remote_data_using_post_method_with_same_body_cached() {
+        let _mjson = mock("POST", "/kr1zdgbm4y2")
+            .match_body("this is a match")
             .with_header("content-type", "application/json")
             .with_body("{i_am:'json'}")
-			.expect(1)
+            .expect(1)
             .create();
-		let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y2");
+        let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y2");
 
-		let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
+        let static_fn = LoadData::new(PathBuf::from(PathBuf::from("../utils")));
         let mut args = HashMap::new();
-		args.insert("url".to_string(), to_value(&url).unwrap());
-		args.insert("format".to_string(), to_value("plain").unwrap());
-		args.insert("method".to_string(), to_value("post").unwrap());
-		args.insert("contenttype".to_string(), to_value("text/plain").unwrap());
-		args.insert("body".to_string(), to_value("this is a match").unwrap());
-		let result = static_fn.call(&args);
-		assert!(result.is_ok());
+        args.insert("url".to_string(), to_value(&url).unwrap());
+        args.insert("format".to_string(), to_value("plain").unwrap());
+        args.insert("method".to_string(), to_value("post").unwrap());
+        args.insert("contenttype".to_string(), to_value("text/plain").unwrap());
+        args.insert("body".to_string(), to_value("this is a match").unwrap());
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
 
-		let mut args2 = HashMap::new();
-		args2.insert("url".to_string(), to_value(&url).unwrap());
-		args2.insert("format".to_string(), to_value("plain").unwrap());
-		args2.insert("method".to_string(), to_value("post").unwrap());
-		args2.insert("contenttype".to_string(), to_value("text/plain").unwrap());
-		args2.insert("body".to_string(), to_value("this is a match").unwrap());
-		let result2 = static_fn.call(&args2);
-		assert!(result2.is_ok());
+        let mut args2 = HashMap::new();
+        args2.insert("url".to_string(), to_value(&url).unwrap());
+        args2.insert("format".to_string(), to_value("plain").unwrap());
+        args2.insert("method".to_string(), to_value("post").unwrap());
+        args2.insert("contenttype".to_string(), to_value("text/plain").unwrap());
+        args2.insert("body".to_string(), to_value("this is a match").unwrap());
+        let result2 = static_fn.call(&args2);
+        assert!(result2.is_ok());
 
-		_mjson.assert();	
-	}
+        _mjson.assert();
+    }
 }

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -349,13 +349,13 @@ The parameter contenttype should be the mimetype of the body.
 This example will make a POST request to the kroki service to generate a SVG.
 
 ```jinja2
-{% set postdata = load_data(url="https://kroki.io/blockdiag/svg", format="plain", method="POST" , contenttype="text/plain", body="blockdiag {
+{% set postdata = load_data(url="https://kroki.io/blockdiag/svg", format="plain", method="POST" ,content_type="text/plain", body="blockdiag {
   'Doing POST' -> 'using load_data'
-  'using load_data' -> 'can generate' -> 'Block diagrams';
+  'using load_data' -> 'can generate' -> 'block diagrams';
   'using load_data' -> is -> 'very easy!';
 
   'Doing POST' [color = 'greenyellow'];
-  'Block diagrams' [color = 'pink'];
+  'block diagrams' [color = 'pink'];
   'very easy!' [color = 'orange'];
 }")%}
 {{postdata|safe}}

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -339,6 +339,18 @@ as below.
 {{ response }}
 ```
 
+When no other parameters are specified the URL will always be retrieved using a HTTP GET request.
+Using the parameter `method`, since version 0.14.0, you can also choose to retrieve the URL using a POST request.
+
+When using `method="POST"` you can also use the parameters `body` and `contenttype`.
+The parameter body is the actual contents sent in the POST request.
+The parameter contenttype should be the mimetype of the body.
+
+```jinja2
+{% set postresponse = load_data(url="https://postman-echo.com/post", format="json", method="POST", body="{i_am:'json'}", contenttype="application/json") %}
+{{ postresponse }}
+```
+
 #### Data caching
 
 Data file loading and remote requests are cached in memory during the build, so multiple requests aren't made

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -346,9 +346,19 @@ When using `method="POST"` you can also use the parameters `body` and `contentty
 The parameter body is the actual contents sent in the POST request.
 The parameter contenttype should be the mimetype of the body.
 
+This example will make a POST request to the kroki service to generate a SVG.
+
 ```jinja2
-{% set postresponse = load_data(url="https://postman-echo.com/post", format="json", method="POST", body="{i_am:'json'}", contenttype="application/json") %}
-{{ postresponse }}
+{% set postdata = load_data(url="https://kroki.io/blockdiag/svg", format="plain", method="POST" , contenttype="text/plain", body="blockdiag {
+  'Doing POST' -> 'using load_data'
+  'using load_data' -> 'can generate' -> 'Block diagrams';
+  'using load_data' -> is -> 'very easy!';
+
+  'Doing POST' [color = 'greenyellow'];
+  'Block diagrams' [color = 'pink'];
+  'very easy!' [color = 'orange'];
+}")%}
+{{postdata|safe}}
 ```
 
 #### Data caching

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -258,7 +258,7 @@ mod tests {
         if cfg!(target_os = "windows") {
             assert_eq!(
                 strip_unc(&canonicalize(Path::new(&dir)).unwrap()),
-                dir.to_str().unwrap().to_string()
+                "C:\\Users\\VssAdministrator\\AppData\\Local\\Temp\\new_project"
             )
         } else {
             assert_eq!(
@@ -284,7 +284,7 @@ mod tests {
         create_dir(&dir).expect("Could not create test directory");
         assert_eq!(
             canonicalize(Path::new(&dir)).unwrap().to_str().unwrap(),
-            format!("\\\\?\\{}",dir.to_str().unwrap().to_string())
+            "\\\\?\\C:\\Users\\VssAdministrator\\AppData\\Local\\Temp\\new_project"
         );
 
         remove_dir_all(&dir).unwrap();

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -258,7 +258,7 @@ mod tests {
         if cfg!(target_os = "windows") {
             assert_eq!(
                 strip_unc(&canonicalize(Path::new(&dir)).unwrap()),
-                "C:\\Users\\VssAdministrator\\AppData\\Local\\Temp\\new_project"
+                dir.to_str().unwrap().to_string()
             )
         } else {
             assert_eq!(
@@ -284,7 +284,7 @@ mod tests {
         create_dir(&dir).expect("Could not create test directory");
         assert_eq!(
             canonicalize(Path::new(&dir)).unwrap().to_str().unwrap(),
-            "\\\\?\\C:\\Users\\VssAdministrator\\AppData\\Local\\Temp\\new_project"
+            format!("\\\\?\\{}",dir.to_str().unwrap().to_string())
         );
 
         remove_dir_all(&dir).unwrap();


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?


This PR adds POST capability to the load_data function.

Three optional parameters are added:
- `method` value must be either GET or POST. setting this to POST will make the request a POST request.
- `body` can be used to send a body in the POST request.
- `contenttype` sets the content-type header and should reflect the mime-type of the body.

These parameters are ignored when path is used instead of url.

