### PR TITLE
Make robots.txt compliant with the RFC

### DIFF
--- a/components/templates/src/builtins/robots.txt
+++ b/components/templates/src/builtins/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
+Disallow:
 Allow: /
 Sitemap: {{ get_url(path="sitemap.xml") }}

--- a/docs/content/documentation/templates/robots.md
+++ b/docs/content/documentation/templates/robots.md
@@ -11,6 +11,7 @@ and the default is what most sites want:
 
 ```jinja2
 User-agent: *
+Disallow:
 Allow: /
 Sitemap: {{/* get_url(path="sitemap.xml") */}}
 ```

--- a/test_site/templates/robots.txt
+++ b/test_site/templates/robots.txt
@@ -1,3 +1,4 @@
 User-agent: zola
+Disallow:
 Allow: /
 Sitemap: {{config.base_url}}/sitemap.xml


### PR DESCRIPTION
The [RFC](http://www.robotstxt.org/orig.html) mentions only `Disallow` directive, so it must appear in the file.

`Allow` is an ad hoc agreement between search engines that no all of them follow.

---

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [X] Are you doing the PR on the `next` branch?
* [X] Have you created/updated the relevant documentation page(s)?



