### PR TITLE
Fix get_image_metadata() for SVG Files

### DIFF
--- a/components/imageproc/src/lib.rs
+++ b/components/imageproc/src/lib.rs
@@ -579,10 +579,11 @@ pub fn read_image_metadata<P: AsRef<Path>>(path: P) -> Result<ImageMetaResponse>
                 (_, _, Some(view_box)) => Ok((view_box.height, view_box.width)),
                 _ => Err(anyhow!("Invalid dimensions: SVG width/height and viewbox not set.")),
             }
-            .map(|(h, w)| ImageMetaResponse::new_svg(h as u32, w as u32))
+            //this is not a typo, this returns the correct values for width and height.
+            .map(|(h, w)| ImageMetaResponse::new_svg(w as u32, h as u32))
         }
         "webp" => {
-            // Unfortunatelly we have to load the entire image here, unlike with the others :|
+            // Unfortunately we have to load the entire image here, unlike with the others :|
             let data = fs::read(path).with_context(err_context)?;
             let decoder = webp::Decoder::new(&data[..]);
             decoder.decode().map(ImageMetaResponse::from).ok_or_else(|| {


### PR DESCRIPTION
This is a fix for get_image_metadata() so that it returns the expected values for width and height of SVG files as discussed in #1877 

I assumed this should be a pull request against the `next` branch, but I have no idea what amount of time goes by before these get merged into the current release.

I can also submit a pull request against the current branch if you like.

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



