### PR TITLE
add theme's robots.txt to tera with name "robots.txt"

### DIFF
--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -81,6 +81,7 @@ pub fn load_tera(path: &Path, config: &Config) -> Result<Tera> {
             .map_err(|e| Error::chain("Error parsing templates from themes", e))?;
         rewrite_theme_paths(&mut tera_theme, theme);
 
+        // TODO: add tests for theme-provided robots.txt (https://github.com/getzola/zola/pull/1722)
         if theme_path.join("templates").join("robots.txt").exists() {
             tera_theme.add_template_file(
                 theme_path.join("templates").join("robots.txt"),

--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -82,7 +82,10 @@ pub fn load_tera(path: &Path, config: &Config) -> Result<Tera> {
         rewrite_theme_paths(&mut tera_theme, theme);
 
         if theme_path.join("templates").join("robots.txt").exists() {
-            tera_theme.add_template_file(theme_path.join("templates").join("robots.txt"), None)?;
+            tera_theme.add_template_file(
+                theme_path.join("templates").join("robots.txt"),
+                Some("robots.txt"),
+            )?;
         }
         tera.extend(&tera_theme)?;
     }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

This fixes #1721 by registering the theme's robots.txt template under the name "robots.txt" whereas it was previously being registered with the filepath, and later ignored during rendering.

Note: there are no tests for this PR at the moment.  I'm looking into how and where to add some, but it might take me a bit.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)? ([docs](https://www.getzola.org/documentation/templates/robots/) are already correct)



