### PR TITLE
Add OrgaTalk wiki to list of example sites

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -37,3 +37,4 @@
 | [guerinpe.com](https://guerinpe.com)                               | https://github.com/Grelot/blog                           |
 | [uggla.fr](https://uggla.fr)                                       | https://github.com/uggla/blog                            |
 | [NorthCon e.V.](https://verein.northcon.de/)                       |                                                          |
+| [OrgaTalk wiki](https://wiki.orgatalk.de/)                         | https://github.com/orgatalk/wiki                         |


### PR DESCRIPTION
We're trying to use Zola as a wiki. Seems to work well so far! :D