### PR TITLE
Provide the current mode to templates

### DIFF
--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -88,7 +88,7 @@ pub struct Config {
 
     /// The mode Zola is currently being ran on. Some logging/feature can differ depending on the
     /// command being used.
-    #[serde(skip_serializing)]
+    #[serde(skip_deserializing)]
     pub mode: Mode,
 
     /// A list of directories to search for additional `.sublime-syntax` files in.

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -15,7 +15,9 @@ you can place `{{ __tera_context }}` in the template to print the whole context.
 
 A few variables are available on all templates except feeds and the sitemap:
 
-- `config`: the [configuration](@/documentation/getting-started/configuration.md) without any modifications
+- `config`: the [configuration](@/documentation/getting-started/configuration.md)
+  with an extra field, `mode`, containing the build mode (`"Check"`,
+  `"Build"`, or `"Serve"`)
 - `current_path`: the path (full URL without `base_url`) of the current page, always starting with a `/`
 - `current_url`: the full URL for the current page
 - `lang`: the language for the current page


### PR DESCRIPTION
This is useful specifically if you have stuff in your templates such as
`__tera_context` dumping gated behind a configuration setting. It was
previously impossible to tell if the site was building in production to
stop this from ever accidentally getting into a production build even if
the config setting were accidentally enabled.

Providing this to templates solves this issue, although it is impure.



Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



