### PR TITLE
Add flag to override prompt for existing dir

### DIFF
--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -46,7 +46,7 @@ $ zola build --base-url $DEPLOY_URL
 This is useful for example when you want to deploy previews of a site to a dynamic URL, such as Netlify
 deploy previews.
 
-You can override the default output directory `public` by passing another value to the `output-dir` flag (if this directory already exists, the user will be prompted whether to replace the folder).
+You can override the default output directory `public` by passing another value to the `output-dir` flag. If this directory already exists, the user will be prompted whether to replace the folder; you can override this prompt by passing the --force flag.
 
 ```bash
 $ zola build --output-dir $DOCUMENT_ROOT

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,10 @@ pub enum Command {
         #[clap(short = 'o', long)]
         output_dir: Option<PathBuf>,
 
+        /// Force building the site even if output directory is non-empty
+        #[clap(short = 'f', long)]
+        force: bool,
+
         /// Include drafts when loading the site
         #[clap(long)]
         drafts: bool,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -13,17 +13,18 @@ pub fn build(
     config_file: &Path,
     base_url: Option<&str>,
     output_dir: Option<&Path>,
+    force: bool,
     include_drafts: bool,
 ) -> Result<()> {
     let mut site = Site::new(root_dir, config_file)?;
     if let Some(output_dir) = output_dir {
         // Check whether output directory exists or not
         // This way we don't replace already existing files.
-        if output_dir.exists() {
+        if !force && output_dir.exists() {
             console::warn(&format!("The directory '{}' already exists. Building to this directory will delete files contained within this directory.", output_dir.display()));
 
             // Prompt the user to ask whether they want to continue.
-            let clear_dir = tokio::runtime::Runtime::new()
+            let clear_dir = force || tokio::runtime::Runtime::new()
                 .expect("Tokio runtime failed to instantiate")
                 .block_on(ask_bool_timeout(
                     "Are you sure you want to continue?",

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -24,7 +24,7 @@ pub fn build(
             console::warn(&format!("The directory '{}' already exists. Building to this directory will delete files contained within this directory.", output_dir.display()));
 
             // Prompt the user to ask whether they want to continue.
-            let clear_dir = force || tokio::runtime::Runtime::new()
+            let clear_dir = tokio::runtime::Runtime::new()
                 .expect("Tokio runtime failed to instantiate")
                 .block_on(ask_bool_timeout(
                     "Are you sure you want to continue?",

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -4,9 +4,6 @@ use errors::{Error, Result};
 use site::Site;
 
 use crate::messages;
-use crate::prompt::ask_bool_timeout;
-
-const BUILD_PROMPT_TIMEOUT_MILLIS: u64 = 10_000;
 
 pub fn build(
     root_dir: &Path,
@@ -18,25 +15,11 @@ pub fn build(
 ) -> Result<()> {
     let mut site = Site::new(root_dir, config_file)?;
     if let Some(output_dir) = output_dir {
-        // Check whether output directory exists or not
-        // This way we don't replace already existing files.
         if !force && output_dir.exists() {
-            console::warn(&format!("The directory '{}' already exists. Building to this directory will delete files contained within this directory.", output_dir.display()));
-
-            // Prompt the user to ask whether they want to continue.
-            let clear_dir = tokio::runtime::Runtime::new()
-                .expect("Tokio runtime failed to instantiate")
-                .block_on(ask_bool_timeout(
-                    "Are you sure you want to continue?",
-                    false,
-                    std::time::Duration::from_millis(BUILD_PROMPT_TIMEOUT_MILLIS),
-                ))?;
-
-            if !clear_dir {
-                return Err(Error::msg(
-                    "Cancelled build process because output directory already exists.",
-                ));
-            }
+            return Err(Error::msg(format!(
+                "Directory '{}' already exists. User --force to overwrite.",
+                output_dir.display(),
+            )));
         }
 
         site.set_output_path(output_dir);

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        Command::Build { base_url, output_dir, drafts } => {
+        Command::Build { base_url, output_dir, force, drafts } => {
             console::info("Building site...");
             let start = Instant::now();
             let (root_dir, config_file) = get_config_file_path(&cli_dir, &cli.config);
@@ -48,6 +48,7 @@ fn main() {
                 &config_file,
                 base_url.as_deref(),
                 output_dir.as_deref(),
+                force,
                 drafts,
             ) {
                 Ok(()) => messages::report_elapsed_time(start),

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,5 +1,4 @@
 use std::io::{self, BufRead, Write};
-use std::time::Duration;
 
 use libs::url::Url;
 
@@ -30,24 +29,6 @@ pub fn ask_bool(question: &str, default: bool) -> Result<bool> {
             println!("Invalid choice: '{}'", input);
             ask_bool(question, default)
         }
-    }
-}
-
-/// Ask a yes/no question to the user with a timeout
-pub async fn ask_bool_timeout(question: &str, default: bool, timeout: Duration) -> Result<bool> {
-    let (tx, rx) = tokio::sync::oneshot::channel();
-
-    let q = question.to_string();
-    std::thread::spawn(move || {
-        tx.send(ask_bool(&q, default)).unwrap();
-    });
-
-    match tokio::time::timeout(timeout, rx).await {
-        Err(_) => {
-            console::warn("\nWaited too long for response.");
-            Ok(default)
-        }
-        Ok(val) => val.expect("Tokio failed to properly execute"),
     }
 }
 


### PR DESCRIPTION
Added --force flag to build subcommand. This restores use-cases that PR #1558
broke, without breaking current default behaviour.

**IMPORTANT: Please do not create a Pull Request adding a new feature without
discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the
feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open 
  [Pull Requests](https://github.com/getzola/zola/pulls) for the same
  update/change?

## Code changes (Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
