### PR TITLE
Minify embedded css and js with additional lib flags

### DIFF
--- a/components/site/src/minify.rs
+++ b/components/site/src/minify.rs
@@ -6,6 +6,8 @@ use libs::minify_html::{minify, Cfg};
 pub fn html(html: String) -> Result<String> {
     let mut cfg = Cfg::spec_compliant();
     cfg.keep_html_and_head_opening_tags = true;
+    cfg.minify_css = true;
+    cfg.minify_js = true;
 
     let minified = minify(html.as_bytes(), &cfg);
     match std::str::from_utf8(&minified) {
@@ -83,4 +85,61 @@ mod tests {
         let res = html(input.to_owned()).unwrap();
         assert_eq!(res, expected);
     }
+
+    // https://github.com/getzola/zola/issues/1765
+    #[test]
+    fn can_minify_css() {
+        let input = r#"
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    p {
+      color: white;
+      margin-left: 10000px;
+    }
+  </style>
+</head>
+<body>
+
+
+    <p>Example blog post</p>
+
+  FOO BAR
+</body>
+</html>
+"#;
+        let expected = r#"<!doctype html><html><head><meta charset=utf-8><style>p{color:white;margin-left:10000px}</style><body><p>Example blog post</p> FOO BAR"#;
+        let res = html(input.to_owned()).unwrap();
+        assert_eq!(res, expected);
+    }
+
+    // https://github.com/getzola/zola/issues/1765
+    #[test]
+    fn can_minify_js() {
+        let input = r#"
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script>
+    alert("Hello World!");
+    console.log("Some information: %o", information);
+  </script>
+</head>
+<body>
+
+
+    <p>Example blog post</p>
+
+  FOO BAR
+</body>
+</html>
+"#;
+        let expected = r#"<!doctype html><html><head><meta charset=utf-8><script>alert("Hello World!");console.log("Some information: %o",information)</script><body><p>Example blog post</p> FOO BAR"#;
+        let res = html(input.to_owned()).unwrap();
+        assert_eq!(res, expected);
+    }
 }
+


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?

^ I don't believe any documentation changes are required with the existing documentation mentioning that "the generated HTML files are minified."

## Notes
A small fix for [#1765](https://github.com/getzola/zola/issues/1765). Just two extra config options so that the already included minify-html library also minifies CSS and JS.