### PR TITLE
Docs: weight ties sort sections in random order

### DIFF
--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -189,4 +189,4 @@ equally weighted sections. Thus, if the `weight` variable for your section is no
 is set in a way that produces ties), then your sections will be sorted in
 **random** order. Moreover, that order is determined at build time and will
 change with each site rebuild.  Thus, if there is any chance that you will
-iterate over your sections, you should always assign them a weight.
+iterate over your sections, you should always assign them distinct weights.

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -85,7 +85,7 @@ extra: HashMap<String, Any>;
 // date and weight, respectively.
 pages: Array<Page>;
 // Direct subsections to this section, sorted by subsections weight
-// This only contains the path to use in the `get_section` Tera function to get
+// This only contains the path to use in the `get_section` built-in function to get
 // the actual section object if you need it
 subsections: Array<String>;
 toc: Array<Header>,


### PR DESCRIPTION
Also https://www.getzola.org/documentation/content/section/#sorting has example for how to sort pages.

How about adding an example template for sorting subsections under https://www.getzola.org/documentation/content/section/#sorting-subsections

I could come up with this and it works but I am struggling with the exact words to put into at the moment!
```
{% for section_path in section.subsections %}
{% set section = get_section(path=section_path) %}
<h1><a href="{{ section.permalink | safe }}">{{ section.title }}</a></h1>
{% endfor %}
```