### PR TITLE
parse also *.yml file suffix as YAML; closes #1958

### DIFF
--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -61,7 +61,7 @@ impl FromStr for OutputFormat {
             "bibtex" => Ok(OutputFormat::Bibtex),
             "xml" => Ok(OutputFormat::Xml),
             "plain" => Ok(OutputFormat::Plain),
-            "yaml" => Ok(OutputFormat::Yaml),
+            "yaml" | "yml" => Ok(OutputFormat::Yaml),
             format => Err(format!("Unknown output format {}", format).into()),
         }
     }

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -259,7 +259,7 @@ The method returns a map containing `width`, `height` and `format` (the lowercas
 
 ### `load_data`
 
-Loads data from a file, URL, or string literal. Supported file types include *toml*, *json*, *csv*, *bibtex*, *yaml* 
+Loads data from a file, URL, or string literal. Supported file types include *toml*, *json*, *csv*, *bibtex*, *yaml*/*yml*, 
 and *xml* and only supports UTF-8 encoding.
 
 Any other file type will be loaded as plain text.


### PR DESCRIPTION
previously only files with *.yaml suffix were recognized as YAML

Questions to the reviewer:
- Should I add more to the documentation?
- Should I add anything to the changelog or change commit message format?
- I have only tested this locally with `load_data` from a path ending with *.yml (and this worked). Should I add/extend some test?
- I tried to also test this for URLs but I am unsure how the parsing works there. It does not seem to look at the URL suffix (tested with .toml and .yaml) but perhaps at the header. So I am unsure whether more is needed for URLs or whether they already worked and I did not have a good test. I tried with pages served via https://raw.githubusercontent.com/ but maybe they had wrong header.

Sanity checks:
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
- [x] Are you doing the PR on the `next` branch?
- [x] Have you created/updated the relevant documentation page(s)?



