### PR TITLE
Create pull request/add yaml to load data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ also specify classes on headers now
 - Make `ignored_content` work with nested paths and directories
 - `zola serve/build` can now run from anywhere in a zola directory
 - Add XML support to `load_data`
+- Add YAML support to `load_data`
 - `skip_prefixes` is now checked before parsing external link URLs
 - Add `render` attribute to taxonomies configuration in `config.toml`, for when you don't want to render
 any pages related to that taxonomy

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -77,7 +77,7 @@ impl OutputFormat {
             OutputFormat::Bibtex => "application/x-bibtex",
             OutputFormat::Xml => "text/xml",
             OutputFormat::Plain => "text/plain",
-            OutputFormat::Yaml => "application/yaml",
+            OutputFormat::Yaml => "application/x-yaml",
         })
     }
 }

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -1,4 +1,3 @@
-use libs::serde_yaml;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -13,7 +12,7 @@ use libs::tera::{
     from_value, to_value, Error, Error as TeraError, Function as TeraFn, Map, Result, Value,
 };
 use libs::url::Url;
-use libs::{nom_bibtex, serde_json, toml};
+use libs::{nom_bibtex, serde_json, serde_yaml, toml};
 use utils::de::fix_toml_dates;
 use utils::fs::{get_file_time, read_file};
 
@@ -212,7 +211,7 @@ fn add_headers_from_args(header_args: Option<Vec<String>>) -> Result<HeaderMap> 
 }
 
 /// A Tera function to load data from a file or from a URL
-/// Currently the supported formats are json, toml, csv, bibtex and plain text
+/// Currently the supported formats are json, toml, csv, yaml, bibtex and plain text
 #[derive(Debug)]
 pub struct LoadData {
     base_path: PathBuf,

--- a/components/utils/test-files/test.yaml
+++ b/components/utils/test-files/test.yaml
@@ -1,0 +1,9 @@
+---
+  key: "value"
+  array: 
+    - 1
+    - 2
+    - 3
+  subpackage: 
+    subkey: 5
+

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -259,7 +259,8 @@ The method returns a map containing `width`, `height` and `format` (the lowercas
 
 ### `load_data`
 
-Loads data from a file, URL, or string literal. Supported file types include *toml*, *json*, *csv*, *bibtex* and *xml* and only supports UTF-8 encoding.
+Loads data from a file, URL, or string literal. Supported file types include *toml*, *json*, *csv*, *bibtex*, *yaml* 
+and *xml* and only supports UTF-8 encoding.
 
 Any other file type will be loaded as plain text.
 
@@ -293,7 +294,9 @@ The snippet below outputs the HTML from a Wikipedia page, or "No data found" if 
 {% if data %}{{ data | safe }}{% else %}No data found{% endif %}
 ```
 
-The optional `format` argument allows you to specify and override which data type is contained within the specified file or URL. Valid entries are `toml`, `json`, `csv`, `bibtex`, `xml` or `plain`. If the `format` argument isn't specified, then the path extension is used. In the case of a literal, `plain` is assumed if `format` is unspecified. 
+The optional `format` argument allows you to specify and override which data type is contained within the specified file or URL.
+Valid entries are `toml`, `json`, `csv`, `bibtex`, `yaml`, `xml` or `plain`. If the `format` argument isn't specified, then the 
+path extension is used. In the case of a literal, `plain` is assumed if `format` is unspecified.
 
 
 ```jinja2
@@ -302,7 +305,7 @@ The optional `format` argument allows you to specify and override which data typ
 
 Use the `plain` format for when your file has a supported extension but you want to load it as plain text.
 
-For *toml*, *json* and *xml*, the data is loaded into a structure matching the original data file;
+For *toml*, *json*, *yaml* and *xml*, the data is loaded into a structure matching the original data file;
 however, for *csv* there is no native notion of such a structure. Instead, the data is separated
 into a data structure containing *headers* and *records*. See the example below to see
 how this works.


### PR DESCRIPTION
A fairly trivial addition; JSON and YAML are handled so similarly that this was a matter of copying the JSON-relevant handlers and editing the copies to handle YAML as well.  The test file was literally generated with 'json2yaml'.

Sanity check:

- I have discussed this with @Keats. He said, "[That should be fine](https://zola.discourse.group/t/add-yaml-to-load-data-supported-types/1292)."
- I have checked that there are no other pull requests matching this issue.
- The PR is pointed to the 'next' branch.
- The documentation has been updated to reflect the change.
- The CHANGELOG has been update to reflect the change.
- There is a unit test to exercise the feature added by this change.
