### PR TITLE
Update Sourcehut deployment instructions

### DIFF
--- a/docs/content/documentation/deployment/sourcehut.md
+++ b/docs/content/documentation/deployment/sourcehut.md
@@ -5,16 +5,17 @@ weight = 15
 
 Deploying your static Zola website on [Sourcehut Pages][srht] is very simple.
 
-You only need to create a manifest `.build.yml` file in your root folder of your Zola project and push your changes to the Sourcehut git/hg repository. To create your `.build.yml` you can start by [a template][srht-tpl].
-
-Example:
-
+You need to create a `.build.yml` manifest file in the root folder of your Zola project and push your changes to the
+Sourcehut git/hg repository.
+To create your `.build.yml` file you can start with [a template][srht-tpl] or use the following example:
 ``` yaml
 image: alpine/edge
-packages: [ zola ]
+packages:
+  - hut
+  - zola
 oauth: pages.sr.ht/PAGES:RW
 environment:
-  site: www.example.org
+  site: your_username.srht.site
 sources:
   - https://git.sr.ht/~your_username/my-website
 tasks:
@@ -25,15 +26,18 @@ tasks:
       cd my-website
       tar -C public -cvz . > ../site.tar.gz
   - upload: |
-      acurl -f https://pages.sr.ht/publish/$site -Fcontent=@site.tar.gz
+      hut pages publish -d $site site.tar.gz
 ```
 
-This manifest will checkout your code from `sources`, build and upload the generated static files to `site` using a wrapper script around `curl` (called `acurl`, already available in all Sourcehut builds).
+This manifest will clone your source code, build the website and upload the generated static files to the domain
+you specified in `site`.
+For publishing the website, the build manifest uses `hut`, a commandline tool which takes care of automatically
+generating authentication tokens, so there is nothing else you need to do.
 
-From this template you need to customize the variable `site` with the domain that will host your website and `sources` to point to your Sourcehut git/hg public URL (in this example `my-website` is the name of the repository).
+From this template you need to customize the variable `site` with the domain that will host your website and
+`sources` to point to your Sourcehut git/hg public URL (in this example `my-website` is the name of the repository).
 
 Then commit and push your changes:
-
 ``` sh
 $ git push
 Enumerating objects: 5, done.
@@ -44,9 +48,13 @@ To git.sr.ht:~your_username/www
    fbe9afa..59ae556  master -> master
 ```
 
-The build job will be automatically triggered. Notice that Sourcehut returns a direct link to the build page.
+The build job will be automatically triggered.
+Notice that Sourcehut returns a direct link to the build page, where you can check the progress and success status.
 
-By default you can use a subdomain of Sourcehut Pages to host your static website (e.g. "your_username.srht.site"). If you want to use a custom domain (e.g. "blog.mydomain.org"), you will need to configure a DNS record to point to the Sourcehut server. Instructions to do this are detailed on [Sourcehut][srht-custom-domain].
+By default you can use a subdomain of Sourcehut Pages to host your static website - `your_username.srht.site`.
+If you want to use a custom domain (e.g. "blog.mydomain.org"), you will need to configure a DNS record to point to
+the Sourcehut server.
+Instructions on how to do this are available on [Sourcehut][srht-custom-domain].
 
 [srht]: https://srht.site
 [srht-tpl]: https://git.sr.ht/~sircmpwn/pages.sr.ht-examples


### PR DESCRIPTION
This commit updates the example code for deploying Zola on Sourcehut and also updates the wording of the tutorial a bit.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
