### PR TITLE
Add sorting by slug

### DIFF
--- a/components/content/src/types.rs
+++ b/components/content/src/types.rs
@@ -15,6 +15,8 @@ pub enum SortBy {
     TitleBytes,
     /// Lower weight comes first
     Weight,
+    /// Sort by slug
+    Slug,
     /// No sorting
     None,
 }

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -187,10 +187,13 @@ of the Swedish alphabet, åäö, for example would be considered by the natural
 sort as aao. In that case the standard byte-order sort may be more suitable.
 
 ### `weight`
-This will be sort all pages by their `weight` field, from lightest weight
-(at the top of the list) to heaviest (at the bottom of the list).  Each
+This will sort all pages by their `weight` field, from the lightest weight
+(at the top of the list) to the heaviest (at the bottom of the list). Each
 page gets `page.lower` and `page.higher` variables that contain the
 pages with lighter and heavier weights, respectively.
+
+### `slug`
+This will sort pages or sections by their slug in natural lexical order.
 
 ### Reversed sorting
 When iterating through pages, you may wish to use the Tera `reverse` filter,


### PR DESCRIPTION
In https://github.com/getzola/zola/pull/1917 we discussed that sorting by `slug` probably makes more sense than by `filepath`, so here is the implementation.

---

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [X] Are you doing the PR on the `next` branch?
* [X] Have you created/updated the relevant documentation page(s)?