### PR TITLE
Add heuristic checking for HTML anchors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,6 +1367,7 @@ dependencies = [
  "lazy_static",
  "mockito",
  "reqwest",
+ "utils",
 ]
 
 [[package]]
@@ -3264,6 +3265,7 @@ dependencies = [
  "filetime",
  "minify-html",
  "percent-encoding",
+ "regex",
  "serde",
  "slug",
  "tempfile",

--- a/components/config/src/config/link_checker.rs
+++ b/components/config/src/config/link_checker.rs
@@ -1,6 +1,6 @@
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LinkChecker {
     /// Skip link checking for these URL prefixes
@@ -9,8 +9,3 @@ pub struct LinkChecker {
     pub skip_anchor_prefixes: Vec<String>,
 }
 
-impl Default for LinkChecker {
-    fn default() -> LinkChecker {
-        LinkChecker { skip_prefixes: Vec::new(), skip_anchor_prefixes: Vec::new() }
-    }
-}

--- a/components/library/src/content/mod.rs
+++ b/components/library/src/content/mod.rs
@@ -14,6 +14,7 @@ pub use self::ser::{SerializingPage, SerializingSection};
 
 use config::Config;
 use rendering::Heading;
+use utils::links::anchor_id_checks;
 
 pub fn has_anchor(headings: &[Heading], anchor: &str) -> bool {
     for heading in headings {
@@ -26,6 +27,12 @@ pub fn has_anchor(headings: &[Heading], anchor: &str) -> bool {
     }
 
     false
+}
+
+
+pub fn has_anchor_id(content: &str, anchor: &str) -> bool {
+    let checks = anchor_id_checks(anchor);
+    checks.is_match(content)
 }
 
 /// Looks into the current folder for the path and see if there's anything that is not a .md

--- a/components/library/src/content/mod.rs
+++ b/components/library/src/content/mod.rs
@@ -14,7 +14,6 @@ pub use self::ser::{SerializingPage, SerializingSection};
 
 use config::Config;
 use rendering::Heading;
-use utils::links::anchor_id_checks;
 
 pub fn has_anchor(headings: &[Heading], anchor: &str) -> bool {
     for heading in headings {
@@ -27,12 +26,6 @@ pub fn has_anchor(headings: &[Heading], anchor: &str) -> bool {
     }
 
     false
-}
-
-
-pub fn has_anchor_id(content: &str, anchor: &str) -> bool {
-    let checks = anchor_id_checks(anchor);
-    checks.is_match(content)
 }
 
 /// Looks into the current folder for the path and see if there's anything that is not a .md

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -20,8 +20,7 @@ use crate::content::file_info::FileInfo;
 use crate::content::ser::SerializingPage;
 use crate::content::{find_related_assets, has_anchor};
 use utils::fs::read_file;
-
-use super::has_anchor_id;
+use utils::links::has_anchor_id;
 
 lazy_static! {
     // Based on https://regex101.com/r/H2n38Z/1/tests

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -21,6 +21,8 @@ use crate::content::ser::SerializingPage;
 use crate::content::{find_related_assets, has_anchor};
 use utils::fs::read_file;
 
+use super::has_anchor_id;
+
 lazy_static! {
     // Based on https://regex101.com/r/H2n38Z/1/tests
     // A regex parsing RFC3339 date followed by {_,-}, some characters and ended by .md
@@ -298,6 +300,10 @@ impl Page {
 
     pub fn has_anchor(&self, anchor: &str) -> bool {
         has_anchor(&self.toc, anchor)
+    }
+
+    pub fn has_anchor_id(&self, id: &str) -> bool {
+        has_anchor_id(&self.content, id)
     }
 
     pub fn to_serialized<'a>(&'a self, library: &'a Library) -> SerializingPage<'a> {

--- a/components/link_checker/Cargo.toml
+++ b/components/link_checker/Cargo.toml
@@ -9,6 +9,7 @@ lazy_static = "1"
 
 config = { path = "../config" }
 errors = { path = "../errors" }
+utils = { path = "../utils" }
 
 [dependencies.reqwest]
 version = "0.11"

--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -2,12 +2,12 @@ use lazy_static::lazy_static;
 use reqwest::header::{HeaderMap, ACCEPT};
 use reqwest::{blocking::Client, StatusCode};
 
-use utils::links::anchor_id_checks;
 use config::LinkChecker;
 
 use std::collections::HashMap;
 use std::result;
 use std::sync::{Arc, RwLock};
+use utils::links::has_anchor_id;
 
 pub type Result = result::Result<StatusCode, String>;
 
@@ -105,9 +105,9 @@ fn has_anchor(url: &str) -> bool {
 fn check_page_for_anchor(url: &str, body: String) -> errors::Result<()> {
     let index = url.find('#').unwrap();
     let anchor = url.get(index + 1..).unwrap();
-    let checks = anchor_id_checks(anchor);
 
-    if checks.is_match(&body){
+
+    if has_anchor_id(&body, &anchor){
         Ok(())
     } else {
         Err(errors::Error::from(format!("Anchor `#{}` not found on page", anchor)))

--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -63,7 +63,8 @@ pub fn check_internal_links_with_anchors(site: &Site) -> Result<()> {
             let page = library
                 .get_page(&full_path)
                 .expect("Couldn't find section in check_internal_links_with_anchors");
-            !page.has_anchor(anchor)
+
+            !(page.has_anchor(anchor)||page.has_anchor_id(anchor))
         }
     });
 

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -9,6 +9,7 @@ include = ["src/**/*"]
 tera = "1"
 unicode-segmentation = "1.2"
 walkdir = "2"
+regex="1"
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 slug = "0.1"

--- a/components/utils/src/lib.rs
+++ b/components/utils/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod de;
 pub mod fs;
+pub mod links;
 pub mod minify;
 pub mod net;
 pub mod site;

--- a/components/utils/src/links.rs
+++ b/components/utils/src/links.rs
@@ -1,9 +1,14 @@
 use regex::Regex;
 
 
-pub fn anchor_id_checks(anchor:&str) -> Regex {
+pub fn has_anchor_id(content: &str, anchor: &str) -> bool {
+    let checks = anchor_id_checks(anchor);
+    checks.is_match(content)
+}
+
+fn anchor_id_checks(anchor:&str) -> Regex {
     Regex::new(
-        &format!(r#" (?i)(id|ID|name|NAME) *= *("|')*{}("|'| |>)+"#, anchor)
+        &format!(r#" (?i)(id|name) *= *("|')*{}("|'| |>)+"#, anchor)
     ).unwrap()
 }
 

--- a/components/utils/src/links.rs
+++ b/components/utils/src/links.rs
@@ -1,0 +1,42 @@
+use regex::Regex;
+
+
+pub fn anchor_id_checks(anchor:&str) -> Regex {
+    Regex::new(
+        &format!(r#" (?i)(id|ID|name|NAME) *= *("|')*{}("|'| |>)+"#, anchor)
+    ).unwrap()
+}
+
+
+#[cfg(test)]
+mod tests{
+    use super::anchor_id_checks;
+
+    fn check(anchor:&str, content:&str) -> bool {
+        anchor_id_checks(anchor).is_match(content)
+    }
+
+    #[test]
+    fn matchers () {
+        let m = |content| {check("fred", content)};
+
+        // Canonical match/non match
+        assert!(m(r#"<a name="fred">"#));
+        assert!(m(r#"<a id="fred">"#));
+        assert!(!m(r#"<a name="george">"#));
+
+        // Whitespace variants
+        assert!(m(r#"<a id ="fred">"#));
+        assert!(m(r#"<a id = "fred">"#));
+        assert!(m(r#"<a id="fred" >"#));
+        assert!(m(r#"<a  id="fred" >"#));
+
+        // Quote variants
+        assert!(m(r#"<a id='fred'>"#));
+        assert!(m(r#"<a id=fred>"#));
+
+        // Case variants
+        assert!(m(r#"<a ID="fred">"#));
+        assert!(m(r#"<a iD="fred">"#));
+    }
+}


### PR DESCRIPTION
As a starter for discussion, not finished yet.


Previously only anchors specified or generated in markdown could be
linked to, without complaint from the link checker. We now use a
simple heuristic check for `name` or `id` attributes.

Addresses #1707

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



