### PR TITLE
Fix clippy warnings

### DIFF
--- a/components/rendering/src/codeblock/highlight.rs
+++ b/components/rendering/src/codeblock/highlight.rs
@@ -236,7 +236,7 @@ mod tests {
         let syntax_and_theme = resolve_syntax_and_theme(Some("py"), &config);
         let mut highlighter = SyntaxHighlighter::new(false, syntax_and_theme);
         let mut out = String::new();
-        for line in LinesWithEndings::from(&code) {
+        for line in LinesWithEndings::from(code) {
             out.push_str(&highlighter.highlight_line(line));
         }
         assert!(!out.contains("<script>"));

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -1,6 +1,5 @@
 use lazy_static::lazy_static;
 use pulldown_cmark as cmark;
-use regex::Regex;
 
 use crate::context::RenderContext;
 use crate::table_of_contents::{make_table_of_contents, Heading};
@@ -57,21 +56,6 @@ fn find_anchor(anchors: &[String], name: String, level: u16) -> String {
     }
 
     find_anchor(anchors, name, level + 1)
-}
-
-/// Returns whether the given string starts with a schema.
-///
-/// Although there exists [a list of registered URI schemes][uri-schemes], a link may use arbitrary,
-/// private schemes. This function checks if the given string starts with something that just looks
-/// like a scheme, i.e., a case-insensitive identifier followed by a colon.
-///
-/// [uri-schemes]: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
-fn starts_with_schema(s: &str) -> bool {
-    lazy_static! {
-        static ref PATTERN: Regex = Regex::new(r"^[0-9A-Za-z\-]+:").unwrap();
-    }
-
-    PATTERN.is_match(s)
 }
 
 /// Returns whether a link starts with an HTTP(s) scheme.
@@ -367,25 +351,6 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_starts_with_schema() {
-        // registered
-        assert!(starts_with_schema("https://example.com/"));
-        assert!(starts_with_schema("ftp://example.com/"));
-        assert!(starts_with_schema("mailto:user@example.com"));
-        assert!(starts_with_schema("xmpp:node@example.com"));
-        assert!(starts_with_schema("tel:18008675309"));
-        assert!(starts_with_schema("sms:18008675309"));
-        assert!(starts_with_schema("h323:user@example.com"));
-
-        // arbitrary
-        assert!(starts_with_schema("zola:post?content=hi"));
-
-        // case-insensitive
-        assert!(starts_with_schema("MailTo:user@example.com"));
-        assert!(starts_with_schema("MAILTO:user@example.com"));
-    }
 
     #[test]
     fn test_is_external_link() {

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -96,7 +96,7 @@ impl DataSource {
         }
 
         if let Some(path) = path_arg {
-            return match search_for_file(&base_path, &path, &theme, &output_path)
+            return match search_for_file(base_path, &path, theme, output_path)
                 .map_err(|e| format!("`load_data`: {}", e))?
             {
                 Some((f, _)) => Ok(Some(DataSource::Path(f))),
@@ -226,7 +226,13 @@ impl TeraFn for LoadData {
 
         // If the file doesn't exist, source is None
         let data_source = match (
-            DataSource::from_args(path_arg.clone(), url_arg, &self.base_path, &self.theme, &self.output_path),
+            DataSource::from_args(
+                path_arg.clone(),
+                url_arg,
+                &self.base_path,
+                &self.theme,
+                &self.output_path,
+            ),
             required,
         ) {
             // If the file was not required, return a Null value to the template


### PR DESCRIPTION
Fixes clippy warnings for the `needless_borrow` lint.
https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

Removes the unused `starts_with_schema` function
(dead code since 4086b07).

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [X] Have you created/updated the relevant documentation page(s)? N/A



