### PR TITLE
Hash collision using the same quality level and incorrect quality for WebP

### DIFF
--- a/components/imageproc/src/lib.rs
+++ b/components/imageproc/src/lib.rs
@@ -316,7 +316,7 @@ impl ImageOp {
             Format::WebP(q) => {
                 let encoder = webp::Encoder::from_image(&img);
                 let memory = match q {
-                    Some(q) => encoder.encode(q as f32 / 100.),
+                    Some(q) => encoder.encode(q as f32),
                     None => encoder.encode_lossless(),
                 };
                 f.write_all(&memory.as_bytes())?;

--- a/components/imageproc/src/lib.rs
+++ b/components/imageproc/src/lib.rs
@@ -207,6 +207,7 @@ impl Hash for Format {
         };
 
         hasher.write_u8(q);
+        hasher.write(self.extension().as_bytes());
     }
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

--- 

## Hash collision using the same quality level

Create a new Zola project with the following directory structure:

```none
.  webp_collision
├─ config.toml
├─ content/
│  └─ zola.png
├─ static/
├─ templates/
│  └─ index.html
└─ themes/
```

With the following contents for `index.html`:

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
  </head>
  <body>
    <img src="{{ resize_image(
      path="zola.png",
      width=300,
      op="fit_width",
      format="jpg",
      quality=75,
    ) }}"/>
    <img src="{{ resize_image(
      path="zola.png",
      width=300,
      op="fit_width",
      format="webp",
      quality=75,
    ) }}"/>
  </body>
</html>
```

Despite the images above having different output formats, the `webp` is not generated as the hash seems to be based on:

* input filename
* resize operation
* quality

https://github.com/getzola/zola/blob/6e2595a191f2dd72a91a632e51b66b1cf5187083/components/imageproc/src/lib.rs#L220-L224

This pull request also hashes the output extension. This allows the same settings, but with different output formats, to be valid.

## Incorrect quality for WebP

The given quality ([0, 100]) to the WebP encoder was divided by 100.0, resulting in a value [0, 1.0], while the documentation for [webp::Encoder::encode](https://docs.rs/webp/0.1.1/webp/struct.Encoder.html#method.encode) states:

> Encode the image with the given quality. The image quality must be between 0.0 and 100.0 inclusive for minimal and maximal quality respectively.



