### PR TITLE
Get term fn

### DIFF
--- a/components/content/src/taxonomies.rs
+++ b/components/content/src/taxonomies.rs
@@ -43,6 +43,27 @@ impl<'a> SerializedTaxonomyTerm<'a> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SerializedTaxonomyTermWithoutPages<'a> {
+    name: &'a str,
+    slug: &'a str,
+    path: &'a str,
+    permalink: &'a str,
+    page_count: usize,
+}
+
+impl<'a> SerializedTaxonomyTermWithoutPages<'a> {
+    pub fn from_item(item: &'a TaxonomyTerm, _library: &'a Library) -> Self {
+        SerializedTaxonomyTermWithoutPages {
+            name: &item.name,
+            slug: &item.slug,
+            path: &item.path,
+            permalink: &item.permalink,
+            page_count: item.pages.len(),
+        }
+    }
+}
+
 /// A taxonomy with all its pages
 #[derive(Debug, Clone)]
 pub struct TaxonomyTerm {
@@ -80,6 +101,13 @@ impl TaxonomyTerm {
 
     pub fn serialize<'a>(&'a self, library: &'a Library) -> SerializedTaxonomyTerm<'a> {
         SerializedTaxonomyTerm::from_item(self, library)
+    }
+
+    pub fn serialize_without_pages<'a>(
+        &'a self,
+        library: &'a Library,
+    ) -> SerializedTaxonomyTermWithoutPages<'a> {
+        SerializedTaxonomyTermWithoutPages::from_item(self, library)
     }
 
     pub fn merge(&mut self, other: Self) {

--- a/components/content/src/taxonomies.rs
+++ b/components/content/src/taxonomies.rs
@@ -23,6 +23,7 @@ pub struct SerializedTaxonomyTerm<'a> {
     path: &'a str,
     permalink: &'a str,
     pages: Vec<SerializingPage<'a>>,
+    page_count: usize,
 }
 
 impl<'a> SerializedTaxonomyTerm<'a> {
@@ -39,6 +40,7 @@ impl<'a> SerializedTaxonomyTerm<'a> {
             path: &item.path,
             permalink: &item.permalink,
             pages,
+            page_count: item.pages.len(),
         }
     }
 }
@@ -49,6 +51,7 @@ pub struct SerializedTaxonomyTermWithoutPages<'a> {
     slug: &'a str,
     path: &'a str,
     permalink: &'a str,
+    pages: Vec<SerializingPage<'a>>,
     page_count: usize,
 }
 
@@ -59,6 +62,7 @@ impl<'a> SerializedTaxonomyTermWithoutPages<'a> {
             slug: &item.slug,
             path: &item.path,
             permalink: &item.permalink,
+            pages: vec!(),
             page_count: item.pages.len(),
         }
     }

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -91,4 +91,12 @@ pub fn register_tera_global_fns(site: &mut Site) {
             site.library.clone(),
         ),
     );
+    site.tera.register_function(
+        "get_taxonomy_term",
+        global_fns::GetTaxonomyTerm::new(
+            &site.config.default_language,
+            site.taxonomies.clone(),
+            site.library.clone(),
+        ),
+    );
 }

--- a/components/templates/src/global_fns/mod.rs
+++ b/components/templates/src/global_fns/mod.rs
@@ -8,7 +8,7 @@ mod i18n;
 mod images;
 mod load_data;
 
-pub use self::content::{GetPage, GetSection, GetTaxonomy, GetTaxonomyUrl};
+pub use self::content::{GetPage, GetSection, GetTaxonomy, GetTaxonomyTerm, GetTaxonomyUrl};
 pub use self::files::{GetFileHash, GetUrl};
 pub use self::i18n::Trans;
 pub use self::images::{GetImageMetadata, ResizeImage};

--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -59,7 +59,7 @@ This will create a shortcode `books` with the argument `path` pointing to a `.to
 titles and descriptions. They will flow with the rest of the document in which `books` is called.
 
 Shortcodes are rendered before the page's Markdown is parsed so they don't have access to the page's table of contents.
-Because of that, you also cannot use the [`get_page`](@/documentation/templates/overview.md#get-page)/[`get_section`](@/documentation/templates/overview.md#get-section)/[`get_taxonomy`](@/documentation/templates/overview.md#get-taxonomy) global functions. It might work while
+Because of that, you also cannot use the [`get_page`](@/documentation/templates/overview.md#get-page)/[`get_section`](@/documentation/templates/overview.md#get-section)/[`get_taxonomy`](@/documentation/templates/overview.md#get-taxonomy)/[`get_taxonomy_term`](@/documentation/templates/overview.md#get-term) global functions. It might work while
 running `zola serve` because it has been loaded but it will fail during `zola build`.
 
 ## Using shortcodes

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -191,7 +191,7 @@ The type of the output is a single `TaxonomyTerm` item.
 
 `lang` (optional) default to `config.default_language` in config.toml
 
-`include_pages` (optional) default to true. If false, the `pages` item in the `TaxonomyTerm` is replaced with `page_count`, an integer with the number of pages for this term.
+`include_pages` (optional) default to true. If false, the `pages` item in the `TaxonomyTerm` will be empty, regardless of what pages may actually exist for this term. `page_count` will correctly reflect the number of pages for this term in both cases.
 
 `required` (optional) if a taxonomy or term is not found`.
 

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -180,6 +180,23 @@ items: Array<TaxonomyTerm>;
 
 See the [Taxonomies documentation](@/documentation/templates/taxonomies.md) for a full documentation of those types.
 
+### `get_taxonomy_term`
+Gets a single term from a taxonomy of a specific kind.
+
+```jinja2
+{% set categories = get_taxonomy_term(kind="categories", term="term_name") %}
+```
+
+The type of the output is a single `TaxonomyTerm` item.
+
+`lang` (optional) default to `config.default_language` in config.toml
+
+`include_pages` (optional) default to true. If false, the `pages` item in the `TaxonomyTerm` is replaced with `page_count`, an integer with the number of pages for this term.
+
+`required` (optional) if a taxonomy or term is not found`.
+
+See the [Taxonomies documentation](@/documentation/templates/taxonomies.md) for a full documentation of those types.
+
 ### `get_url`
 Gets the permalink for the given path.
 If the path starts with `@/`, it will be treated as an internal link like the ones used in Markdown, 

--- a/docs/content/documentation/templates/taxonomies.md
+++ b/docs/content/documentation/templates/taxonomies.md
@@ -20,6 +20,7 @@ slug: String;
 path: String;
 permalink: String;
 pages: Array<Page>;
+page_count: Number;
 ```
 
 and `TaxonomyConfig` has the following fields:


### PR DESCRIPTION
As discussed in #1897, this adds a new `get_term` global function which returns a single `TaxonomyTerm` item instead of the entire site. In the personal site discussed in that issue, this results in a 4x improvement in rendering speed (5.4s vs 22.1s).

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



