### PR TITLE
templates/load_data: add an optional parameter `headers`

### DIFF
--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use csv::Reader;
-use reqwest::header::{HeaderValue, CONTENT_TYPE};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use reqwest::{blocking::Client, header};
 use tera::{from_value, to_value, Error, Function as TeraFn, Map, Result, Value};
 use url::Url;
@@ -162,6 +162,31 @@ fn get_output_format_from_args(
     }
 }
 
+fn add_headers_from_args(header_args: Option<Vec<String>>) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    if let Some(header_args) = header_args {
+        for arg in header_args {
+            let mut splitter = arg.splitn(2, '=');
+            let key = splitter
+                .next()
+                .ok_or_else(|| {
+                    format!("Invalid header argument. Expecting header key, got '{}'", arg)
+                })?
+                .to_string();
+            let value = splitter.next().ok_or_else(|| {
+                format!("Invalid header argument. Expecting header value, got '{}'", arg)
+            })?;
+            headers.append(
+                HeaderName::from_str(&key)
+                    .map_err(|e| format!("Invalid header name '{}': {}", key, e))?,
+                value.parse().map_err(|e| format!("Invalid header value '{}': {}", value, e))?,
+            );
+        }
+    }
+
+    Ok(headers)
+}
+
 /// A Tera function to load data from a file or from a URL
 /// Currently the supported formats are json, toml, csv, bibtex and plain text
 #[derive(Debug)]
@@ -223,6 +248,11 @@ impl TeraFn for LoadData {
             },
             _ => Method::Get,
         };
