### PR TITLE
Allow `load_data` to take a literal

### DIFF
--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -258,7 +258,9 @@ The method returns a map containing `width`, `height` and `format` (the lowercas
 ```
 
 ### `load_data`
-Loads data from a file or URL. Supported file types include *toml*, *json*, *csv*, *bibtex* and *xml* and only supports UTF-8 encoding.
+
+Loads data from a file, URL, or string literal. Supported file types include *toml*, *json*, *csv*, *bibtex* and *xml* and only supports UTF-8 encoding.
+
 Any other file type will be loaded as plain text.
 
 The `path` argument specifies the path to a local data file, according to the [File Searching Logic](@/documentation/templates/overview.md#file-searching-logic).
@@ -273,6 +275,15 @@ Alternatively, the `url` argument specifies the location of a remote URL to load
 {% set data = load_data(url="https://en.wikipedia.org/wiki/Commune_of_Paris") %}
 ```
 
+Alternatively, the `literal` argument specifies an object literal. Note: if the `format` argument is not specified, then plain text will be what is assumed.
+
+```jinja2
+{% set data = load_data(literal='{"name": "bob"}', format="json") %}
+{{ data["name"] }}
+```
+
+*Note: the `required` parameter has no effect when used in combination with the `literal` argument.*
+
 The optional `required` boolean argument can be set to false so that missing data (HTTP error or local file not found) does not produce an error, but returns a null value instead. However, permission issues with a local file and invalid data that could not be parsed to the requested data format will still produce an error even with `required=false`.
 
 The snippet below outputs the HTML from a Wikipedia page, or "No data found" if the page was not reachable, or did not return a successful HTTP code:
@@ -282,8 +293,7 @@ The snippet below outputs the HTML from a Wikipedia page, or "No data found" if 
 {% if data %}{{ data | safe }}{% else %}No data found{% endif %}
 ```
 
-The optional `format` argument allows you to specify and override which data type is contained
-within the specified file or URL. Valid entries are `toml`, `json`, `csv`, `bibtex`, `xml` or `plain`. If the `format` argument isn't specified, then the path extension is used.
+The optional `format` argument allows you to specify and override which data type is contained within the specified file or URL. Valid entries are `toml`, `json`, `csv`, `bibtex`, `xml` or `plain`. If the `format` argument isn't specified, then the path extension is used. In the case of a literal, `plain` is assumed if `format` is unspecified. 
 
 
 ```jinja2


### PR DESCRIPTION
Relevant discussion: https://zola.discourse.group/t/allow-load-data-to-take-a-literal/1165

I posted on the Zola discourse site but I don't think anyone responded. In any case, I've being using `POST` + an "echo server" to essentially do the same thing, which is kind of less than ideal. The change was relatively easy to make, so I just did it. 

Basically, I just think this is relatively harmless and would make Zola a tiny bit more flexible and easy to use. It could be something as simple as prototyping and not wanting to have to load from an actual file, or there could be something very complicated that you're doing perhaps, for example maybe you need to deviate from something that's stored in a file, like it's beyond your control, but you still need it in object format. 

In any case, I ran into some circumstances that weren't pleasant to deal with without it, and my **best** solution was the echo server I mentioned above, which isn't super fun to use.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



