### PR TITLE
Update Travis CI link to point to updated website

### DIFF
--- a/docs/content/documentation/deployment/github-pages.md
+++ b/docs/content/documentation/deployment/github-pages.md
@@ -100,7 +100,7 @@ by substituting your username or organization.
 
 ## Travis CI
 
-Alternatively, you can use [Travis CI](https://travis-ci.org) to automatically publish the site. If you are not using Travis
+Alternatively, you can use [Travis CI](https://www.travis-ci.com/) to automatically publish the site. If you are not using Travis
 already, you will need to login with the GitHub OAuth and activate Travis for the repository.
 Don't forget to also check if your repository allows GitHub Pages in its settings.
 


### PR DESCRIPTION
Updated link to https://www.travis-ci.org/  to travis-ci.com.
As per site :"Please be aware travis-ci.org will be shutting down by end of May 2021. Please consider migrating to travis-ci.com."




