### PR TITLE
Make taxonomies available to Sections

### DIFF
--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -15,6 +15,7 @@ use crate::front_matter::{split_section_content, SectionFrontMatter};
 use crate::library::Library;
 use crate::ser::{SectionSerMode, SerializingSection};
 use crate::utils::{find_related_assets, get_reading_analytics, has_anchor};
+use crate::Taxonomy;
 
 // Default is used to create a default index section if there is no _index.md in the root content directory
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -61,6 +62,8 @@ pub struct Section {
     pub internal_links: Vec<(String, Option<String>)>,
     /// The list of all links to external webpages. They can be validated by the `link_checker`.
     pub external_links: Vec<String>,
+    /// Taxonomies specific to the section (i.e. all pages in this section and sub-sections)
+    pub taxonomies: Vec<Taxonomy>,
 }
 
 impl Section {

--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::library::Library;
+use crate::taxonomies::SerializedTaxonomy;
 use crate::{Page, Section};
 use libs::tera::{Map, Value};
 use utils::table_of_contents::Heading;
@@ -155,6 +156,7 @@ pub struct SerializingSection<'a> {
     subsections: Vec<&'a str>,
     translations: Vec<TranslatedContent<'a>>,
     backlinks: Vec<BackLink<'a>>,
+    taxonomies: Vec<SerializedTaxonomy<'a>>,
 }
 
 #[derive(Debug)]
@@ -174,10 +176,17 @@ impl<'a> SerializingSection<'a> {
         let mut subsections = Vec::with_capacity(section.subsections.len());
         let mut translations = Vec::new();
         let mut backlinks = Vec::new();
+        let mut taxonomies = Vec::new();
 
         match mode {
             SectionSerMode::ForMarkdown => {}
             SectionSerMode::MetadataOnly(lib) | SectionSerMode::Full(lib) => {
+                taxonomies = section
+                    .taxonomies
+                    .iter()
+                    .map(|t| SerializedTaxonomy::from_taxonomy(t, lib))
+                    .collect();
+
                 translations = lib.find_translations(&section.file.canonical);
                 subsections = section
                     .subsections
@@ -216,6 +225,7 @@ impl<'a> SerializingSection<'a> {
             subsections,
             translations,
             backlinks,
+            taxonomies,
         }
     }
 }

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -104,6 +104,8 @@ lang: String;
 translations: Array<TranslatedContent>;
 // All the pages/sections linking this page: their permalink and a title if there is one
 backlinks: Array<{permalink: String, title: String?}>;
+// The merged taxonomies of this section and any sub-sections
+taxonomies: Array<Taxonomy>;
 ```
 
 ## Table of contents


### PR DESCRIPTION
See issue #1989 and [the forum post](https://zola.discourse.group/t/list-all-terms-in-taxonomies-within-category/1431).

Allows section-specific taxonomies to be renderable on section pages.

Taxonomies are built from each page in a leaf section, and then will be merged upwards to ancestor sections.

These are then usable in the section template, e.g.:

```html
    {% for tax in section.taxonomies %}
    <section>
	    <h2 class="capitalize">{{ tax.kind.name }}</h2>
	    <ul display="block">
		{% for term in tax.items %}
		<li><a href={{ term.permalink }}>{{ term.name }} ({{term.pages | length}})</a></li>
		{% endfor %}
	    </ul>
    </section>
    {% endfor %}

```



