### PR TITLE
cargo: run rustfmt on the codebase

### DIFF
--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -712,7 +712,8 @@ Hello world
 Hello world
 <!-- more -->"#
             .to_string();
-        let res = Page::parse(Path::new("2018-10-08 - hello.md"), &content, &config, &PathBuf::new());
+        let res =
+            Page::parse(Path::new("2018-10-08 - hello.md"), &content, &config, &PathBuf::new());
         assert!(res.is_ok());
         let page = res.unwrap();
 
@@ -730,7 +731,8 @@ Hello world
 Hello world
 <!-- more -->"#
             .to_string();
-        let res = Page::parse(Path::new("2018-10-08 - hello.md"), &content, &config, &PathBuf::new());
+        let res =
+            Page::parse(Path::new("2018-10-08 - hello.md"), &content, &config, &PathBuf::new());
         assert!(res.is_ok());
         let page = res.unwrap();
 

--- a/components/library/src/library.rs
+++ b/components/library/src/library.rs
@@ -187,8 +187,6 @@ impl Library {
                 }
             }
             ancestors.insert(section.file.path.clone(), parents);
-
-
         }
 
         for (key, page) in &mut self.pages {

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -243,11 +243,8 @@ impl Site {
                     .collect::<Vec<DirEntry>>();
 
                 for index_file in index_files {
-                    let section = Section::from_file(
-                        index_file.path(),
-                        &self.config,
-                        &self.base_path,
-                    )?;
+                    let section =
+                        Section::from_file(index_file.path(), &self.config, &self.base_path)?;
 
                     // if the section is drafted we can skip the enitre dir
                     if section.meta.draft && !self.include_drafts {

--- a/components/templates/src/global_fns/mod.rs
+++ b/components/templates/src/global_fns/mod.rs
@@ -839,27 +839,23 @@ title = "A title"
     #[test]
     fn can_get_feed_url_with_default_language() {
         let config = Config::parse(TRANS_CONFIG).unwrap();
-        let static_fn = GetUrl::new(config.clone(), HashMap::new(), vec![TEST_CONTEXT.static_path.clone()]);
+        let static_fn =
+            GetUrl::new(config.clone(), HashMap::new(), vec![TEST_CONTEXT.static_path.clone()]);
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value(config.feed_filename).unwrap());
         args.insert("lang".to_string(), to_value("fr").unwrap());
-        assert_eq!(
-            static_fn.call(&args).unwrap(),
-            "https://remplace-par-ton-url.fr/atom.xml"
-        );
+        assert_eq!(static_fn.call(&args).unwrap(), "https://remplace-par-ton-url.fr/atom.xml");
     }
 
     #[test]
     fn can_get_feed_url_with_other_language() {
         let config = Config::parse(TRANS_CONFIG).unwrap();
-        let static_fn = GetUrl::new(config.clone(), HashMap::new(), vec![TEST_CONTEXT.static_path.clone()]);
+        let static_fn =
+            GetUrl::new(config.clone(), HashMap::new(), vec![TEST_CONTEXT.static_path.clone()]);
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value(config.feed_filename).unwrap());
         args.insert("lang".to_string(), to_value("en").unwrap());
-        assert_eq!(
-            static_fn.call(&args).unwrap(),
-            "https://remplace-par-ton-url.fr/en/atom.xml"
-        );
+        assert_eq!(static_fn.call(&args).unwrap(), "https://remplace-par-ton-url.fr/en/atom.xml");
     }
 
     #[test]

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -256,9 +256,9 @@ mod tests {
         }
         create_dir(&dir).expect("Could not create test directory");
         if cfg!(target_os = "windows") {
-			let stripped_path = strip_unc(&canonicalize(Path::new(&dir)).unwrap());
-			assert!(same_file::is_same_file(Path::new(&stripped_path),&dir).unwrap()); 
-            assert!(!stripped_path.starts_with(LOCAL_UNC),"The path was not stripped.");
+            let stripped_path = strip_unc(&canonicalize(Path::new(&dir)).unwrap());
+            assert!(same_file::is_same_file(Path::new(&stripped_path), &dir).unwrap());
+            assert!(!stripped_path.starts_with(LOCAL_UNC), "The path was not stripped.");
         } else {
             assert_eq!(
                 strip_unc(&canonicalize(Path::new(&dir)).unwrap()),
@@ -281,9 +281,9 @@ mod tests {
             remove_dir_all(&dir).expect("Could not free test directory");
         }
         create_dir(&dir).expect("Could not create test directory");
-		
-		let canonicalized_path = canonicalize(Path::new(&dir)).unwrap();
-		assert!(same_file::is_same_file(Path::new(&canonicalized_path),&dir).unwrap());
+
+        let canonicalized_path = canonicalize(Path::new(&dir)).unwrap();
+        assert!(same_file::is_same_file(Path::new(&canonicalized_path), &dir).unwrap());
         assert!(canonicalized_path.to_str().unwrap().starts_with(LOCAL_UNC));
 
         remove_dir_all(&dir).unwrap();

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -274,11 +274,7 @@ pub fn serve(
         return Err(format!("Cannot start server on address {}.", address).into());
     }
 
-    let config_filename = config_file
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap_or("config.toml");
+    let config_filename = config_file.file_name().unwrap().to_str().unwrap_or("config.toml");
 
     // An array of (path, bool, bool) where the path should be watched for changes, and the boolean value
     // indicates whether this file/folder must exist for zola serve to operate
@@ -478,7 +474,7 @@ pub fn serve(
         match rx.recv() {
             Ok(event) => {
                 let can_do_fast_reload = !matches!(event, Remove(_));
-                
+
                 match event {
                     // Intellij does weird things on edit, chmod is there to count those changes
                     // https://github.com/passcod/notify/issues/150#issuecomment-494912080


### PR DESCRIPTION
This applies a rustfmt pass on the whole project, in order to avoid
spurious reflows while working on unrelated changes.

---

Sanity checks:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?
* [ ] Have you created/updated the relevant documentation page(s)?
  * LB: Not applicable 



