### PR TITLE
Fix typo: hightlighting -> highlighting

### DIFF
--- a/docs/content/themes/tale-zola/index.md
+++ b/docs/content/themes/tale-zola/index.md
@@ -207,7 +207,7 @@ disqus = false
 disqus_id = ""
 ```
 
-Code syntax highlighting. See also [syntax hightlighting](https://www.getzola.org/documentation/getting-started/configuration/#syntax-highlighting).
+Code syntax highlighting. See also [syntax highlighting](https://www.getzola.org/documentation/getting-started/configuration/#syntax-highlighting).
 
 ```toml
 [markdown]


### PR DESCRIPTION
Fix a typo in the [tale-zola | Zola](https://www.getzola.org/themes/tale-zola/).

X: hightlighting
O: highlighting
