### PR TITLE
fix crash in build.rs when installing from source on linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ fn generate_pe_header() {
     }
     res.set_icon("docs/static/favicon.ico");
     res.set("LegalCopyright", &copyright);
-    res.compile().expect("Failed to compile Windows resources!");
+        res.compile().expect("Failed to compile Windows resources!");
 }
 
 fn main() {
@@ -29,5 +29,7 @@ fn main() {
     {
         return;
     }
-    generate_pe_header();
+    if cfg!(windows){
+        generate_pe_header();
+    }
 }


### PR DESCRIPTION
The current `build.rs` fails to compile "widows resources" when installing from source on Linux, so I added a `!cfg(windows)` to fix that. That's all. 

Sanity check:
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



