### PR TITLE
Fix option in syntax highlighting docs

### DIFF
--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -227,7 +227,7 @@ you get CSS class definitions, instead.
 </pre>
 ```
 
-Zola can output a css file for a theme in the `static` directory using the `highlighting_themes_css` option.
+Zola can output a css file for a theme in the `static` directory using the `highlight_themes_css` option.
 
 ```toml
 highlight_themes_css = [


### PR DESCRIPTION
The sentence mentions `highlighting_themes_css` but the actual option is `highlight_themes_css`.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

