### PR TITLE
rendering: keep track of all internal links

### DIFF
--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -82,12 +82,11 @@ pub struct Page {
     pub lang: String,
     /// Contains all the translated version of that page
     pub translations: Vec<DefaultKey>,
-    /// Contains the internal links that have an anchor: we can only check the anchor
-    /// after all pages have been built and their ToC compiled. The page itself should exist otherwise
-    /// it would have errored before getting there
-    /// (path to markdown, anchor value)
-    pub internal_links_with_anchors: Vec<(String, String)>,
-    /// Contains the external links that need to be checked
+    /// The list of all internal links (as path to markdown file), with optional anchor fragments.
+    /// We can only check the anchor after all pages have been built and their ToC compiled.
+    /// The page itself should exist otherwise it would have errored before getting there.
+    pub internal_links: Vec<(String, Option<String>)>,
+    /// The list of all links to external webpages. They can be validated by the `link_checker`.
     pub external_links: Vec<String>,
 }
 
@@ -262,7 +261,7 @@ impl Page {
         self.content = res.body;
         self.toc = res.toc;
         self.external_links = res.external_links;
-        self.internal_links_with_anchors = res.internal_links_with_anchors;
+        self.internal_links = res.internal_links;
 
         Ok(())
     }

--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -56,12 +56,11 @@ pub struct Section {
     /// The language of that section. Equal to the default lang if the user doesn't setup `languages` in config.
     /// Corresponds to the lang in the _index.{lang}.md file scheme
     pub lang: String,
-    /// Contains the internal links that have an anchor: we can only check the anchor
-    /// after all pages have been built and their ToC compiled. The page itself should exist otherwise
-    /// it would have errored before getting there
-    /// (path to markdown, anchor value)
-    pub internal_links_with_anchors: Vec<(String, String)>,
-    /// Contains the external links that need to be checked
+    /// The list of all internal links (as path to markdown file), with optional anchor fragments.
+    /// We can only check the anchor after all pages have been built and their ToC compiled.
+    /// The page itself should exist otherwise it would have errored before getting there.
+    pub internal_links: Vec<(String, Option<String>)>,
+    /// The list of all links to external webpages. They can be validated by the `link_checker`.
     pub external_links: Vec<String>,
 }
 
@@ -185,7 +184,7 @@ impl Section {
         self.content = res.body;
         self.toc = res.toc;
         self.external_links = res.external_links;
-        self.internal_links_with_anchors = res.internal_links_with_anchors;
+        self.internal_links = res.internal_links;
 
         Ok(())
     }

--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -3,16 +3,21 @@ use rayon::prelude::*;
 use crate::Site;
 use errors::{Error, ErrorKind, Result};
 
