### PR TITLE
Add `charset=utf-8` when serving site HTML files

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -158,12 +158,9 @@ fn livereload_js() -> Response<Body> {
 
 fn in_memory_content(path: &RelativePathBuf, content: &str) -> Response<Body> {
     let content_type = match path.extension() {
-        Some(ext) => match ext {
-            "xml" => "text/xml",
-            "json" => "application/json",
-            _ => "text/html",
-        },
-        None => "text/html",
+        Some("xml") => "text/xml",
+        Some("json") => "application/json",
+        _ => "text/html; charset=utf-8",
     };
     Response::builder()
         .header(header::CONTENT_TYPE, content_type)


### PR DESCRIPTION
This is useful when the site uses emoji or other non-Latin characters, which can get jumbled by the browser. We're not setting the charset for non-Zola-generated pages, but that's probably less important.

![image](https://user-images.githubusercontent.com/308347/170065749-23e55be0-297d-4c2d-ac46-7cf790b5c6cf.png)

![image](https://user-images.githubusercontent.com/308347/170065771-23d66715-e7ee-4357-a278-c26fef7fd3d0.png)

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?
