### PR TITLE
fix #1731 (asset colocation does not detect files without an extension)

### DIFF
--- a/components/library/src/content/mod.rs
+++ b/components/library/src/content/mod.rs
@@ -48,7 +48,7 @@ pub fn find_related_assets(path: &Path, config: &Config, recursive: bool) -> Vec
                     Some("md") => continue,
                     _ => assets.push(entry_path.to_path_buf()),
                 },
-                None => continue,
+                None => assets.push(entry_path.to_path_buf()),
             }
         }
     }
@@ -82,15 +82,16 @@ mod tests {
         File::create(path.join("example.js")).unwrap();
         File::create(path.join("graph.jpg")).unwrap();
         File::create(path.join("fail.png")).unwrap();
+        File::create(path.join("extensionless")).unwrap();
         create_dir(path.join("subdir")).expect("create subdir temp dir");
         File::create(path.join("subdir").join("index.md")).unwrap();
         File::create(path.join("subdir").join("example.js")).unwrap();
 
         let assets = find_related_assets(path, &Config::default(), true);
-        assert_eq!(assets.len(), 4);
-        assert_eq!(assets.iter().filter(|p| p.extension().unwrap() != "md").count(), 4);
+        assert_eq!(assets.len(), 5);
+        assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or("".as_ref()) != "md").count(), 5);
 
-        for asset in vec!["example.js", "graph.jpg", "fail.png", "subdir/example.js"] {
+        for asset in vec!["example.js", "graph.jpg", "fail.png", "subdir/example.js", "extensionless"] {
             assert!(assets
                 .iter()
                 .find(|p| p.strip_prefix(path).unwrap() == Path::new(asset))
@@ -106,15 +107,15 @@ mod tests {
         File::create(path.join("example.js")).unwrap();
         File::create(path.join("graph.jpg")).unwrap();
         File::create(path.join("fail.png")).unwrap();
+        File::create(path.join("extensionless")).unwrap();
         create_dir(path.join("subdir")).expect("create subdir temp dir");
         File::create(path.join("subdir").join("index.md")).unwrap();
         File::create(path.join("subdir").join("example.js")).unwrap();
-
         let assets = find_related_assets(path, &Config::default(), false);
-        assert_eq!(assets.len(), 3);
-        assert_eq!(assets.iter().filter(|p| p.extension().unwrap() != "md").count(), 3);
+        assert_eq!(assets.len(), 4);
+        assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or("".as_ref()) != "md").count(), 4);
 
-        for asset in vec!["example.js", "graph.jpg", "fail.png"] {
+        for asset in vec!["example.js", "graph.jpg", "fail.png", "extensionless"] {
             assert!(assets
                 .iter()
                 .find(|p| p.strip_prefix(path).unwrap() == Path::new(asset))


### PR DESCRIPTION
Pretty minor change; I just adjusted the match statement so that if Path::extension returned None it would include that asset -- only Some("md") should be ignored. I also added a file without an extension to the test cases for this function. 


* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?



