### PR TITLE
Use distroless instead of dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM rust:slim AS builder
 
 RUN apt-get update -y && \
-  apt-get install -y python-pip make g++ python-setuptools libssl-dev pkg-config rsync && \
-  pip install dockerize && \
+  apt-get install -y make g++ libssl-dev && \
   rustup target add x86_64-unknown-linux-gnu
 
 WORKDIR /app
@@ -10,12 +9,7 @@ COPY . .
 
 RUN cargo build --release --target x86_64-unknown-linux-gnu
 
-RUN mv target/x86_64-unknown-linux-gnu/release/zola /usr/bin
-RUN mkdir -p /workdir
-WORKDIR /workdir
-RUN dockerize -n  -o /workdir  /usr/bin/zola
 
-
-FROM scratch
-COPY --from=builder /workdir .
-ENTRYPOINT [ "/usr/bin/zola" ]
+FROM gcr.io/distroless/cc
+COPY --from=builder /app/target/x86_64-unknown-linux-gnu/release/zola /bin/zola
+ENTRYPOINT [ "/bin/zola" ]


### PR DESCRIPTION
The distroless cc base image includes only what's required to run compiled rust binaries,
see https://github.com/GoogleContainerTools/distroless for more info about these images.
Using this base image lets us get rid of dockerize and its build steps and dependencies, including python.
On top of that it provides ca-certificates, timezone data, and other necessary infrastructure.

Fixes #1642

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes


* [X] Are you doing the PR on the `next` branch?
