### PR TITLE
remove string manipulation of paths

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -162,8 +162,6 @@ impl Site {
     /// Reads all .md files in the `content` directory and create pages/sections
     /// out of them
     pub fn load(&mut self) -> Result<()> {
-        let base_path = self.base_path.to_string_lossy().replace('\\', "/");
-
         self.library = Arc::new(RwLock::new(Library::new(&self.config)));
         let mut pages_insert_anchors = HashMap::new();
 
@@ -171,7 +169,7 @@ impl Site {
         // which we can only decide to use after we've deserialised the section
         // so it's kinda necessecary
         let mut dir_walker =
-            WalkDir::new(format!("{}/{}", base_path, "content/")).follow_links(true).into_iter();
+            WalkDir::new(self.base_path.join("content")).follow_links(true).into_iter();
         let mut allowed_index_filenames: Vec<_> = self
             .config
             .other_languages()

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -54,6 +54,8 @@ relative_path: String;
 lang: String;
 // Information about all the available languages for that content, including the current page
 translations: Array<TranslatedContent>;
+// All the pages/sections linking this page: their permalink and a title if there is one
+backlinks: Array<{permalink: String, title: String?}>;
 ```
 
 ## Section variables
@@ -100,6 +102,8 @@ relative_path: String;
 lang: String;
 // Information about all the available languages for that content
 translations: Array<TranslatedContent>;
+// All the pages/sections linking this page: their permalink and a title if there is one
+backlinks: Array<{permalink: String, title: String?}>;
 ```
 
 ## Table of contents


### PR DESCRIPTION
The string manipulation here breaks canonical Windows file paths, so use the path API directly instead.

Fixes #1939

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [ ] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



