### PR TITLE
use provided config file path instead of name

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -294,12 +294,12 @@ pub fn serve(
         return Err(format!("Cannot start server on address {}.", address).into());
     }
 
-    let config_filename = config_file.file_name().unwrap().to_str().unwrap_or("config.toml");
+    let config_path = config_file.to_str().unwrap_or("config.toml");
 
     // An array of (path, bool, bool) where the path should be watched for changes, and the boolean value
     // indicates whether this file/folder must exist for zola serve to operate
     let watch_this = vec![
-        (config_filename, WatchMode::Required),
+        (config_path, WatchMode::Required),
         ("content", WatchMode::Required),
         ("sass", WatchMode::Condition(site.config.compile_sass)),
         ("static", WatchMode::Optional),
@@ -517,7 +517,7 @@ pub fn serve(
                         );
 
                         let start = Instant::now();
-                        match detect_change_kind(&root_dir, &path, &config_filename) {
+                        match detect_change_kind(&root_dir, &path, &config_path) {
                             (ChangeKind::Content, _) => {
                                 console::info(&format!("-> Content changed {}", path.display()));
 


### PR DESCRIPTION
Fixes #1563 - a bug which made it impossible to specify a configuration file outside of the root directory.

There's no automated tests for this, but I did to a quick CLI test:

```
../target/debug/zola build # ok
../target/debug/zola -c config.toml build # ok
mkdir f
mv config.toml f
../target/debug/zola -c f/config.toml build # ok
../target/debug/zola -c does_not_exist.toml build  # expected failure
```


Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [ ] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?


