### PR TITLE
Add sorting by path

### DIFF
--- a/components/content/src/sorting.rs
+++ b/components/content/src/sorting.rs
@@ -202,6 +202,16 @@ mod tests {
         assert_eq!(pages[1], page1.file.path);
         assert_eq!(pages[2], page2.file.path);
         assert_eq!(ignored_pages.len(), 0);
+
+        // 10 should come after 2
+        let page1 = create_page_with_title("1");
+        let page2 = create_page_with_title("10");
+        let page3 = create_page_with_title("2");
+        let (pages, ignored_pages) = sort_pages(&[&page1, &page2, &page3], SortBy::Path);
+        assert_eq!(pages[0], page1.file.path);
+        assert_eq!(pages[1], page3.file.path);
+        assert_eq!(pages[2], page2.file.path);
+        assert_eq!(ignored_pages.len(), 0);
     }
 
     #[test]

--- a/components/content/src/types.rs
+++ b/components/content/src/types.rs
@@ -15,6 +15,8 @@ pub enum SortBy {
     TitleBytes,
     /// Lower weight comes first
     Weight,
+    /// Sort by file system path
+    Path,
     /// No sorting
     None,
 }

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -187,10 +187,15 @@ of the Swedish alphabet, åäö, for example would be considered by the natural
 sort as aao. In that case the standard byte-order sort may be more suitable.
 
 ### `weight`
-This will be sort all pages by their `weight` field, from lightest weight
-(at the top of the list) to heaviest (at the bottom of the list).  Each
+This will sort all pages by their `weight` field, from the lightest weight
+(at the top of the list) to the heaviest (at the bottom of the list). Each
 page gets `page.lower` and `page.higher` variables that contain the
 pages with lighter and heavier weights, respectively.
+
+### `path`
+This will sort pages or sections by their file system path. First, it tries to
+sort in natural lexical order, but if a path contains non-lexical bytes, it'll
+fall back to a simple byte-to-byte comparison.
 
 ### Reversed sorting
 When iterating through pages, you may wish to use the Tera `reverse` filter,


### PR DESCRIPTION
This adds sorting by file system path. Very useful when you name your pages like `00_post.md`, `01_post.md`.

---

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [X] Are you doing the PR on the `next` branch?
* [X] Have you created/updated the relevant documentation page(s)?



