### PR TITLE
apply skip_prefixes before parsing external link domain

### DIFF
--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -24,6 +24,7 @@ anchors = "on"
 [link_checker]
 skip_prefixes = [
     "http://[2001:db8::]/",
+    "http://invaliddomain",
 ]
 
 skip_anchor_prefixes = [

--- a/test_site/content/posts/skip_prefixes.md
+++ b/test_site/content/posts/skip_prefixes.md
@@ -1,0 +1,4 @@
++++
++++
+
+[test skip 1](http://invaliddomain</)


### PR DESCRIPTION
From [Handling improperly formed external links](https://zola.discourse.group/t/handling-improperly-formed-external-links/1268) on the forum.

This PR applies `skip_prefixes` before attempting to parse the URL.

Sanity check:
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?


