### PR TITLE
Add generic template fallbacks to taxonomies

### DIFF
--- a/components/library/src/pagination/mod.rs
+++ b/components/library/src/pagination/mod.rs
@@ -99,13 +99,10 @@ impl<'a> Paginator<'a> {
     ) -> Paginator<'a> {
         let paginate_by = taxonomy.kind.paginate_by.unwrap();
         // Check for taxon-specific template, or use generic as fallback.
-        let template = match check_template_fallbacks(
-            &format!("{}/single.html", taxonomy.kind.name),
-            tera,
-            theme,
-        ) {
+        let specific_template = format!("{}/single.html", taxonomy.kind.name);
+        let template = match check_template_fallbacks(&specific_template, tera, theme) {
             Some(template) => template,
-            None => "taxonomy_single.html".to_string(),
+            None => "taxonomy_single.html",
         };
         let mut paginator = Paginator {
             all_pages: Cow::Borrowed(&item.pages),
@@ -121,7 +118,7 @@ impl<'a> Paginator<'a> {
                 .clone()
                 .unwrap_or_else(|| "page".to_string()),
             is_index: false,
-            template,
+            template: template.to_string(),
         };
 
         // taxonomy paginators have no sorting so we won't have to reverse

--- a/components/library/src/pagination/mod.rs
+++ b/components/library/src/pagination/mod.rs
@@ -105,7 +105,7 @@ impl<'a> Paginator<'a> {
             theme,
         ) {
             Some(template) => template,
-            None => "single.html".to_string(),
+            None => "taxonomy_single.html".to_string(),
         };
         let mut paginator = Paginator {
             all_pages: Cow::Borrowed(&item.pages),

--- a/components/library/src/pagination/mod.rs
+++ b/components/library/src/pagination/mod.rs
@@ -6,7 +6,7 @@ use tera::{to_value, Context, Tera, Value};
 
 use config::Config;
 use errors::{Error, Result};
-use utils::templates::render_template;
+use utils::templates::{check_template_fallbacks, render_template};
 
 use crate::content::{Section, SerializingPage, SerializingSection};
 use crate::library::Library;
@@ -94,8 +94,19 @@ impl<'a> Paginator<'a> {
         taxonomy: &'a Taxonomy,
         item: &'a TaxonomyItem,
         library: &'a Library,
+        tera: &Tera,
+        theme: &Option<String>,
     ) -> Paginator<'a> {
         let paginate_by = taxonomy.kind.paginate_by.unwrap();
+        // Check for taxon-specific template, or use generic as fallback.
+        let template = match check_template_fallbacks(
+            &format!("{}/single.html", taxonomy.kind.name),
+            tera,
+            theme,
+        ) {
+            Some(template) => template,
+            None => "single.html".to_string(),
+        };
         let mut paginator = Paginator {
             all_pages: Cow::Borrowed(&item.pages),
             pagers: Vec::with_capacity(item.pages.len() / paginate_by),
@@ -110,7 +121,7 @@ impl<'a> Paginator<'a> {
                 .clone()
                 .unwrap_or_else(|| "page".to_string()),
             is_index: false,
-            template: format!("{}/single.html", taxonomy.kind.name),
+            template,
         };
 
         // taxonomy paginators have no sorting so we won't have to reverse
@@ -249,7 +260,7 @@ impl<'a> Paginator<'a> {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use tera::to_value;
+    use tera::{to_value, Tera};
 
     use crate::content::{Page, Section};
     use crate::library::Library;
@@ -408,6 +419,7 @@ mod tests {
     #[test]
     fn test_can_create_paginator_for_taxonomy() {
         let (_, library) = create_library(false, 3, false);
+        let tera = Tera::default();
         let taxonomy_def = TaxonomyConfig {
             name: "tags".to_string(),
             paginate_by: Some(2),
@@ -427,7 +439,7 @@ mod tests {
             permalink: "/tags/".to_string(),
             items: vec![taxonomy_item.clone()],
         };
-        let paginator = Paginator::from_taxonomy(&taxonomy, &taxonomy_item, &library);
+        let paginator = Paginator::from_taxonomy(&taxonomy, &taxonomy_item, &library, &tera, &None);
         assert_eq!(paginator.pagers.len(), 2);
 
         assert_eq!(paginator.pagers[0].index, 1);
@@ -444,6 +456,7 @@ mod tests {
     #[test]
     fn test_can_create_paginator_for_slugified_taxonomy() {
         let (_, library) = create_library(false, 3, false);
+        let tera = Tera::default();
         let taxonomy_def = TaxonomyConfig {
             name: "some tags".to_string(),
             paginate_by: Some(2),
@@ -463,7 +476,7 @@ mod tests {
             permalink: "/some-tags/".to_string(),
             items: vec![taxonomy_item.clone()],
         };
-        let paginator = Paginator::from_taxonomy(&taxonomy, &taxonomy_item, &library);
+        let paginator = Paginator::from_taxonomy(&taxonomy, &taxonomy_item, &library, &tera, &None);
         assert_eq!(paginator.pagers.len(), 2);
 
         assert_eq!(paginator.pagers[0].index, 1);

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -209,7 +209,7 @@ impl Taxonomy {
             &config.theme,
         ) {
             Some(template) => template,
-            None => "single.html".to_string(),
+            None => "taxonomy_single.html".to_string(),
         };
 
         render_template(&template, tera, context, &config.theme).map_err(|e| {
@@ -240,7 +240,7 @@ impl Taxonomy {
             &config.theme,
         ) {
             Some(template) => template,
-            None => "list.html".to_string(),
+            None => "taxonomy_list.html".to_string(),
         };
 
         render_template(&template, tera, context, &config.theme).map_err(|e| {

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -203,13 +203,10 @@ impl Taxonomy {
         context.insert("current_path", &format!("/{}/{}/", self.kind.name, item.slug));
 
         // Check for taxon-specific template, or use generic as fallback.
-        let template = match check_template_fallbacks(
-            &format!("{}/single.html", self.kind.name),
-            tera,
-            &config.theme,
-        ) {
+        let specific_template = format!("{}/single.html", self.kind.name);
+        let template = match check_template_fallbacks(&specific_template, tera, &config.theme) {
             Some(template) => template,
-            None => "taxonomy_single.html".to_string(),
+            None => "taxonomy_single.html",
         };
 
         render_template(&template, tera, context, &config.theme).map_err(|e| {
@@ -234,13 +231,10 @@ impl Taxonomy {
         context.insert("current_path", &format!("/{}/", self.kind.name));
 
         // Check for taxon-specific template, or use generic as fallback.
-        let template = match check_template_fallbacks(
-            &format!("{}/list.html", self.kind.name),
-            tera,
-            &config.theme,
-        ) {
+        let specific_template = format!("{}/list.html", self.kind.name);
+        let template = match check_template_fallbacks(&specific_template, tera, &config.theme) {
             Some(template) => template,
-            None => "taxonomy_list.html".to_string(),
+            None => "taxonomy_list.html",
         };
 
         render_template(&template, tera, context, &config.theme).map_err(|e| {

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -7,7 +7,7 @@ use tera::{Context, Tera};
 
 use config::{Config, Taxonomy as TaxonomyConfig};
 use errors::{bail, Error, Result};
-use utils::templates::render_template;
+use utils::templates::{check_template_fallbacks, render_template};
 
 use crate::content::SerializingPage;
 use crate::library::Library;
@@ -202,10 +202,19 @@ impl Taxonomy {
         );
         context.insert("current_path", &format!("/{}/{}/", self.kind.name, item.slug));
 
-        render_template(&format!("{}/single.html", self.kind.name), tera, context, &config.theme)
-            .map_err(|e| {
-                Error::chain(format!("Failed to render single term {} page.", self.kind.name), e)
-            })
+        // Check for taxon-specific template, or use generic as fallback.
+        let template = match check_template_fallbacks(
+            &format!("{}/single.html", self.kind.name),
+            tera,
+            &config.theme,
+        ) {
+            Some(template) => template,
+            None => "single.html".to_string(),
+        };
+
+        render_template(&template, tera, context, &config.theme).map_err(|e| {
+            Error::chain(format!("Failed to render single term {} page.", self.kind.name), e)
+        })
     }
 
     pub fn render_all_terms(
@@ -224,10 +233,19 @@ impl Taxonomy {
         context.insert("current_url", &config.make_permalink(&self.kind.name));
         context.insert("current_path", &format!("/{}/", self.kind.name));
 
-        render_template(&format!("{}/list.html", self.kind.name), tera, context, &config.theme)
-            .map_err(|e| {
-                Error::chain(format!("Failed to render a list of {} page.", self.kind.name), e)
-            })
+        // Check for taxon-specific template, or use generic as fallback.
+        let template = match check_template_fallbacks(
+            &format!("{}/list.html", self.kind.name),
+            tera,
+            &config.theme,
+        ) {
+            Some(template) => template,
+            None => "list.html".to_string(),
+        };
+
+        render_template(&template, tera, context, &config.theme).map_err(|e| {
+            Error::chain(format!("Failed to render a list of {} page.", self.kind.name), e)
+        })
     }
 
     pub fn to_serialized<'a>(&'a self, library: &'a Library) -> SerializedTaxonomy<'a> {

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -829,7 +829,7 @@ impl Site {
                 if taxonomy.kind.is_paginated() {
                     self.render_paginated(
                         comp.clone(),
-                        &Paginator::from_taxonomy(taxonomy, item, &library),
+                        &Paginator::from_taxonomy(taxonomy, item, &library, &self.tera, &self.config.theme),
                     )?;
                 } else {
                     let single_output =

--- a/components/utils/src/templates.rs
+++ b/components/utils/src/templates.rs
@@ -95,6 +95,8 @@ pub fn check_template_fallbacks<'a>(
 
 #[cfg(test)]
 mod tests {
+    use crate::templates::check_template_fallbacks;
+
     use super::rewrite_theme_paths;
     use tera::Tera;
 
@@ -118,6 +120,25 @@ mod tests {
         assert_eq!(
             tera.templates["hyde/templates/child.html"].parent,
             Some("index.html".to_string())
+        );
+    }
+
+    #[test]
+    fn template_fallback_is_successful() {
+        let mut tera = Tera::parse("test-templates/*.html").unwrap();
+        tera.add_raw_template(&"hyde/templates/index.html", "Hello").unwrap();
+        tera.add_raw_template(&"hyde/templates/theme-only.html", "Hello").unwrap();
+
+        // Check finding existing template
+        assert_eq!(check_template_fallbacks("index.html", &tera, &None), Some("index.html"));
+
+        // Check trying to find non-existant template
+        assert_eq!(check_template_fallbacks("not-here.html", &tera, &None), None);
+
+        // Check theme fallback
+        assert_eq!(
+            check_template_fallbacks("theme-only.html", &tera, &Some("hyde".to_string())),
+            Some("hyde/templates/theme-only.html")
         );
     }
 }

--- a/components/utils/src/templates.rs
+++ b/components/utils/src/templates.rs
@@ -63,27 +63,31 @@ pub fn rewrite_theme_paths(tera_theme: &mut Tera, theme: &str) {
     tera_theme.templates.extend(new_templates);
 }
 
-/// Checks for the presence of a given template. If none is found, also looks for a 
+/// Checks for the presence of a given template. If none is found, also looks for a
 /// fallback in theme and default templates. Returns the path of the most specific
 /// template found, or none if none are present.
-pub fn check_template_fallbacks(name: &str, tera: &Tera, theme: &Option<String>) -> Option<String> {
+pub fn check_template_fallbacks<'a>(
+    name: &'a str,
+    tera: &'a Tera,
+    theme: &Option<String>,
+) -> Option<&'a str> {
     // check if it is in the templates
     if tera.templates.contains_key(name) {
-        return Some(name.to_string());
+        return Some(name);
     }
 
     // check if it is part of a theme
     if let Some(ref t) = *theme {
         let theme_template_name = format!("{}/templates/{}", t, name);
-        if tera.templates.contains_key(&theme_template_name) {
-            return Some(theme_template_name);
+        if let Some((key, _)) = tera.templates.get_key_value(&theme_template_name) {
+            return Some(key);
         }
     }
 
     // check if it is part of ZOLA_TERA defaults
     let default_name = format!("__zola_builtins/{}", name);
-    if tera.templates.contains_key(&default_name) {
-        return Some(default_name);
+    if let Some((key, _)) = tera.templates.get_key_value(&default_name) {
+        return Some(key);
     }
 
     None

--- a/docs/content/documentation/templates/taxonomies.md
+++ b/docs/content/documentation/templates/taxonomies.md
@@ -9,8 +9,8 @@ Zola will look up the following, taxon-specific files in the `templates` directo
 - `$TAXONOMY_NAME/list.html`
 
 if they are not found, it will attempt to fall back on the following generic template files:
-- `single.html`
-- `list.html`
+- `taxonomy_single.html`
+- `taxonomy_list.html`
 
 First, `TaxonomyTerm` has the following fields:
 

--- a/docs/content/documentation/templates/taxonomies.md
+++ b/docs/content/documentation/templates/taxonomies.md
@@ -3,10 +3,14 @@ title = "Taxonomies"
 weight = 40
 +++
 
-Zola will look up the following files in the `templates` directory:
+Zola will look up the following, taxon-specific files in the `templates` directory:
 
 - `$TAXONOMY_NAME/single.html`
 - `$TAXONOMY_NAME/list.html`
+
+if they are not found, it will attempt to fall back on the following generic template files:
+- `single.html`
+- `list.html`
 
 First, `TaxonomyTerm` has the following fields:
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one: adding to an existing feature.

* [x] Have you created/updated the relevant documentation page(s)?

## Description
This PR adds support for generic fall-back templates for taxonomies, as per issue #1630. It currently splits off the template fall-back logic into a separate function, and then utilises that when rendering a taxonomy to check whether there is a taxon-specific template available and, if not, fallback to a generic `list.html` or `single.html` file in the `template` directory root.

Getting it to work with paginated taxonomies did require that I extend the number of arguments on the `Paginator::from_taxonomy()` function which may not be desirable. Hopefully other might be able to suggest and alternate implementation, or comment on whether what I have done is worth it for the extra utility.