-/// Very similar to check_external_links but can't be merged as far as I can see since we always
-/// want to check the internal links but only the external in zola check :/
+/// Check whether all internal links pointing to explicit anchor fragments are valid.
+///
+/// This is very similar to `check_external_links`, although internal links checking
+/// is always performed (while external ones only conditionally in `zola check`).
 pub fn check_internal_links_with_anchors(site: &Site) -> Result<()> {
+    println!("Checking all internal links with anchors.");
     let library = site.library.write().expect("Get lock for check_internal_links_with_anchors");
+
+    // Chain all internal links, from both sections and pages.
     let page_links = library
         .pages()
         .values()
         .map(|p| {
             let path = &p.file.path;
-            p.internal_links_with_anchors.iter().map(move |l| (path.clone(), l))
+            p.internal_links.iter().map(move |l| (path.clone(), l))
         })
         .flatten();
     let section_links = library
@@ -20,67 +25,46 @@ pub fn check_internal_links_with_anchors(site: &Site) -> Result<()> {
         .values()
         .map(|p| {
             let path = &p.file.path;
-            p.internal_links_with_anchors.iter().map(move |l| (path.clone(), l))
+            p.internal_links.iter().map(move |l| (path.clone(), l))
         })
         .flatten();
-    let all_links = page_links.chain(section_links).collect::<Vec<_>>();
+    let all_links = page_links.chain(section_links);
 
-    if site.config.is_in_check_mode() {
-        println!("Checking {} internal link(s) with an anchor.", all_links.len());
-    }
-
-    if all_links.is_empty() {
-        return Ok(());
-    }
-
-    let mut full_path = site.base_path.clone();
-    full_path.push("content");
-
-    let errors: Vec<_> = all_links
-        .iter()
-        .filter_map(|(page_path, (md_path, anchor))| {
-            // There are a few `expect` here since the presence of the .md file will
-            // already have been checked in the markdown rendering
-            let mut p = full_path.clone();
-            for part in md_path.split('/') {
-                p.push(part);
-            }
-            if md_path.contains("_index.md") {
-                let section = library
-                    .get_section(&p)
-                    .expect("Couldn't find section in check_internal_links_with_anchors");
-                if section.has_anchor(&anchor) {
-                    None
-                } else {
-                    Some((page_path, md_path, anchor))
-                }
-            } else {
-                let page = library
-                    .get_page(&p)
-                    .expect("Couldn't find section in check_internal_links_with_anchors");
-                if page.has_anchor(&anchor) {
-                    None
-                } else {
-                    Some((page_path, md_path, anchor))
-                }
-            }
+    // Only keep links with anchor fragments, and count them too.
+    // Bare files have already been checked elsewhere, thus they are not interesting here.
+    let mut anchors_total = 0usize;
+    let links_with_anchors = all_links
+        .filter_map(|(page_path, link)| match link {
+            (md_path, Some(anchor)) => Some((page_path, md_path, anchor)),
+            _ => None,
         })
-        .collect();
+        .inspect(|_| anchors_total = anchors_total.saturating_add(1));
 
-    if site.config.is_in_check_mode() {
-        println!(
-            "> Checked {} internal link(s) with an anchor: {} error(s) found.",
-            all_links.len(),
-            errors.len()
-        );
-    }
+    // Check for targets existence (including anchors), then keep only the faulty
+    // entries for error reporting purposes.
+    let missing_targets = links_with_anchors.filter(|(_, md_path, anchor)| {
+        // There are a few `expect` here since the presence of the .md file will
+        // already have been checked in the markdown rendering
+        let mut full_path = site.base_path.clone();
+        full_path.push("content");
+        for part in md_path.split('/') {
+            full_path.push(part);
+        }
+        if md_path.contains("_index.md") {
+            let section = library
+                .get_section(&full_path)
+                .expect("Couldn't find section in check_internal_links_with_anchors");
+            !section.has_anchor(&anchor)
+        } else {
+            let page = library
+                .get_page(&full_path)
+                .expect("Couldn't find section in check_internal_links_with_anchors");
+            !page.has_anchor(&anchor)
+        }
+    });
 
-    if errors.is_empty() {
-        return Ok(());
-    }
-
-    let msg = errors
-        .into_iter()
+    // Format faulty entries into error messages, and collect them.
+    let errors = missing_targets
         .map(|(page_path, md_path, anchor)| {
             format!(
                 "The anchor in the link `@/{}#{}` in {} does not exist.",
@@ -89,9 +73,22 @@ pub fn check_internal_links_with_anchors(site: &Site) -> Result<()> {
                 page_path.to_string_lossy(),
             )
         })
-        .collect::<Vec<_>>()
-        .join("\n");
-    Err(Error { kind: ErrorKind::Msg(msg), source: None })
+        .collect::<Vec<_>>();
+
+    // Finally emit a summary, and return overall anchors-checking result.
+    match errors.len() {
+        0 => {
+            println!("> Succesfully checked {} internal link(s) with anchors.", anchors_total);
+            Ok(())
+        }
+        errors_total => {
+            println!(
+                "> Checked {} internal link(s) with anchors: {} target(s) missing.",
+                anchors_total, errors_total,
+            );
+            Err(Error { kind: ErrorKind::Msg(errors.join("\n")), source: None })
+        }
+    }
 }
 
 pub fn check_external_links(site: &Site) -> Result<()> {


### PR DESCRIPTION
This updates rendered markdown structures in order to keep track
of all internal links, not anymore limiting to only those targeting
an explicit anchor fragment.
The goal of this rework is to allow building other features, such
as backlinks, on top of the existing collection of internal links.

---

Sanity check:
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?
* [ ] Have you created/updated the relevant documentation page(s)?
  * Not applicable 



