### PR TITLE
Fix cachebust for files in the output path

### DIFF
--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -23,6 +23,7 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.base_path.clone(),
             site.config.clone(),
             site.permalinks.clone(),
+            site.output_path.clone(),
         ),
     );
     site.tera.register_function(

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -32,15 +32,24 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.base_path.clone(),
             site.imageproc.clone(),
             site.config.theme.clone(),
+            site.output_path.clone(),
         ),
     );
     site.tera.register_function(
         "get_image_metadata",
-        global_fns::GetImageMetadata::new(site.base_path.clone(), site.config.theme.clone()),
+        global_fns::GetImageMetadata::new(
+            site.base_path.clone(),
+            site.config.theme.clone(),
+            site.output_path.clone(),
+        ),
     );
     site.tera.register_function(
         "load_data",
-        global_fns::LoadData::new(site.base_path.clone(), site.config.theme.clone()),
+        global_fns::LoadData::new(
+            site.base_path.clone(),
+            site.config.theme.clone(),
+            site.output_path.clone(),
+        ),
     );
     site.tera.register_function("trans", global_fns::Trans::new(site.config.clone()));
     site.tera.register_function(
@@ -53,7 +62,11 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
     );
     site.tera.register_function(
         "get_file_hash",
-        global_fns::GetFileHash::new(site.base_path.clone(), site.config.theme.clone()),
+        global_fns::GetFileHash::new(
+            site.base_path.clone(),
+            site.config.theme.clone(),
+            site.output_path.clone(),
+        ),
     );
 
     Ok(())

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -117,7 +117,7 @@ impl TeraFn for GetUrl {
             }
 
             if cachebust {
-                match search_for_file(&self.base_path, &path_with_lang, &self.config.theme, Some(&self.output_path))
+                match search_for_file(&self.base_path, &path_with_lang, &self.config.theme, &self.output_path)
                     .map_err(|e| format!("`get_url`: {}", e))?
                     .and_then(|(p, _)| fs::File::open(&p).ok())
                     .and_then(|f| compute_file_hash::<Sha256>(f, false).ok())
@@ -148,10 +148,11 @@ impl TeraFn for GetUrl {
 pub struct GetFileHash {
     base_path: PathBuf,
     theme: Option<String>,
+    output_path: PathBuf,
 }
 impl GetFileHash {
-    pub fn new(base_path: PathBuf, theme: Option<String>) -> Self {
-        Self { base_path, theme }
+    pub fn new(base_path: PathBuf, theme: Option<String>, output_path: PathBuf) -> Self {
+        Self { base_path, theme, output_path }
     }
 }
 
@@ -175,7 +176,7 @@ impl TeraFn for GetFileHash {
         )
         .unwrap_or(true);
 
-        let file_path = match search_for_file(&self.base_path, &path, &self.theme, None)
+        let file_path = match search_for_file(&self.base_path, &path, &self.theme, &self.output_path)
             .map_err(|e| format!("`get_file_hash`: {}", e))?
         {
             Some((f, _)) => f,
@@ -366,7 +367,7 @@ title = "A title"
     #[test]
     fn can_get_file_hash_sha256_no_base64() {
         let dir = create_temp_dir();
-        let static_fn = GetFileHash::new(dir.into_path(), None);
+        let static_fn = GetFileHash::new(dir.into_path(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("app.css").unwrap());
         args.insert("sha_type".to_string(), to_value(256).unwrap());
@@ -380,7 +381,7 @@ title = "A title"
     #[test]
     fn can_get_file_hash_sha256_base64() {
         let dir = create_temp_dir();
-        let static_fn = GetFileHash::new(dir.into_path(), None);
+        let static_fn = GetFileHash::new(dir.into_path(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("app.css").unwrap());
         args.insert("sha_type".to_string(), to_value(256).unwrap());
@@ -391,7 +392,7 @@ title = "A title"
     #[test]
     fn can_get_file_hash_sha384_no_base64() {
         let dir = create_temp_dir();
-        let static_fn = GetFileHash::new(dir.into_path(), None);
+        let static_fn = GetFileHash::new(dir.into_path(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("app.css").unwrap());
         args.insert("base64".to_string(), to_value(false).unwrap());
@@ -404,7 +405,7 @@ title = "A title"
     #[test]
     fn can_get_file_hash_sha384() {
         let dir = create_temp_dir();
-        let static_fn = GetFileHash::new(dir.into_path(), None);
+        let static_fn = GetFileHash::new(dir.into_path(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("app.css").unwrap());
         assert_eq!(
@@ -416,7 +417,7 @@ title = "A title"
     #[test]
     fn can_get_file_hash_sha512_no_base64() {
         let dir = create_temp_dir();
-        let static_fn = GetFileHash::new(dir.into_path(), None);
+        let static_fn = GetFileHash::new(dir.into_path(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("app.css").unwrap());
         args.insert("sha_type".to_string(), to_value(512).unwrap());
@@ -430,7 +431,7 @@ title = "A title"
     #[test]
     fn can_get_file_hash_sha512() {
         let dir = create_temp_dir();
-        let static_fn = GetFileHash::new(dir.into_path(), None);
+        let static_fn = GetFileHash::new(dir.into_path(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("app.css").unwrap());
         args.insert("sha_type".to_string(), to_value(512).unwrap());
@@ -443,7 +444,7 @@ title = "A title"
     #[test]
     fn error_when_file_not_found_for_hash() {
         let dir = create_temp_dir();
-        let static_fn = GetFileHash::new(dir.into_path(), None);
+        let static_fn = GetFileHash::new(dir.into_path(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("doesnt-exist").unwrap());
         let err = format!("{}", static_fn.call(&args).unwrap_err());

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -211,6 +211,7 @@ mod tests {
     use super::{GetFileHash, GetUrl};
 
     use std::collections::HashMap;
+    use std::fs::create_dir;
     use std::path::PathBuf;
 
     use tempfile::{tempdir, TempDir};
@@ -279,6 +280,20 @@ title = "A title"
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("/app.css").unwrap());
         assert_eq!(static_fn.call(&args).unwrap(), "http://a-website.com/app.css");
+    }
+
+    #[test]
+    fn can_link_to_file_in_output_path() {
+        let dir = create_temp_dir();
+        let public = dir.path().join("public");
+        create_dir(&public).expect("Failed to create output directory");
+        create_file(&public.join("style.css"), "// Hello world")
+            .expect("Failed to create file in output directory");
+
+        let static_fn = GetUrl::new(dir.path().to_path_buf(), Config::default(), HashMap::new(), public);
+        let mut args = HashMap::new();
+        args.insert("path".to_string(), to_value("style.css").unwrap());
+        assert_eq!(static_fn.call(&args).unwrap(), "http://a-website.com/style.css");
     }
 
     #[test]

--- a/components/templates/src/global_fns/helpers.rs
+++ b/components/templates/src/global_fns/helpers.rs
@@ -19,12 +19,9 @@ pub fn search_for_file(
     base_path: &Path,
     path: &str,
     theme: &Option<String>,
-    output_dir: Option<&Path>,
+    output_path: &Path,
 ) -> Result<Option<(PathBuf, String)>> {
-    let mut search_paths = vec![base_path.join("static"), base_path.join("content")];
-    if let Some(o) = output_dir {
-        search_paths.push(base_path.join(o));
-    }
+    let mut search_paths = vec![base_path.join("static"), base_path.join("content"), base_path.join(output_path)];
     if let Some(t) = theme {
         search_paths.push(base_path.join("themes").join(t).join("static"));
     }

--- a/components/templates/src/global_fns/helpers.rs
+++ b/components/templates/src/global_fns/helpers.rs
@@ -5,11 +5,12 @@ use errors::{bail, Result};
 use utils::fs::is_path_in_directory;
 
 /// This is used by a few Tera functions to search for files on the filesystem.
-/// This does try to find the file in 3 different spots:
+/// This does try to find the file in 5 different spots:
 /// 1. base_path + path
 /// 2. base_path + static + path
 /// 3. base_path + content + path
-/// 4. base_path + themes + {current_theme} + static + path
+/// 4. base_path + {output dir} + path
+/// 5. base_path + themes + {current_theme} + static + path
 /// A path starting with @/ will replace it with `content/` and a path starting with `/` will have
 /// it removed.
 /// It also returns the unified path so it can be used as unique hash for a given file.
@@ -18,8 +19,12 @@ pub fn search_for_file(
     base_path: &Path,
     path: &str,
     theme: &Option<String>,
+    output_dir: Option<&Path>,
 ) -> Result<Option<(PathBuf, String)>> {
     let mut search_paths = vec![base_path.join("static"), base_path.join("content")];
+    if let Some(o) = output_dir {
+        search_paths.push(base_path.join(o));
+    }
     if let Some(t) = theme {
         search_paths.push(base_path.join("themes").join(t).join("static"));
     }
@@ -37,7 +42,7 @@ pub fn search_for_file(
     }
 
     if !file_exists {
-        // we need to search in both search folders now
+        // we need to search in all search folders now
         for dir in &search_paths {
             let p = dir.join(&*actual_path);
             if p.exists() {

--- a/components/templates/src/global_fns/images.rs
+++ b/components/templates/src/global_fns/images.rs
@@ -60,7 +60,7 @@ impl TeraFn for ResizeImage {
         }
 
         let mut imageproc = self.imageproc.lock().unwrap();
-        let (file_path, unified_path) = match search_for_file(&self.base_path, &path, &self.theme)
+        let (file_path, unified_path) = match search_for_file(&self.base_path, &path, &self.theme, None)
             .map_err(|e| format!("`resize_image`: {}", e))?
         {
             Some(f) => f,
@@ -105,7 +105,7 @@ impl TeraFn for GetImageMetadata {
         )
         .unwrap_or(false);
 
-        let (src_path, unified_path) = match search_for_file(&self.base_path, &path, &self.theme)
+        let (src_path, unified_path) = match search_for_file(&self.base_path, &path, &self.theme, None)
             .map_err(|e| format!("`get_image_metadata`: {}", e))?
         {
             Some((f, p)) => (f, p),

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -95,7 +95,7 @@ impl DataSource {
         }
 
         if let Some(path) = path_arg {
-            return match search_for_file(base_path, &path, theme)
+            return match search_for_file(&base_path, &path, &theme, None)
                 .map_err(|e| format!("`load_data`: {}", e))?
             {
                 Some((f, _)) => Ok(Some(DataSource::Path(f))),

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -89,13 +89,14 @@ impl DataSource {
         url_arg: Option<String>,
         base_path: &Path,
         theme: &Option<String>,
+        output_path: &Path,
     ) -> Result<Option<Self>> {
         if path_arg.is_some() && url_arg.is_some() {
             return Err(GET_DATA_ARGUMENT_ERROR_MESSAGE.into());
         }
 
         if let Some(path) = path_arg {
-            return match search_for_file(&base_path, &path, &theme, None)
+            return match search_for_file(&base_path, &path, &theme, &output_path)
                 .map_err(|e| format!("`load_data`: {}", e))?
             {
                 Some((f, _)) => Ok(Some(DataSource::Path(f))),
@@ -169,9 +170,10 @@ pub struct LoadData {
     theme: Option<String>,
     client: Arc<Mutex<Client>>,
     result_cache: Arc<Mutex<HashMap<u64, Value>>>,
+    output_path: PathBuf,
 }
 impl LoadData {
-    pub fn new(base_path: PathBuf, theme: Option<String>) -> Self {
+    pub fn new(base_path: PathBuf, theme: Option<String>, output_path: PathBuf) -> Self {
         let client = Arc::new(Mutex::new(
             Client::builder()
                 .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
@@ -179,7 +181,7 @@ impl LoadData {
                 .expect("reqwest client build"),
         ));
         let result_cache = Arc::new(Mutex::new(HashMap::new()));
-        Self { base_path, client, result_cache, theme }
+        Self { base_path, client, result_cache, theme, output_path }
     }
 }
 
@@ -224,7 +226,7 @@ impl TeraFn for LoadData {
 
         // If the file doesn't exist, source is None
         let data_source = match (
-            DataSource::from_args(path_arg.clone(), url_arg, &self.base_path, &self.theme),
+            DataSource::from_args(path_arg.clone(), url_arg, &self.base_path, &self.theme, &self.output_path),
             required,
         ) {
             // If the file was not required, return a Null value to the template
@@ -478,7 +480,7 @@ mod tests {
 
     #[test]
     fn fails_illegal_method_parameter() {
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value("https://example.com").unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
@@ -505,7 +507,7 @@ mod tests {
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y");
 
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(url).unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
@@ -533,7 +535,7 @@ mod tests {
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4yw");
 
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(url).unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
@@ -562,7 +564,7 @@ mod tests {
 
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y");
 
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(url).unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
@@ -578,7 +580,7 @@ mod tests {
 
     #[test]
     fn fails_when_missing_file() {
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("../../../READMEE.md").unwrap());
         let result = static_fn.call(&args);
@@ -588,7 +590,7 @@ mod tests {
 
     #[test]
     fn doesnt_fail_when_missing_file_is_not_required() {
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("../../../READMEE.md").unwrap());
         args.insert("required".to_string(), to_value(false).unwrap());
@@ -607,7 +609,7 @@ mod tests {
             .unwrap();
         copy(get_test_file("test.css"), dir.path().join("static").join("test.css")).unwrap();
 
-        let static_fn = LoadData::new(dir.path().to_path_buf(), None);
+        let static_fn = LoadData::new(dir.path().to_path_buf(), None, PathBuf::new());
         let mut args = HashMap::new();
         let val = if cfg!(windows) { ".hello {}\r\n" } else { ".hello {}\n" };
 
@@ -634,7 +636,7 @@ mod tests {
 
     #[test]
     fn cannot_load_outside_base_dir() {
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("../../README.md").unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
@@ -711,7 +713,7 @@ mod tests {
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/zpydpkjj67");
-        let static_fn = LoadData::new(PathBuf::new(), None);
+        let static_fn = LoadData::new(PathBuf::new(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(&url).unwrap());
         args.insert("format".to_string(), to_value("json").unwrap());
@@ -728,7 +730,7 @@ mod tests {
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/aazeow0kog");
-        let static_fn = LoadData::new(PathBuf::new(), None);
+        let static_fn = LoadData::new(PathBuf::new(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(&url).unwrap());
         args.insert("format".to_string(), to_value("json").unwrap());
@@ -749,7 +751,7 @@ mod tests {
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/aazeow0kog");
-        let static_fn = LoadData::new(PathBuf::new(), None);
+        let static_fn = LoadData::new(PathBuf::new(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(&url).unwrap());
         args.insert("format".to_string(), to_value("json").unwrap());
@@ -776,7 +778,7 @@ mod tests {
             .create();
 
         let url = format!("{}{}", mockito::server_url(), "/chu8aizahBiy");
-        let static_fn = LoadData::new(PathBuf::new(), None);
+        let static_fn = LoadData::new(PathBuf::new(), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(&url).unwrap());
         args.insert("format".to_string(), to_value("json").unwrap());
@@ -786,7 +788,7 @@ mod tests {
 
     #[test]
     fn can_load_toml() {
-        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("test.toml").unwrap());
         let result = static_fn.call(&args.clone()).unwrap();
@@ -806,7 +808,7 @@ mod tests {
 
     #[test]
     fn unknown_extension_defaults_to_plain() {
-        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("test.css").unwrap());
         let result = static_fn.call(&args.clone()).unwrap();
@@ -821,7 +823,7 @@ mod tests {
 
     #[test]
     fn can_override_known_extension_with_format() {
-        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("test.csv").unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
@@ -839,7 +841,7 @@ mod tests {
 
     #[test]
     fn will_use_format_on_unknown_extension() {
-        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("test.css").unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
@@ -854,7 +856,7 @@ mod tests {
 
     #[test]
     fn can_load_csv() {
-        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("test.csv").unwrap());
         let result = static_fn.call(&args.clone()).unwrap();
@@ -874,7 +876,7 @@ mod tests {
     // Test points to bad csv file with uneven row lengths
     #[test]
     fn bad_csv_should_result_in_error() {
-        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("uneven_rows.csv").unwrap());
         let result = static_fn.call(&args.clone());
@@ -894,7 +896,7 @@ mod tests {
 
     #[test]
     fn bad_csv_should_result_in_error_even_when_not_required() {
-        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("uneven_rows.csv").unwrap());
         args.insert("required".to_string(), to_value(false).unwrap());
@@ -915,7 +917,7 @@ mod tests {
 
     #[test]
     fn can_load_json() {
-        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils/test-files"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("test.json").unwrap());
         let result = static_fn.call(&args.clone()).unwrap();
@@ -941,7 +943,7 @@ mod tests {
             .create();
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y3");
 
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(&url).unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());
@@ -973,7 +975,7 @@ mod tests {
             .create();
         let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y2");
 
-        let static_fn = LoadData::new(PathBuf::from("../utils"), None);
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
         let mut args = HashMap::new();
         args.insert("url".to_string(), to_value(&url).unwrap());
         args.insert("format".to_string(), to_value("plain").unwrap());

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -109,11 +109,12 @@ logic applies.
 
 1. The base directory is the Zola root directory, where the `config.toml` is
 2. For the given path: if it starts with `@/`, replace that with `content/` instead and trim any leading `/`
-3. Search in the following 3 or 4 locations in this order, returning the first where the file exists:
-   a. $base_directory + $path
-   b. $base_directory + "static/" + $path
-   c. $base_directory + "content/" + $path
-   d. $base_directory + "themes" + $theme + "static/" + $path only if using a theme
+3. Search in the following locations in this order, returning the first where the file exists:
+   1. $base_directory + $path
+   2. $base_directory + "static/" + $path
+   3. $base_directory + "content/" + $path
+   4. $base_directory + $output_path + $path
+   5. $base_directory + "themes" + $theme + "static/" + $path (only if using a theme)
 
 In practice this means that `@/some/image.jpg`, `/content/some/image.jpg` and `content/some/image.jpg` will point to the
 same thing.


### PR DESCRIPTION
The `search_for_file` helper function now accepts an ~optional~ output path. If passed, the file will also be searched there.
This is used in the `get_url` Tera function to search in the `Site::output_path`.

In practice, this means cachebust works again for files in the output path.
I've tested this with one of my sites and it seems to work perfectly.

This *should* fix the main issue of #1570. That issue's thread also discusses other things related to getting urls of files in the output path though, so you might want to keep it open.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?