### PR TITLE
fix windows EOL in markdown files

### DIFF
--- a/components/markdown/tests/codeblocks.rs
+++ b/components/markdown/tests/codeblocks.rs
@@ -240,6 +240,16 @@ bar
 }
 
 #[test]
+fn can_add_line_numbers_windows_eol() {
+    let body = render_codeblock(
+        "```linenos\r\nfoo\r\nbar\r\n```\r\n",
+        true,
+    );
+    insta::assert_snapshot!(body);
+} 
+
+
+#[test]
 fn can_add_line_numbers_with_lineno_start() {
     let body = render_codeblock(
         r#"

--- a/components/markdown/tests/snapshots/codeblocks__can_add_line_numbers_windows_eol.snap
+++ b/components/markdown/tests/snapshots/codeblocks__can_add_line_numbers_windows_eol.snap
@@ -1,0 +1,9 @@
+---
+source: components/markdown/tests/codeblocks.rs
+assertion_line: 248
+expression: body
+---
+<pre data-linenos style="background-color:#2b303b;color:#c0c5ce;"><code><table><tbody><tr><td>1</td><td><span>foo
+</span></td></tr><tr><td>2</td><td><span>bar
+</span></td></tr></tbody></table></code></pre>
+


### PR DESCRIPTION
zola v0.15.3
os windows

if  &#96;&#96;&#96;linenos is enable in codeblock and EOL is windows style (0xD,0x0A) vs unix style (0x0A), 
code highlighting failed.

![image](https://user-images.githubusercontent.com/7641990/175340703-59c46f71-5a93-4f4f-b63a-03b707efce77.png)

Text are borrowed, to sanitize the CR+LF to LF, the strings are split in parts. 
To reconstruct the string, parts must be concatenated.
cf https://github.com/raphlinus/pulldown-cmark/issues/507


check
```
> cargo test  --test=codeblocks --package=markdown
running 21 tests
test can_add_line_numbers_windows_eol ... ok
test can_add_line_numbers_with_lineno_start ... ok
test can_add_line_numbers_with_highlight ... ok
test can_add_line_numbers ... ok
test can_highlight_all_lines ... ok
test can_hide_lines ... ok
test can_highlight_at_end ... ok
test can_highlight_line_range ... ok
test can_highlight_out_of_bounds ... ok
test can_highlight_mix_line_ranges ... ok
test can_highlight_ranges_overlap ... ok
test can_highlight_reversed_range ... ok
test can_highlight_single_line ... ok
test can_highlight_single_line_range ... ok
test can_highlight_unknown_lang ... ok
test can_highlight_weird_fence_tokens ... ok
test can_render_multiple_shortcodes_in_codeblock ... ok
test can_highlight_zero_start_same_as_one ... ok
test does_nothing_with_highlighting_disabled ... ok
test can_render_shortcode_in_codeblock ... ok
test can_render_completely_mixed_codeblock ... ok

test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.57s
```
