### PR TITLE
Enables setting base-url to / for relative URLs in serve mode

### DIFF
--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -74,7 +74,7 @@ You can also specify different addresses for the interface and base_url using `-
 
 > By default, devices from the local network **won't** be able to access the served pages. This may be of importance when you want to test page interaction and layout on your mobile device or tablet. If you set the interface to `0.0.0.0` however, devices from your local network will be able to access the served pages by requesting the local ip-address of the machine serving the pages and port used.
 >
-> In order to have everything work correctly, you might also have to alter the `base-url` flag to your local ip.
+> In order to have everything work correctly, you might also have to alter the `base-url` flag to your local ip or set it to `/` to use server-base relative paths.
 
 Use the `--open` flag to automatically open the locally hosted instance in your
 web browser.
@@ -87,6 +87,7 @@ $ zola serve --port 2000
 $ zola serve --interface 0.0.0.0
 $ zola serve --interface 0.0.0.0 --port 2000
 $ zola serve --interface 0.0.0.0 --base-url 127.0.0.1
+$ zola serve --interface 0.0.0.0 --base-url /
 $ zola serve --interface 0.0.0.0 --port 2000 --output-dir www/public
 $ zola serve --open
 ```

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -246,14 +246,18 @@ fn create_new_site(
     SITE_CONTENT.write().unwrap().clear();
 
     let mut site = Site::new(root_dir, config_file)?;
-
-    let base_address = format!("{}:{}", base_url, interface_port);
     let address = format!("{}:{}", interface, interface_port);
 
-    let base_url = if site.config.base_url.ends_with('/') {
-        format!("http://{}/", base_address)
+    let base_url = if base_url == "/" {
+        String::from("/")
     } else {
-        format!("http://{}", base_address)
+        let base_address = format!("{}:{}", base_url, interface_port);
+
+        if site.config.base_url.ends_with('/') {
+            format!("http://{}/", base_address)
+        } else {
+            format!("http://{}", base_address)
+        }
     };
 
     site.enable_serve_mode();


### PR DESCRIPTION
Having to change the base URL to whatever ngrok URL was provisioned for
me was frustrating. This patch enables setting it to `/`, which will
then make the `get_url()` function simply return `/`.

Fixes #1568 for at least `zola serve` in my local testing.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [X] Have you created/updated the relevant documentation page(s)?