### PR TITLE
Fix get_url resolving asset path to invalid url on Windows

### DIFF
--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -135,6 +135,13 @@ impl TeraFn for GetUrl {
                 };
             }
 
+            if cfg!(target_os = "windows") {
+                permalink = match url::Url::parse(&permalink) {
+                    Ok(parsed) => parsed.into(),
+                    Err(_) => return Err(format!("`get_url`: Could not parse link `{}` as a valid URL", permalink).into())
+                };
+            }
+
             Ok(to_value(permalink).unwrap())
         }
     }
@@ -454,6 +461,28 @@ title = "A title"
             static_fn.call(&args).unwrap(),
             "N536s1EjuRWdnk6S3JDivkTPPC9/CbLi34Chshm0Yd41Vsk+GpzrMAjpmeLWpUtPHWXum+m+Y/pF7IiTFiM3Lw=="
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn can_resolve_asset_path_to_valid_url() {
+        let config = Config::parse(CONFIG_DATA).unwrap();
+        let dir = create_temp_dir();
+        let static_fn =
+            GetUrl::new(dir.path().to_path_buf(), config, HashMap::new(), PathBuf::new());
+        let mut args = HashMap::new();
+        args.insert(
+            "path".to_string(),
+            to_value(dir.path().join("app.css")
+            .strip_prefix(std::env::temp_dir()).unwrap()).unwrap(),
+        );
+        assert_eq!(
+            static_fn.call(&args).unwrap(),
+            format!(
+                "https://remplace-par-ton-url.fr/{}/app.css",
+                dir.path().file_stem().unwrap().to_string_lossy()
+            )
+        )
     }
 
     #[test]

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -464,7 +464,6 @@ title = "A title"
     }
 
     #[test]
-    #[cfg(target_os = "windows")]
     fn can_resolve_asset_path_to_valid_url() {
         let config = Config::parse(CONFIG_DATA).unwrap();
         let dir = create_temp_dir();


### PR DESCRIPTION
Hi, I'm a beginner in Rust. I followed [this](https://www.getzola.org/documentation/content/image-processing/#creating-picture-galleries) example on the documentation page. However, there is an issue on Windows where get_url resolves colocated asset paths (page\section\asset.jpg) to something like this 'http://localhost/page\section\asset.jpg'. This is my attempt at a fix/workaround.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