+        let headers = optional_arg!(
+            Vec<String>,
+            args.get("headers"),
+            "`load_data`: `headers` needs to be an argument with a list of strings of format <name>=<value>."
+        );
 
         // If the file doesn't exist, source is None
         let data_source = match (
@@ -271,10 +301,12 @@ impl TeraFn for LoadData {
                 let req = match method {
                     Method::Get => response_client
                         .get(url.as_str())
+                        .headers(add_headers_from_args(headers)?)
                         .header(header::ACCEPT, file_format.as_accept_header()),
                     Method::Post => {
                         let mut resp = response_client
                             .post(url.as_str())
+                            .headers(add_headers_from_args(headers)?)
                             .header(header::ACCEPT, file_format.as_accept_header());
                         if let Some(content_type) = post_content_type {
                             match HeaderValue::from_str(&content_type) {
@@ -999,6 +1031,70 @@ mod tests {
         args2.insert("body".to_string(), to_value("this is a match").unwrap());
         let result2 = static_fn.call(&args2);
         assert!(result2.is_ok());
+
+        _mjson.assert();
+    }
+
+    #[test]
+    fn is_custom_headers_working() {
+        let _mjson = mock("POST", "/kr1zdgbm4y4")
+            .with_header("content-type", "application/json")
+            .match_header("accept", "text/plain")
+            .match_header("x-custom-header", "some-values")
+            .with_body("{i_am:'json'}")
+            .expect(1)
+            .create();
+        let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y4");
+
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), to_value(&url).unwrap());
+        args.insert("format".to_string(), to_value("plain").unwrap());
+        args.insert("method".to_string(), to_value("post").unwrap());
+        args.insert("content_type".to_string(), to_value("text/plain").unwrap());
+        args.insert("body".to_string(), to_value("this is a match").unwrap());
+        args.insert("headers".to_string(), to_value(["x-custom-header=some-values"]).unwrap());
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
+
+        _mjson.assert();
+    }
+
+    #[test]
+    fn is_custom_headers_working_with_multiple_values() {
+        let _mjson = mock("POST", "/kr1zdgbm4y5")
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .match_header("authorization", "Bearer 123")
+            // Mockito currently does not have a way to validate multiple headers with the same name
+            // see https://github.com/lipanski/mockito/issues/117
+            .match_header("accept", mockito::Matcher::Any)
+            .match_header("x-custom-header", "some-values")
+            .match_header("x-other-header", "some-other-values")
+            .with_body("<html>I am a server that needs authentication and returns HTML with Accept set to JSON</html>")
+            .expect(1)
+            .create();
+        let url = format!("{}{}", mockito::server_url(), "/kr1zdgbm4y5");
+
+        let static_fn = LoadData::new(PathBuf::from("../utils"), None, PathBuf::new());
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), to_value(&url).unwrap());
+        args.insert("format".to_string(), to_value("plain").unwrap());
+        args.insert("method".to_string(), to_value("post").unwrap());
+        args.insert("content_type".to_string(), to_value("text/plain").unwrap());
+        args.insert("body".to_string(), to_value("this is a match").unwrap());
+        args.insert(
+            "headers".to_string(),
+            to_value([
+                "x-custom-header=some-values",
+                "x-other-header=some-other-values",
+                "accept=application/json",
+                "authorization=Bearer 123",
+            ])
+            .unwrap(),
+        );
+        let result = static_fn.call(&args);
+        assert!(result.is_ok());
 
         _mjson.assert();
     }

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -440,8 +440,7 @@ headers=["accept=application/json,text/html"]
 
 Which is equivalent to two `Accept` headers with `application/json` and `text/html`.
 
-In rare cases where the target resource backend is not implemented correctly, you can instead specify
-the headers multiple times to achieve the same effect:
+If it doesn't work, you can instead specify the headers multiple times to achieve a similar effect:
 
 ```
 headers=["accept=application/json", "accept=text/html"]

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -432,6 +432,21 @@ environment variable to the access token you have obtained.
 {{postdata|safe}}
 ```
 
+In case you need to specify multiple headers with the same name, you can specify them like this:
+
+```
+headers=["accept=application/json,text/html"]
+```
+
+Which is equivalent to two `Accept` headers with `application/json` and `text/html`.
+
+In rare cases where the target resource backend is not implemented correctly, you can instead specify
+the headers multiple times to achieve the same effect:
+
+```
+headers=["accept=application/json", "accept=text/html"]
+```
+
 #### Data caching
 
 Data file loading and remote requests are cached in memory during the build, so multiple requests aren't made

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -409,6 +409,29 @@ This example will make a POST request to the kroki service to generate a SVG.
 {{postdata|safe}}
 ```
 
+If you need additional handling for the HTTP headers, you can use the `headers` parameter.
+You might need this parameter when the resource requires authentication or require passing additional
+parameters via special headers.
+Please note that the headers will be appended to the default headers set by Zola itself instead of replacing them.
+
+This example will make a POST request to the GitHub markdown rendering service.
+
+```jinja2
+{% set postdata = load_data(url="https://api.github.com/markdown", format="plain", method="POST", content_type="application/json", headers=["accept=application/vnd.github.v3+json"], body='{"text":"headers support added in #1710, commit before it: b3918f124d13ec1bedad4860c15a060dd3751368","context":"getzola/zola","mode":"gfm"}')%}
+{{postdata|safe}}
+```
+
+The following example shows how to send a GraphQL query to GitHub (requires authentication).
+If you want to try this example on your own machine, you need to provide a GitHub PAT (Personal Access Token),
+you can acquire the access token at this link: https://github.com/settings/tokens and then set `GITHUB_TOKEN`
+environment variable to the access token you have obtained.
+
+```jinja2
+{% set token = get_env(name="GITHUB_TOKEN") %}
+{% set postdata = load_data(url="https://api.github.com/graphql", format="json", method="POST" ,content_type="application/json", headers=["accept=application/vnd.github.v4.idl", "authentication=Bearer " ~ token], body='{"query":"query { viewer { login }}"}')%}
+{{postdata|safe}}
+```
+
 #### Data caching
 
 Data file loading and remote requests are cached in memory during the build, so multiple requests aren't made


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [X] Have you created/updated the relevant documentation page(s)?

* [X] New tests are added as well

------

This pull request adds an optional parameter `headers` to the `load_data` function.

This is useful for accessing protected resources (either by setting `Authorization` header or `Cookie`) or handling some anomalies like GitHub Markdown rendering API (it expect you to set `Accept` to `application/json` but it will return a response with a type of `text/html`).

Two new tests have been added to ensure the newly added logic does not interfere with the existing `load_data` logic and works as expected. Due to limitations with `mockito`, one of the tests has relaxed passing conditions.

Two worked examples have been added to the documentation, they have been tested to work correctly.