### PR TITLE
Fix extra syntaxes when highlight_theme = "css"

### DIFF
--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -107,16 +107,17 @@ impl Markdown {
     }
 
     pub fn init_extra_syntaxes_and_highlight_themes(&mut self, path: &Path) -> Result<()> {
-        if self.highlight_theme == "css" {
-            return Ok(());
-        }
-
         let (loaded_extra_syntaxes, loaded_extra_highlight_themes) =
             self.load_extra_syntaxes_and_highlight_themes(path)?;
 
         if let Some(extra_syntax_set) = loaded_extra_syntaxes {
             self.extra_syntax_set = Some(extra_syntax_set);
         }
+
+        if self.highlight_theme == "css" {
+            return Ok(());
+        }
+
         if let Some(extra_theme_set) = loaded_extra_highlight_themes {
             self.extra_theme_set = Arc::new(Some(extra_theme_set));
         }


### PR DESCRIPTION
Currently, init_extra_syntaxtes_and_highlight_themes will supress
loading anything if highlight_theme is "css". This makes sense for the
highlight themes, but will also skip loading any extra syntax
definitions too.

This change defers the theme = css check, so we still load syntaxes in
this case.

Fixes: #1723

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



