### PR TITLE
fixes #1599

### DIFF
--- a/components/library/src/content/mod.rs
+++ b/components/library/src/content/mod.rs
@@ -3,9 +3,8 @@ mod page;
 mod section;
 mod ser;
 
+use std::fs::read_dir;
 use std::path::{Path, PathBuf};
-
-use walkdir::WalkDir;
 
 pub use self::file_info::FileInfo;
 pub use self::page::Page;
@@ -32,19 +31,32 @@ pub fn has_anchor(headings: &[Heading], anchor: &str) -> bool {
 /// file. Those will be copied next to the rendered .html file
 pub fn find_related_assets(path: &Path, config: &Config) -> Vec<PathBuf> {
     let mut assets = vec![];
-
-    for entry in WalkDir::new(path).into_iter().filter_map(std::result::Result::ok) {
-        let entry_path = entry.path();
-        if entry_path.is_file() {
-            match entry_path.extension() {
-                Some(e) => match e.to_str() {
-                    Some("md") => continue,
-                    _ => assets.push(entry_path.to_path_buf()),
-                },
-                None => continue,
-            }
-        }
-    }
+	
+	if path.is_dir() {
+		match read_dir(path) {
+			Ok(d) => {
+				for entry_path_res in d {
+					match entry_path_res {
+						Ok(entry) => {
+							let entry_path = entry.path();
+							if entry_path.is_file() {
+								match entry_path.extension() {
+									Some(e) => match e.to_str() {
+										Some("md") => {},
+										_ => assets.push(entry_path.to_path_buf()),
+									},
+									None => {},
+								}
+							}
+						}
+						_ => {}
+					}
+					
+				}
+			},
+			_ => {},
+		}	
+	}
 
     if let Some(ref globset) = config.ignored_content_globset {
         assets = assets
@@ -80,15 +92,8 @@ mod tests {
         File::create(path.join("subdir").join("example.js")).unwrap();
 
         let assets = find_related_assets(path, &Config::default());
-        assert_eq!(assets.len(), 4);
-        assert_eq!(assets.iter().filter(|p| p.extension().unwrap() != "md").count(), 4);
-        assert_eq!(
-            assets
-                .iter()
-                .filter(|p| p.strip_prefix(path).unwrap() == Path::new("example.js"))
-                .count(),
-            1
-        );
+        assert_eq!(assets.len(), 3);
+        assert_eq!(assets.iter().filter(|p| p.extension().unwrap() != "md").count(), 3);
         assert_eq!(
             assets
                 .iter()
@@ -106,7 +111,18 @@ mod tests {
         assert_eq!(
             assets
                 .iter()
-                .filter(|p| p.strip_prefix(path).unwrap() == Path::new("subdir/example.js"))
+                .filter(|p| p.strip_prefix(path).unwrap() == Path::new("example.js"))
+                .count(),
+            1
+        );
+
+		let assetssub = find_related_assets(&path.join("subdir"), &Config::default());
+
+		assert_eq!(assetssub.len(), 1);
+		assert_eq!(
+            assetssub
+                .iter()
+                .filter(|p| p.strip_prefix(path.join("subdir")).unwrap() == Path::new("example.js"))
                 .count(),
             1
         );


### PR DESCRIPTION
no longer associate assets from subfolders, only the current folder.
This caused two threads writing creating the same file. when this happens at the same time zola build on windows crashes.

I've ran the test-suite about 10 times no longer seen the error.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [ x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [ x ] Are you doing the PR on the `next` branch?





