### PR TITLE
Some more improvements to documentation

### DIFF
--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -121,7 +121,7 @@ The source for all examples is this 300 pixel × 380 pixel image:
 
 ## Using `resize_image` in markdown via shortcodes
 
-`resize_image` is a built-in Tera global function (see the [templates](@/documentation/templates/_index.md) chapter),
+`resize_image` is a Zola built-in Tera function (see the [templates](@/documentation/templates/_index.md) chapter),
 but it can be used in Markdown using [shortcodes](@/documentation/content/shortcodes.md).
 
 The examples above were generated using a shortcode file named `resize_image.html` with this content:

--- a/docs/content/documentation/content/taxonomies.md
+++ b/docs/content/documentation/content/taxonomies.md
@@ -131,7 +131,7 @@ In a similar manner to how section and pages calculate their output path:
 
 The taxonomy pages are then available at the following paths:
 
-```
+```txt
 $BASE_URL/$NAME/ (taxonomy)
 $BASE_URL/$NAME/$SLUG (taxonomy entry)
 ```

--- a/docs/content/documentation/deployment/github-pages.md
+++ b/docs/content/documentation/deployment/github-pages.md
@@ -18,7 +18,7 @@ We can use any continuous integration (CI) server to build and deploy our site. 
 
 In either case, it seems to work best if you use `git submodule` to include your theme, e.g.:
 
-```shell
+```sh
 git submodule add https://github.com/getzola/after-dark.git themes/after-dark
 ```
 
@@ -110,7 +110,7 @@ Depending on how you added your theme, Travis may not know how to access
 it. The best way to ensure that it will have full access to the theme is to use git
 submodules. When doing this, ensure that you are using the `https` version of the URL.
 
-```shell
+```sh
 $ git submodule add {THEME_URL} themes/{THEME_NAME}
 ```
 

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -21,12 +21,13 @@ This guide assumes that your Zola project is located in the root of your reposit
 Depending on how you added your theme, your repository may not contain it. The best way to ensure that the theme will
 be added is to use submodules. When doing this, ensure that you are using the `https` version of the URL.
 
-```shell
+```sh
 $ git submodule add {THEME_URL} themes/{THEME_NAME}
 ```
 
 For example, this could look like:
-```shell
+
+```sh
 $ git submodule add https://github.com/getzola/hyde.git themes/hyde
 ```
 

--- a/docs/content/documentation/themes/installing-and-using-themes.md
+++ b/docs/content/documentation/themes/installing-and-using-themes.md
@@ -35,7 +35,7 @@ in the configuration file is `simple-blog`. Also make sure to place the variable
 Any file from the theme can be overridden by creating a file with the same path and name in your `templates` or `static`
 directory. Here are a few examples of that, assuming that the theme name is `simple-blog`:
 
-```plain
+```txt
 templates/pages/post.html -> replace themes/simple-blog/templates/pages/post.html
 templates/macros.html -> replace themes/simple-blog/templates/macros.html
 static/js/site.js -> replace themes/simple-blog/static/js/site.js


### PR DESCRIPTION
The `gallery` shortcode needs to be in `<div>` otherwise the accompanying attribute text doesn't start on next line.

Also why do we need `get_url(path=asset) | safe` in `gallery.html` I don't understand...