### PR TITLE
Fix metainfo version for 0.16.0 release

### DIFF
--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -55,6 +55,9 @@
     <release version="0.16.0" date="2022-07-16">
       <url>https://github.com/getzola/zola/releases/tag/v0.16.0</url>
     </release>
+    <release version="0.15.3" date="2022-01-22">
+      <url>https://github.com/getzola/zola/releases/tag/v0.15.3</url>
+    </release>
   </releases>
 
 </component>

--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -52,8 +52,8 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="0.15.3" date="2022-01-22">
-      <url>https://github.com/getzola/zola/releases/tag/v0.15.3</url>
+    <release version="0.16.0" date="2022-07-16">
+      <url>https://github.com/getzola/zola/releases/tag/v0.16.0</url>
     </release>
   </releases>
 


### PR DESCRIPTION
The version number in the metainfo wasn't updated for the v0.16.0 release.