### PR TITLE
Strip all occurrences of `<pre data-shortcode>...</pre>`

### DIFF
--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -359,17 +359,20 @@ pub fn markdown_to_html(content: &str, context: &RenderContext) -> Result<Render
 }
 
 fn strip_pre_data_shortcode(markup: &str, in_html_block: &mut bool) -> Option<Event<'static>> {
+    let start_tag = "<pre data-shortcode>";
+    let end_tag = "</pre>";
+
     let mut markup = String::from(markup);
     let mut made_replacements = false;
 
     loop {
-        if *in_html_block && markup.contains("</pre>") {
+        if *in_html_block && markup.contains(end_tag) {
             *in_html_block = false;
-            markup = markup.replacen("</pre>", "", 1).into();
+            markup = markup.replacen(end_tag, "", 1).into();
             made_replacements = true;
-        } else if markup.contains("pre data-shortcode") {
+        } else if markup.contains(start_tag) {
             *in_html_block = true;
-            markup = markup.replacen("<pre data-shortcode>", "", 1);
+            markup = markup.replacen(start_tag, "", 1);
             made_replacements = true;
         } else {
             break;

--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -412,4 +412,27 @@ mod tests {
 
         assert!(!is_external_link("http.jpg"))
     }
+
+    #[test]
+    fn test_strip_pre_data_shortcode() {
+        // Strip one occurrence
+        let input = "1 <pre data-shortcode>2</pre> 3";
+        let mut in_html_block = false;
+        assert_eq(strip_pre_data_shortcode(input, &mut in_html_block), "1 2 3");
+        assert_eq!(in_html_block, false);
+
+        // Strip end tag
+        let input = "1</pre> 2";
+        let mut in_html_block = true;
+        assert_eq(strip_pre_data_shortcode(input, &mut in_html_block), "1 2");
+        assert_eq!(in_html_block, false);
+
+        fn assert_eq(actual: Option<Event>, expected: &str) {
+            if let Some(Event::Html(actual)) = actual {
+                assert_eq!(actual.as_ref(), expected);
+            } else {
+                unreachable!()
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fix the code that strips `<pre data-shortcode>...</pre>` from HTML code that was generated from Markdown. Currently, if there are multiple occurrences of that `pre` element in the same paragraph, only the first one is stripped. This pull request extracts the offending code into a separate function, adds unit tests, and fixes the function so it strips all occurrences.

This pull request conflicts with #1564, which is a larger rewrite of the shortcode logic. I haven't tested whether that PR has the same bug, but since it's a larger change that might not be merged soon (I don't know), I think it makes sense to fix this issue separately in any case. It seems that #1564 removes the code I'm fixing here, so it should be easy to merge this change.