### PR TITLE
Add `rel="alternate"` to Atom post links

### DIFF
--- a/components/templates/src/builtins/atom.xml
+++ b/components/templates/src/builtins/atom.xml
@@ -24,7 +24,7 @@
 		<title>{{ page.title }}</title>
 		<published>{{ page.date | date(format="%+") }}</published>
 		<updated>{{ page.updated | default(value=page.date) | date(format="%+") }}</updated>
-		<link href="{{ page.permalink | safe }}" type="text/html"/>
+		<link rel="alternate" href="{{ page.permalink | safe }}" type="text/html"/>
 		<id>{{ page.permalink | safe }}</id>
 		<content type="html">{{ page.content }}</content>
 	</entry>


### PR DESCRIPTION
This improves compatibility with some readers, e.g. Miniflux, which otherwise don't detect these.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



