### PR TITLE
Fix next/previous page links when using transparent sections

### DIFF
--- a/components/library/src/library.rs
+++ b/components/library/src/library.rs
@@ -319,28 +319,38 @@ impl Library {
         }
 
         for (key, (sorted, cannot_be_sorted, sort_by)) in updates {
-            // Find sibling between sorted pages first
-            let with_siblings = find_siblings(&sorted);
+            let section_is_transparent = if let Some(section) = self.sections.get(key) {
+                section.meta.transparent
+            } else {
+                false
+            };
 
-            for (k2, val1, val2) in with_siblings {
-                if let Some(page) = self.pages.get_mut(k2) {
-                    match sort_by {
-                        SortBy::Date => {
-                            page.earlier = val2;
-                            page.later = val1;
+            if !section_is_transparent {
+                // Find sibling between sorted pages first
+                let with_siblings = find_siblings(&sorted);
+
+                for (k2, val1, val2) in with_siblings {
+                    if let Some(page) = self.pages.get_mut(k2) {
+                        match sort_by {
+                            SortBy::Date => {
+                                page.earlier = val2;
+                                page.later = val1;
+                            }
+                            SortBy::Title => {
+                                page.title_prev = val1;
+                                page.title_next = val2;
+                            }
+                            SortBy::Weight => {
+                                page.lighter = val1;
+                                page.heavier = val2;
+                            }
+                            SortBy::None => {
+                                unreachable!("Impossible to find siblings in SortBy::None")
+                            }
                         }
-                        SortBy::Title => {
-                            page.title_prev = val1;
-                            page.title_next = val2;
-                        }
-                        SortBy::Weight => {
-                            page.lighter = val1;
-                            page.heavier = val2;
-                        }
-                        SortBy::None => unreachable!("Impossible to find siblings in SortBy::None"),
+                    } else {
+                        unreachable!("Sorting got an unknown page")
                     }
-                } else {
-                    unreachable!("Sorting got an unknown page")
                 }
             }
 


### PR DESCRIPTION
## Code changes

There is a race condition in the generation of next/previous page links when combined with sections that use `transparent = true`. I use next/previous generically to all manner of sorting (date, title, weight).

The next/previous links are generated per-section, but the sections themselves are iterated in an apparently arbitrary sequence. A parent section may be iterated before or after its child. For each page, the last section which _might_ contain it wins, which means the next/previous links _may or may not_ include page from sibling sections.

This change disables the generation of next/previous page references for sections with `transparent = true`, meaning that larger list of pages available to the (grand)parent section will be the only (sorted) list used to generate next/previous references.

I believe this is in keeping with the intent of the transparent flag, as quoted from documentation here:

```
# If set to "true", the section will pass its pages on to the parent section. Defaults to `false`.
# Useful when the section shouldn't split up the parent section, like
# sections for each year under a posts section.
transparent = false
```

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)? _n/a - no new API created_



