### PR TITLE
Fix incorrect documentation for syntax directory

### DIFF
--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -93,8 +93,8 @@ build_search_index = false
 # When set to "true", all code blocks are highlighted.
 highlight_code = false
 
-# A list of directories used to search for additional `.sublime-syntax` files.
-extra_syntaxes = []
+# A list of directories used to search for additional `.sublime-syntax` and `.tmTheme` files.
+extra_syntaxes_and_themes = []
 
 # The theme to use for code highlighting.
 # See below for list of allowed values.


### PR DESCRIPTION
Currently the Configuration docs says to load syntax files into config.toml `[markdown] extra_syntaxes`. However, ever since 23064f57c8d45534bdf4d757f4e8263415f35e3d (released in Zola v0.15.0), the `extra_syntaxes` property was replaced by `extra_syntaxes_and_themes`, and used as both syntax and color theme search paths. Following the docs and trying to set the `extra_syntaxes` property does nothing, and #1723 ran into this issue.

Change the docs to consistently reference `extra_syntaxes_and_themes`.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

Should this be merged into next or master? If merged directly into master (to edit live docs), you need to cherry-pick #1606 as well, since that PR partly fixed the docs and this fixes the remaining errors.