### PR TITLE
Docs: shortcodes: Mention argument parens are mandatory

### DIFF
--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -69,7 +69,8 @@ There are two kinds of shortcodes:
 - ones that do not take a body, such as the YouTube example above
 - ones that do, such as one that styles a quote
 
-In both cases, the arguments must be named and they will all be passed to the template.
+In both cases, the arguments must be named and they will all be passed to the template. 
+Parentheses are mandatory even if there are no arguments.
 
 Lastly, a shortcode name (and thus the corresponding `.html` file) as well as the argument names
 can only contain numbers, letters and underscores, or in Regex terms `[0-9A-Za-z_]`.
@@ -129,6 +130,29 @@ A quote
 
 The body of the shortcode will be automatically passed down to the rendering context as the `body` variable and needs
 to be on a new line.
+
+### Shortcodes with no arguments
+Note that for both cases that the parentheses for shortcodes are necessary. 
+A shortcode without the parentheses will render as plaintext and no warning will be emitted.
+
+As an example, this is how an `aside` shortcode-with-body with no arguments would be defined in `aside.html`:
+```jinja2
+<aside>
+    {{ body }}
+</aside>
+```
+
+We could use it in our Markdown file like so:
+
+```md
+Readers can refer to the aside for more information.
+
+{%/* aside() */%}
+An aside
+{%/* end */%}
+```
+
+### Content similar to shortcodes
 
 If you want to have some content that looks like a shortcode but not have Zola try to render it,
 you will need to escape it by using `{%/*` and `*/%}` instead of `{%` and `%}`. You won't need to escape


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

I wanted to create an `aside` shortcode to decouple content structuring from its HTML rendering (trying to keep HTML out of my Markdown), and was struggling to figure out why my shortcode wasn't rendering. 

An unrelated search for something else brought me [here](https://zola.discourse.group/t/using-markdown-in-shortcodes-body/241/7), which ended up solving my problem for me. Figured I'd bring it across to the docs for the next poor sap to come by! 😆 
