### PR TITLE
Discussion: Reenable link rewriting for colocated assets

### DIFF
--- a/components/rendering/tests/markdown.rs
+++ b/components/rendering/tests/markdown.rs
@@ -1018,7 +1018,7 @@ fn can_make_permalinks_with_colocated_assets_for_link() {
         InsertAnchor::None,
     );
     let res = render_content("[an image](image.jpg)", &context).unwrap();
-    assert_eq!(res.body, "<p><a href=\"image.jpg\">an image</a></p>\n");
+    assert_eq!(res.body, "<p><a href=\"https://vincent.is/about/image.jpg\">an image</a></p>\n");
 }
 
 #[test]
@@ -1034,7 +1034,7 @@ fn can_make_permalinks_with_colocated_assets_for_image() {
         InsertAnchor::None,
     );
     let res = render_content("![alt text](image.jpg)", &context).unwrap();
-    assert_eq!(res.body, "<p><img src=\"image.jpg\" alt=\"alt text\" /></p>\n");
+    assert_eq!(res.body, "<p><img src=\"https://vincent.is/about/image.jpg\" alt=\"alt text\" /></p>\n");
 }
 
 #[test]


### PR DESCRIPTION
In #1582 I broke the asset colocation example from the documentation:
https://www.getzola.org/documentation/content/overview/#asset-colocation

The breakage was discovered by irimi1:
https://github.com/getzola/zola/pull/1582#issuecomment-1042300973

When I wrote #1582 I was not aware of the old behavior: links to assets
used to be rewritten to absolute links, so that colocated assets could
be linked to from `pagename/index.md` simply as `asset.xyz` instead of
`pagename/asset.xyz`. I unintentionally changed this, so that currently
you have to write `pagename/asset.xyz`.

Read this commit as a partial revert of #1582. It restores the old
behavior as described above.

Caveats:
1. This will break lots of sites, just like #1582 unintentionally broke
   lots of sites (but no one seemed to notice).
2. The old behavior is restored, including the quirk, that when linking
   from a page `pagename.md` to a section asset `asset.xyz` you need to
   write `../asset.xyz`, even though both files are in the same folder
   on disk. You can make sense of it in the following way: the asset
   belongs to the section so that is one level up from the page.

---

@irimi1

Please discuss this before merging. Some might prefer the current behavior over the old behavior.