### PR TITLE
Adjust whitespace in expression delimiters

### DIFF
--- a/docs/content/documentation/content/table-of-contents.md
+++ b/docs/content/documentation/content/table-of-contents.md
@@ -16,12 +16,12 @@ Here is an example of using that field to render a two-level table of contents:
     <ul>
     {% for h1 in page.toc %}
         <li>
-            <a href="{{h1.permalink | safe}}">{{ h1.title }}</a>
+            <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
             {% if h1.children %}
                 <ul>
                     {% for h2 in h1.children %}
                         <li>
-                            <a href="{{h2.permalink | safe}}">{{ h2.title }}</a>
+                            <a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
                         </li>
                     {% endfor %}
                 </ul>


### PR DESCRIPTION
Hi Keats,

the inconsistent whitespace annoyed me while reading the docs, so there is a patch to unify it.


Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?