### PR TITLE
Add slugify.paths_keep_dates option. Update docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.17.0 (unreleased)
+
 ## 0.16.1 (2022-08-14)
 
 - Fix many Windows bugs

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -658,8 +658,28 @@ anchors = "off"
 
         let config = Config::parse(config_str).unwrap();
         assert_eq!(config.slugify.paths, SlugifyStrategy::On);
+        assert_eq!(config.slugify.paths_keep_dates, false);
         assert_eq!(config.slugify.taxonomies, SlugifyStrategy::Safe);
         assert_eq!(config.slugify.anchors, SlugifyStrategy::Off);
+    }
+
+    #[test]
+    fn slugify_paths_keep_dates() {
+        let config_str = r#"
+title = "My site"
+base_url = "example.com"
+
+[slugify]
+paths_keep_dates = true
+taxonomies = "off"
+anchors = "safe"
+        "#;
+
+        let config = Config::parse(config_str).unwrap();
+        assert_eq!(config.slugify.paths, SlugifyStrategy::On);
+        assert_eq!(config.slugify.paths_keep_dates, true);
+        assert_eq!(config.slugify.taxonomies, SlugifyStrategy::Off);
+        assert_eq!(config.slugify.anchors, SlugifyStrategy::Safe);
     }
 
     #[test]

--- a/components/config/src/config/slugify.rs
+++ b/components/config/src/config/slugify.rs
@@ -6,6 +6,7 @@ use utils::slugs::SlugifyStrategy;
 #[serde(default)]
 pub struct Slugify {
     pub paths: SlugifyStrategy,
+    pub paths_keep_dates: bool,
     pub taxonomies: SlugifyStrategy,
     pub anchors: SlugifyStrategy,
 }

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -126,7 +126,9 @@ impl Page {
         };
 
         if let Some(ref caps) = RFC3339_DATE.captures(&file_path_for_slug) {
-            slug_from_dated_filename = Some(caps.name("slug").unwrap().as_str().to_string());
+            if !config.slugify.paths_keep_dates {
+                slug_from_dated_filename = Some(caps.name("slug").unwrap().as_str().to_string());
+            }
             if page.meta.date.is_none() {
                 page.meta.date = Some(caps.name("datetime").unwrap().as_str().to_string());
                 page.meta.date_to_datetime();

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -16,11 +16,13 @@ create a **page** at `[base_url]/about`).
 If the file is given any name _other_ than `index.md` or `_index.md`, then it will
 create a page with that name (without the `.md`). For example, naming a file in the root of your
 content directory `about.md` would create a page at `[base_url]/about`.
+
 Another exception to this rule is that a filename starting with a datetime (YYYY-mm-dd or [an RFC3339 datetime](https://www.ietf.org/rfc/rfc3339.txt)) followed by
 an underscore (`_`) or a dash (`-`) will use that date as the page date, unless already set
 in the front matter. The page name will be anything after `_`/`-`, so the file `2018-10-10-hello-world.md` will
 be available at `[base_url]/hello-world`. Note that the full RFC3339 datetime contains colons, which is not a valid
 character in a filename on Windows.
+This behavior can be disabled by setting `slugify.paths_keep_date` to `true` (the default is `false`). Note that a `_` separating the date would be slugified into a `-` with the default value for `slugify.paths` of `"on"`.
 
 As you can see, creating an `about.md` file is equivalent to creating an
 `about/index.md` file. The only difference between the two methods is that creating

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -142,6 +142,10 @@ external_level = "error"
 paths = "on"
 taxonomies = "on"
 anchors = "on"
+# Whether to remove date prefixes for page path slugs.
+# For example, content/posts/2016-10-08_a-post-with-dates.md => posts/a-post-with-dates
+# When true, content/posts/2016-10-08_a-post-with-dates.md => posts/2016-10-08-a-post-with-dates
+paths_keep_dates = false
 
 [search]
 # Whether to include the title of the page/section in the index

--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -52,6 +52,9 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.16.1" date="2022-08-14">
+      <url>https://github.com/getzola/zola/releases/tag/v0.16.1</url>
+    </release>
     <release version="0.16.0" date="2022-07-16">
       <url>https://github.com/getzola/zola/releases/tag/v0.16.0</url>
     </release>


### PR DESCRIPTION
Manual testing:

Existing test_site/config.toml

http://127.0.0.1:1111/posts/a-post-with-dates

====
```
--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -18,6 +18,7 @@ extra_syntaxes_and_themes = ["syntaxes", "highlight_themes"]

 [slugify]
 paths = "on"
+paths_keep_dates = true
 taxonomies = "on"
 anchors = "on"
```
http://127.0.0.1:1111/posts/2016-10-08-a-post-with-dates

====
```
--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -17,7 +17,8 @@ highlight_theme = "custom_gruvbox"
 extra_syntaxes_and_themes = ["syntaxes", "highlight_themes"]

 [slugify]
-paths = "on"
+paths = "off"
+paths_keep_dates = true
 taxonomies = "on"
 anchors = "on"
```
http://127.0.0.1:1111/posts/2016-10-08_a-post-with-dates

====
```
--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -17,7 +17,8 @@ highlight_theme = "custom_gruvbox"
 extra_syntaxes_and_themes = ["syntaxes", "highlight_themes"]

 [slugify]
-paths = "on"
+paths = "safe"
+paths_keep_dates = true
 taxonomies = "on"
 anchors = "on"
```
http://127.0.0.1:1111/posts/2016-10-08_a-post-with-dates

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

* [x] Are you doing the PR on the `next` branch?

* [x] Have you created/updated the relevant documentation page(s)?

Proposal thread:
https://zola.discourse.group/t/proposal-config-option-to-keep-dates-in-slugs/1405


