### PR TITLE
Allow links with empty fragment

### DIFF
--- a/components/rendering/src/markdown.rs
+++ b/components/rendering/src/markdown.rs
@@ -96,6 +96,8 @@ fn fix_link(
         if is_external_link(link) {
             external_links.push(link.to_owned());
             link.to_owned()
+        } else if link == "#" {
+            link.to_string()
         } else if link.starts_with("#") {
             // local anchor without the internal zola path
             if let Some(current_path) = context.current_page_path {


### PR DESCRIPTION
fixes #1754 

This makes links with an empty fragment (ex: `[link to nothing](#)`) pass the link checker.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?  There's no relevant documentation that I could find (nor is any needed, IMO).



