### PR TITLE
link_checking: prevent rate-limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
  "tempfile",
  "templates",
  "tera",
+ "url",
  "utils",
  "walkdir",
 ]

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -16,6 +16,7 @@ sass-rs = "0.2"
 lazy_static = "1.1"
 relative-path = "1"
 slotmap = "0.4"
+url = "2"
 
 errors = { path = "../errors" }
 config = { path = "../config" }

--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -156,14 +156,11 @@ pub fn check_external_links(site: &Site) -> Result<()> {
     let errors = pool.install(|| {
         links_by_domain
             .par_iter()
-            .map(|(domain, links)| {
-                println!("Thread for domain: {}", domain);
-
+            .map(|(_domain, links)| {
                 let mut links_to_process = links.len();
                 links
                     .into_iter()
                     .filter_map(move |(page_path, link)| {
-                        println!("Domain: {}, url: {:?}", domain, link);
                         links_to_process -= 1;
 
                         if site

--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -159,12 +159,12 @@ pub fn check_external_links(site: &Site) -> Result<()> {
             .map(|(domain, links)| {
                 println!("Thread for domain: {}", domain);
 
-                let mut links_processed = 0;
+                let mut links_to_process = links.len();
                 links
                     .into_iter()
                     .filter_map(move |(page_path, link)| {
                         println!("Domain: {}, url: {:?}", domain, link);
-                        links_processed += 1;
+                        links_to_process -= 1;
 
                         if site
                             .config
@@ -178,7 +178,7 @@ pub fn check_external_links(site: &Site) -> Result<()> {
 
                         let res = link_checker::check_url(&link, &site.config.link_checker);
 
-                        if links_processed != links.len() {
+                        if links_to_process > 0 {
                             // Prevent rate-limiting, wait before next crawl unless we're done with this domain
                             thread::sleep(time::Duration::from_millis(500));
                         }


### PR DESCRIPTION
Fix for https://github.com/getzola/zola/issues/1056.

- assign all links for a domain to the same thread
- reduce number of threads from 32 to 8
- add sleep between HTTP calls

Demo

```
devenv :: ~/dawn-zola ‹main› » time ~/zola/target/debug/zola check
Checking site...
Checking 0 internal link(s) with an anchor.
Checking 502 external link(s).
Thread for domain: soundiiz.com
Thread for domain: grafana.com
Thread for domain: web.archive.org
[...]
Thread for domain: docs.docker.com
Domain: docs.docker.com, url: "https://docs.docker.com/docker-hub/github/"
Domain: docs.docker.com, url: "https://docs.docker.com/engine/reference/commandline/login/#provide-a-password-using-stdin"
Thread for domain: wiki.diasporafoundation.org
Domain: wiki.diasporafoundation.org, url: "https://wiki.diasporafoundation.org/Installation/Debian/Jessie"
Thread for domain: core.telegram.org
Domain: core.telegram.org, url: "https://core.telegram.org/bots"
Domain: grafana.com, url: "https://grafana.com/plugins?type=datasource"
Domain: twitter.com, url: "https://twitter.com/fuolpit"
Domain: docs.docker.com, url: "https://docs.docker.com/storage/storagedriver/zfs-driver/"
Thread for domain: caniuse.com
Domain: caniuse.com, url: "https://caniuse.com/#feat=tls1-3"
Domain: twitter.com, url: "https://twitter.com/torproject?ref_src=twsrc%5Etfw"
[...]
Domain: github.com, url: "https://github.com/hyperic/sigar/issues/74"
Domain: github.com, url: "https://github.com/Angristan/dockerfiles/tree/master/diaspora"
Domain: github.com, url: "https://github.com/angristan/dockerfiles/tree/master/diaspora"
Domain: github.com, url: "https://github.com/caddyserver/caddy/issues/2080"
Domain: github.com, url: "https://github.com/caddyserver/caddy/releases/tag/v0.11.5"
Domain: github.com, url: "https://github.com/sivel/speedtest-cli"
Domain: github.com, url: "https://github.com/sivel/speedtest-cli#installation"
Domain: github.com, url: "https://github.com/sivel/speedtest-cli#usage"
Domain: github.com, url: "https://github.com/Microsoft/vscode/issues/51132"
Domain: github.com, url: "https://github.com/alexanderyakusik"
Domain: github.com, url: "https://github.com/Microsoft/vscode/issues/51132#issuecomment-424132330"
> Checked 502 external link(s): 1 error(s) found.
Failed to check the site
Error: Dead link in /root/dawn-zola/content/2018-03-diaspora-in-docker/index.md to https://gitlab.koehn.com/docker/diaspora: error sending request for url (https://gitlab.koehn.com/docker/diaspora): operation timed out
~/zola/target/debug/zola check  14.13s user 1.44s system 8% cpu 3:05.32 total
```

Considering there is 500 links to check, it takes about 2.7s per link. Out of these 500 links there are 150 `github.com` links, that's why we see all the github links at the end, since this is the last thread running. I didn't get any `429 Too Many Requests` using this patch.

---

This is my first time using Rust 🦀, so I'm not familiar with the idiomatic way of doing things. I had a hard times with iterators, but it looks like I ended up with something that works! I look forward to some review so I can see what can be improved. 🙏  I added a few comments on things that I'm not sure how to handle.