### PR TITLE
documentation: rename extra_highlight_themes to extra_syntaxes_and_themes

### DIFF
--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -385,5 +385,5 @@ If your site source is laid out as follows:
     └── ...
 ```
 
-you would set your `extra_highlight_themes` to `["highlight_themes", "highlight_themes/MyGroovyTheme"]` to load `theme1.tmTheme` and `theme2.tmTheme`.
+you would set your `extra_syntaxes_and_themes` to `["highlight_themes", "highlight_themes/MyGroovyTheme"]` to load `theme1.tmTheme` and `theme2.tmTheme`.
 Then choose one of them to use, say theme1, by setting `highlight_theme = theme1`.


### PR DESCRIPTION
extra_highlight_themes does not exist, this is a typo.
The config option that exists and should be used is called extra_syntaxes_and_themes

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



