### PR TITLE
Fix docs by moving `extra_syntaxes` to `[markdown]`

### DIFF
--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -84,9 +84,6 @@ hard_link_static = false
 #
 taxonomies = []
 
-# A list of directories used to search for additional `.sublime-syntax` files.
-extra_syntaxes = []
-
 # When set to "true", a search index is built from the pages and section
 # content for `default_language`.
 build_search_index = false
@@ -95,6 +92,9 @@ build_search_index = false
 [markdown]
 # When set to "true", all code blocks are highlighted.
 highlight_code = false
+
+# A list of directories used to search for additional `.sublime-syntax` files.
+extra_syntaxes = []
 
 # The theme to use for code highlighting.
 # See below for list of allowed values.


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

**Description**
After some trial and error and issue-browsing, it looks like the correct location in the configuration for `extra_syntaxes` is actually the `[markdown]` section, and not the main section, so I just wanted to update the docs to make sure they were accurate :smile: 