### PR TITLE
Added sidenote on serving to local devices

### DIFF
--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -72,6 +72,10 @@ the interface/port combination to use if you want something different than the d
 
 You can also specify different addresses for the interface and base_url using `--interface` and `-u`/`--base-url`, respectively, if for example you are running Zola in a Docker container.
 
+> By default, devices from the local network **won't** be able to access the served pages. This may be of importance when you want to test page interaction and layout on your mobile device or tablet. If you set the interface to `0.0.0.0` however, devices from your local network will be able to access the served pages by requesting the local ip-address of the machine serving the pages and port used.
+>
+> In order to have everything work correctly, you might also have to alter the `base-url` flag to your local ip.
+
 Use the `--open` flag to automatically open the locally hosted instance in your
 web browser.
 


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
I added a sidenote to the CLI usage section in the documentation on how to serve to devices on the local network. Something which is done standard in a lot of SSGs and caused many headaches for me. Hopefully, with this documentation not anymore or less for others.

Fixes #1556.



