### PR TITLE
Strip binary artifact when building for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = ["components/*"]
 [profile.release]
 lto = true
 codegen-units = 1
+strip = true
 
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
               rustup_toolchain: stable
             linux-pinned:
               imageName: 'ubuntu-20.04'
-              rustup_toolchain: 1.57.0
+              rustup_toolchain: 1.59.0
         pool:
           vmImage: $(imageName)
         steps:


### PR DESCRIPTION
As discussed on Discourse ([thread](https://zola.discourse.group/t/stripping-binaries-in-releases/1396)).

thanks!



