### PR TITLE
Support standard byte order sorting

### DIFF
--- a/components/front_matter/src/lib.rs
+++ b/components/front_matter/src/lib.rs
@@ -60,6 +60,15 @@ pub enum SortBy {
 
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    /// Lexicographical sorting provided by the crate lexical_sort
+    Lexical,
+    /// Standard byte-order sorting
+    Standard,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum InsertAnchor {
     Left,
     Right,

--- a/components/front_matter/src/section.rs
+++ b/components/front_matter/src/section.rs
@@ -1,7 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 use tera::{Map, Value};
 
-use super::{InsertAnchor, SortBy};
+use super::{InsertAnchor, SortBy, SortOrder};
 use errors::Result;
 use utils::de::fix_toml_dates;
 
@@ -20,6 +20,9 @@ pub struct SectionFrontMatter {
     /// Whether to sort by "date", "order", "weight" or "none". Defaults to `none`.
     #[serde(skip_serializing)]
     pub sort_by: SortBy,
+    /// Sort order used when sorting by title. "lexical" (default) or "standard".
+    #[serde(skip_serializing)]
+    pub sort_order: SortOrder,
     /// Used by the parent section to order its subsections.
     /// Higher values means it will be at the end. Defaults to `0`
     #[serde(skip_serializing)]
@@ -101,6 +104,7 @@ impl Default for SectionFrontMatter {
             title: None,
             description: None,
             sort_by: SortBy::None,
+            sort_order: SortOrder::Lexical,
             weight: 0,
             template: None,
             paginate_by: None,

--- a/components/library/src/library.rs
+++ b/components/library/src/library.rs
@@ -301,7 +301,7 @@ impl Library {
                 SortBy::Title => {
                     let data = get_data(section, &self.pages, |meta| meta.title.as_deref());
 
-                    sort_pages_by_title(data)
+                    sort_pages_by_title(data, section.meta.sort_order)
                 }
                 SortBy::Weight => {
                     let data = get_data(section, &self.pages, |meta| meta.weight);

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -51,6 +51,9 @@ draft = false
 # Used to sort pages by "date", "title, "weight", or "none". See below for more information.
 sort_by = "none"
 
+# What sort order to use when sorting by title. "lexical" or "standard".
+sort_order = "lexical"
+
 # Used by the parent section to order its subsections.
 # Lower values have higher priority.
 weight = 0
@@ -164,16 +167,22 @@ get `page.earlier` and `page.later` variables that contain the pages with
 earlier and later dates, respectively.
 
 ### `title`
-This will sort all pages by their `title` field in natural lexical order, as
-defined  by `natural_lexical_cmp` in the [lexical-sort] crate. Each page will
-get `page.title_prev` and `page.title_next` variables that  contain the pages
-with  previous and next titles, respectively.
+This will sort all pages by their `title` field according to the `sort_order`
+in either natural lexical or standard byte order. They are defined by
+`natural_lexical_cmp` in the [lexical-sort] crate or String::cmp in the
+standard library respectively. Each page will get `page.title_prev` and
+`page.title_next` variables that contain the pages with previous and next
+titles, respectively.
 
-For example, here is a natural lexical ordering: "bachata, BART, bolero,
+For example, here is a natural lexical ordering: "åland, bachata, BART, bolero,
 μ-kernel, meter, Métro, Track-2, Track-3, Track-13, underground". Notice how
-special characters and numbers are sorted reasonably. This is better than
-the standard sorting: "BART, Métro, Track-13, Track-2, Track-3, bachata,
-bolero, meter, underground, μ-kernel".
+special characters and numbers are sorted reasonably. This might be preferable
+to the standard sorting: "BART, Métro, Track-13, Track-2, Track-3, bachata,
+bolero, meter, underground, åland, μ-kernel". Natural sorting treats non-ascii
+characters like their closest ascii character. This can lead to unexpected
+results for languages with different character sets. The last three characters
+of the Swedish alphabet, åäö, for example would be considered by the natural
+sort as aao. In that case the standard byte-order sort may be more suitable.
 
 [lexical-sort]: https://docs.rs/lexical-sort
 


### PR DESCRIPTION
This PR adds the `sort_order` property to sections that defaults to
lexical in order to keep backwards compatability and adds "standard" for
byte order sort.

This is useful if you have a list of non-english names and you want them
sorted correctly. My site is in Swedish and with natural sort åäö (our
last three letters of the alphabet) end up in the same position as aao
respectively.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**
*Didn't realize this was a requirement for feature additions (as well as requests).. Sorry!*

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

This PR is a continuation of #1315 which added natural sort order. Unfortunately that sort order wasn't perfect for my use case.

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [X] Have you created/updated the relevant documentation page(s)?



