### PR TITLE
cargo: update slotmap to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,9 +2490,12 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "slotmap"
-version = "0.4.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46a3482db8f247956e464d783693ece164ca056e6e67563ee5505bdb86452cd"
+checksum = "ab3003725ae562cf995f3dc82bb99e70926e09000396816765bb6d7adbe740b1"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "slug"
@@ -3028,9 +3031,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "walkdir"

--- a/components/library/Cargo.toml
+++ b/components/library/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-slotmap = "0.4"
+slotmap = "1"
 rayon = "1"
 chrono = { version = "0.4", features = ["serde"] }
 tera = "1"

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = "1"
 sass-rs = "0.2"
 lazy_static = "1.1"
 relative-path = "1"
-slotmap = "0.4"
+slotmap = "1"
 
 errors = { path = "../errors" }
 config = { path = "../config" }


### PR DESCRIPTION
This bumps `slotmap` depedency to latest version.

---

Sanity checks:
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?
* [ ] Have you created/updated the relevant documentation page(s)?
  * Not applicable


