### PR TITLE
Add corona-effekt.orgatalk.de to list of example sites

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -38,3 +38,4 @@
 | [uggla.fr](https://uggla.fr)                                       | https://github.com/uggla/blog                            |
 | [NorthCon e.V.](https://verein.northcon.de/)                       |                                                          |
 | [OrgaTalk wiki](https://wiki.orgatalk.de/)                         | https://github.com/orgatalk/wiki                         |
+| [Der Corona-Effekt](https://corona-effekt.orgatalk.de/)            | https://github.com/orgatalk/corona-effekt                |


### PR DESCRIPTION
The site offers a manually maintained list of LAN party cancellations due to COVID-19.