### PR TITLE
Update Vercel documentation

### DIFF
--- a/docs/content/documentation/deployment/vercel.md
+++ b/docs/content/documentation/deployment/vercel.md
@@ -3,34 +3,23 @@ title = "Vercel"
 weight = 50
 +++
 
-Vercel (previously zeit) is similar to Netlify, making deployment of sites easy.
-The sites are hosted by Vercel and automatically deployed whenever we push a
-commit to our selected production branch (e.g, master).
+Vercel (previously Zeit) is similar to Netlify, making the deployment of your site easy as pie.
+The sites are hosted by Vercel and automatically deployed whenever we push a commit to our
+selected production branch (e.g, master).
 
 If you don't have an account with Vercel, you can sign up [here](https://vercel.com/signup).
 
 ## Automatic deploys
 
 Once you sign up you can import your site from a Git provider (Github, GitLab or Bitbucket). 
-After the import, you can set the settings for your project. 
+When you import your repository, Vercel will try to find out what frmaework your site is using.
 
-- Choose Framework Preset as **Other**
-- Build command as `zola build` and make sure toggle on Override switch.
-- By default Vercel chooses output directory as `public`, if you use a different directory then specify output directory.
-- To add your own domain, go to domain setting in left and add it there.
+If it doesn't default to Zola:
+- Set Framework Preset as **Zola**.
 
+By default, Vercel chooses output directory as `public`. If you use a different directory, then
+specify output directory under the "Build and Output Settings" dropdown.
+You can learn more about how to setup a custom domain and how to get the most out of Vercel
+[via their documentation.](https://vercel.com/docs) 
 
-All we have to is include a `vercel.json` in our project's root directory by
-specifying the `ZOLA_VERSION` we want to use to deploy the site.
-
-```json
-  {
-  "build": {
-    "env": {
-      "ZOLA_VERSION": "0.13.0"
-    }
-  }
-}
-```
-
-And your site should now be up and running.
+After you click the blue "Deploy" button, it's off to the races!


### PR DESCRIPTION
This PR updates the documentation for Vercel to use the framework preset on Vercel, as well as remove the since-deprecated method of using Zola with Vercel that was in the docs prior to this PR.


Sanity check:
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?