### PR TITLE
Add permalink to Taxonomy

### DIFF
--- a/components/library/src/pagination/mod.rs
+++ b/components/library/src/pagination/mod.rs
@@ -422,6 +422,7 @@ mod tests {
             kind: taxonomy_def,
             lang: "en".to_owned(),
             slug: "tags".to_string(),
+            permalink: "/tags/".to_string(),
             items: vec![taxonomy_item.clone()],
         };
         let paginator = Paginator::from_taxonomy(&taxonomy, &taxonomy_item, &library);
@@ -457,6 +458,7 @@ mod tests {
             kind: taxonomy_def,
             lang: "en".to_owned(),
             slug: "some-tags".to_string(),
+            permalink: "/some-tags/".to_string(),
             items: vec![taxonomy_item.clone()],
         };
         let paginator = Paginator::from_taxonomy(&taxonomy, &taxonomy_item, &library);

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -108,6 +108,7 @@ impl PartialEq for TaxonomyItem {
 pub struct SerializedTaxonomy<'a> {
     kind: &'a TaxonomyConfig,
     lang: &'a str,
+    permalink: &'a str,
     items: Vec<SerializedTaxonomyItem<'a>>,
 }
 
@@ -115,7 +116,12 @@ impl<'a> SerializedTaxonomy<'a> {
     pub fn from_taxonomy(taxonomy: &'a Taxonomy, library: &'a Library) -> Self {
         let items: Vec<SerializedTaxonomyItem> =
             taxonomy.items.iter().map(|i| SerializedTaxonomyItem::from_item(i, library)).collect();
-        SerializedTaxonomy { kind: &taxonomy.kind, lang: &taxonomy.lang, items }
+        SerializedTaxonomy {
+            kind: &taxonomy.kind,
+            lang: &taxonomy.lang,
+            permalink: &taxonomy.permalink,
+            items,
+        }
     }
 }
 
@@ -125,6 +131,7 @@ pub struct Taxonomy {
     pub kind: TaxonomyConfig,
     pub lang: String,
     pub slug: String,
+    pub permalink: String,
     // this vec is sorted by the count of item
     pub items: Vec<TaxonomyItem>,
 }
@@ -159,7 +166,14 @@ impl Taxonomy {
                 false
             }
         });
-        Taxonomy { kind, slug, lang: lang.to_owned(), items: sorted_items }
+        let path = if lang != config.default_language {
+            format!("/{}/{}/", lang, slug)
+        } else {
+            format!("/{}/", slug)
+        };
+        let permalink = config.make_permalink(&path);
+
+        Taxonomy { kind, slug, lang: lang.to_owned(), permalink, items: sorted_items }
     }
 
     pub fn len(&self) -> usize {

--- a/components/templates/src/global_fns/content.rs
+++ b/components/templates/src/global_fns/content.rs
@@ -202,12 +202,14 @@ mod tests {
             kind: taxo_config,
             lang: config.default_language.clone(),
             slug: "tags".to_string(),
+            permalink: "/tags/".to_string(),
             items: vec![tag],
         };
         let tags_fr = Taxonomy {
             kind: taxo_config_fr,
             lang: "fr".to_owned(),
             slug: "tags".to_string(),
+            permalink: "/fr/tags/".to_string(),
             items: vec![tag_fr],
         };
 
@@ -278,12 +280,14 @@ mod tests {
             kind: taxo_config,
             lang: config.default_language.clone(),
             slug: "tags".to_string(),
+            permalink: "/tags/".to_string(),
             items: vec![tag],
         };
         let tags_fr = Taxonomy {
             kind: taxo_config_fr,
             lang: "fr".to_owned(),
             slug: "tags".to_string(),
+            permalink: "/fr/tags/".to_string(),
             items: vec![tag_fr],
         };
 

--- a/docs/content/documentation/templates/taxonomies.md
+++ b/docs/content/documentation/templates/taxonomies.md
@@ -26,6 +26,7 @@ paginate_by: Number?;
 paginate_path: String?;
 feed: Bool;
 lang: String;
+permalink: String;
 ```
 
 


### PR DESCRIPTION
I started a discussion regarding this here: https://zola.discourse.group/t/get-permalink-to-taxonomy-list-page/928 but I figured it would be simpler to just write some code.

## Code changes

This updates the `Taxonomy` struct as well as the `SerializedTaxonomy` to include a new `permalink` which is the permanent link to the taxonomy. This allows templates to then use something like this:

```
        {% for taxonomy_kind, taxonomies in page.taxonomies %}
        <div>
        {% set taxonomy_config = get_taxonomy(kind=taxonomy_kind) %}
        <a href="{{ taxonomy_config.permalink }}">{{ taxonomy_kind }}</a>:

        {% for taxonomy in taxonomies %}
        <a href="{{ get_taxonomy_url(kind=taxonomy_kind, name=taxonomy, lang=page.lang) }}">{{ taxonomy }}</a>
        {% endfor %}
        </div>
        {% endfor %}
```

To automatically display and link to the taxonomies this page exists under, as well as link to the individual taxonomy items.

Wanted to create this PR to see if this is the way forward for this, or if there is a better way, the following is still left to be done:

* [x] Update template documentation to add the additional `permalink`
* [ ] Add additional tests to validate the `permalink` is being generated correctly

As a test, it is working to build a website I am currently building using zola (next branch).

Thanks!


