### PR TITLE
Issue/1359

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -107,9 +107,16 @@ async fn handle_request(req: Request<Body>, mut root: PathBuf) -> Result<Respons
         return Ok(not_found());
     }
 
-    // Remove the trailing slash from the request path
+    // Remove the first slash from the request path
     // otherwise `PathBuf` will interpret it as an absolute path
     root.push(&decoded[1..]);
+
+    let metadata = tokio::fs::metadata(root.as_path()).await?;
+    if metadata.is_dir() {
+        // if root is a directory, append index.html to try to read that instead
+        root.push("index.html");
+    };
+
     let result = tokio::fs::read(&root).await;
 
     let contents = match result {


### PR DESCRIPTION
If it's a directory that `zola serve` tries to read, make sure we try `/index.html` instead of crashing.

This will fix issue #1359 

I have not yet written a lot of Rust so the solution is probably a bit ugly, feel free to edit and update.
