### PR TITLE
Add check for export highlight theme CSS in Config

### DIFF
--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -139,7 +139,7 @@ impl Markdown {
         // Validate that all exported highlight themes exist as well
         for theme in self.highlight_themes_css.iter() {
             let theme_name = &theme.theme;
-            if !(THEME_SET.themes.contains_key(theme_name)) {
+            if !THEME_SET.themes.contains_key(theme_name) {
                 // Check extra themes
                 if let Some(extra) = &*self.extra_theme_set {
                     if !extra.themes.contains_key(theme_name) {

--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -121,7 +121,7 @@ impl Markdown {
             self.extra_theme_set = Arc::new(Some(extra_theme_set));
         }
 
-        // validate that the chosen highlight_theme exists in the loaded highlight theme sets
+        // Validate that the chosen highlight_theme exists in the loaded highlight theme sets
         if !THEME_SET.themes.contains_key(&self.highlight_theme) {
             if let Some(extra) = &*self.extra_theme_set {
                 if !extra.themes.contains_key(&self.highlight_theme) {
@@ -133,6 +133,20 @@ impl Markdown {
             } else {
                 bail!("Highlight theme {} not available.\n\
                 You can load custom themes by configuring `extra_syntaxes_and_themes` to include a list of folders containing '.tmTheme' files", self.highlight_theme)
+            }
+        }
+
+        // Validate that all exported highlight themes exist as well
+        for theme in self.highlight_themes_css.iter() {
+            let theme_name = &theme.theme;
+            if !(THEME_SET.themes.contains_key(theme_name)) {
+                // Check extra themes
+                if let Some(extra) = &*self.extra_theme_set {
+                    if !extra.themes.contains_key(theme_name) {
+                        bail!("Can't export highlight theme {}, as it does not exist.\n\
+                        Make sure it's spelled correctly, or your custom .tmTheme' is defined properly.", theme_name)
+                    }
+                }
             }
         }
 

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -677,4 +677,32 @@ output_dir = "docs"
         let config = Config::parse(config).unwrap();
         assert_eq!(config.output_dir, "docs".to_string());
     }
+
+    // TODO: Tests for valid themes; need extra scaffolding (test site) for custom themes.
+
+    #[test]
+    fn invalid_highlight_theme() {
+        let config = r#"
+[markup]
+highlight_code = true
+highlight_theme = "asdf"
+    "#;
+
+        let config = Config::parse(config);
+        assert_eq!(config.is_err(), true);
+    }
+
+    #[test]
+    fn invalid_highlight_theme_css_export() {
+        let config = r#"
+[markup]
+highlight_code = true
+highlight_themes_css = [
+  { theme = "asdf", filename = "asdf.css" },
+]
+    "#;
+
+        let config = Config::parse(config);
+        assert_eq!(config.is_err(), true);
+    }
 }


### PR DESCRIPTION

## Background

This PR fixes #1635.

The markup init method `init_extra_syntaxes_and_highlight_themes` checked to see if the specified `highlight_theme` existed, but did not check any attempts to export theme CSS, in `highlight_themes_css`.

(Notably, this logic used to be in `Config::parse()`, but was refactored in #1499 to accomodate custom themes.)

## Contents
- Check `THEME_SET` and `extra_theme_set` for each theme attempted to export
- Give user readable message if this is not the case.

## Notes
- I didn't notice any tests in the `config` module; probably best for a different PR, to prevent regressions?
- I'm not too sold on the the 3 nested `if` logic, coming from a Swift background; if there's a cleaner way in Rust I'm happy to change it :)

## Template Checks
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?
If the change is a new feature or adding to/changing an existing one:
N/A
* [x] Have you created/updated the relevant documentation page(s)?



