### PR TITLE
Docs: Unset highlight_theme variable in sample config.toml

### DIFF
--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -107,7 +107,7 @@ highlight_code = false
 
 # The theme to use for code highlighting.
 # See below for list of allowed values.
-highlight_theme = "base16-ocean-dark"
+highlight_theme = ""
 
 # When set to "true", emoji aliases translated to their corresponding
 # Unicode emoji equivalent in the rendered Markdown files. (e.g.: :smile: => 😄)


### PR DESCRIPTION
Do not set `highlight_theme` like `theme`. See https://github.com/getzola/zola/issues/1197#issuecomment-846606390 