### PR TITLE
Search json index

### DIFF
--- a/components/config/src/config/search.rs
+++ b/components/config/src/config/search.rs
@@ -1,6 +1,20 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IndexFormat {
+    #[serde(rename = "json")]
+    Json,
+    #[serde(rename = "javascript")]
+    Javascript,
+}
+
+impl Default for IndexFormat {
+    fn default() -> IndexFormat {
+        IndexFormat::Javascript
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Search {
     /// Include the title of the page in the search index. `true` by default.
@@ -15,6 +29,8 @@ pub struct Search {
     pub include_description: bool,
     /// Include the path of the page in the search index. `false` by default.
     pub include_path: bool,
+    /// Foramt of the search index to be produced. Javascript by default
+    pub index_format: IndexFormat,
 }
 
 impl Default for Search {
@@ -25,6 +41,7 @@ impl Default for Search {
             include_description: false,
             include_path: false,
             truncate_content_length: None,
+            index_format: Default::default(),
         }
     }
 }

--- a/components/config/src/config/search.rs
+++ b/components/config/src/config/search.rs
@@ -1,16 +1,15 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum IndexFormat {
-    #[serde(rename = "json")]
-    Json,
-    #[serde(rename = "javascript")]
-    Javascript,
+    ElasticlunrJson,
+    ElasticlunrJavascript,
 }
 
 impl Default for IndexFormat {
     fn default() -> IndexFormat {
-        IndexFormat::Javascript
+        IndexFormat::ElasticlunrJavascript
     }
 }
 

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -5,8 +5,13 @@ mod theme;
 use std::path::Path;
 
 pub use crate::config::{
-    languages::LanguageOptions, link_checker::LinkChecker, link_checker::LinkCheckerLevel,
-    search::Search, slugify::Slugify, taxonomies::TaxonomyConfig, Config,
+    languages::LanguageOptions,
+    link_checker::LinkChecker,
+    link_checker::LinkCheckerLevel,
+    search::{IndexFormat, Search},
+    slugify::Slugify,
+    taxonomies::TaxonomyConfig,
+    Config,
 };
 use errors::Result;
 

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -771,11 +771,11 @@ impl Site {
             &self.config,
         )?;
         let (path, content) = match &self.config.search.index_format {
-            IndexFormat::Json => {
+            IndexFormat::ElasticlunrJson => {
                 let path = self.output_path.join(&format!("search_index.{}.json", lang));
                 (path, index_json)
             }
-            IndexFormat::Javascript => {
+            IndexFormat::ElasticlunrJavascript => {
                 let path = self.output_path.join(&format!("search_index.{}.js", lang));
                 let content = format!("window.searchIndex = {};", index_json);
                 (path, content)

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -6,7 +6,7 @@ compile_sass = true
 build_search_index = true
 
 [search]
-index_format = "json"
+index_format = "elasticlunr_json"
 
 [markdown]
 highlight_code = true

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -5,6 +5,9 @@ description = "Everything you need to make a static site engine in one binary."
 compile_sass = true
 build_search_index = true
 
+[search]
+index_format = "json"
+
 [markdown]
 highlight_code = true
 highlight_theme = "kronuz"

--- a/docs/content/documentation/content/search.md
+++ b/docs/content/documentation/content/search.md
@@ -17,7 +17,7 @@ After `zola build` or `zola serve`, you should see two files in your public dire
 - `search_index.${default_language}.js`: so `search_index.en.js` for a default setup
 - `elasticlunr.min.js`
 
-If you set `index_format = "json"` in your `config.toml`, a `search_index.${default_language}.json` is generated
+If you set `index_format = "elasticlunr_json"` in your `config.toml`, a `search_index.${default_language}.json` is generated
 instead of the default `search_index.${default_language}.js`.
 
 As each site will be different, Zola makes no assumptions about your search function and doesn't provide

--- a/docs/content/documentation/content/search.md
+++ b/docs/content/documentation/content/search.md
@@ -17,6 +17,9 @@ After `zola build` or `zola serve`, you should see two files in your public dire
 - `search_index.${default_language}.js`: so `search_index.en.js` for a default setup
 - `elasticlunr.min.js`
 
+If you set `index_format = "json"` in your `config.toml`, a `search_index.${default_language}.json` is generated
+instead of the default `search_index.${default_language}.js`.
+
 As each site will be different, Zola makes no assumptions about your search function and doesn't provide
 the JavaScript/CSS code to do an actual search and display results. You can look at how this site
 implements it to get an idea: [search.js](https://github.com/getzola/zola/tree/master/docs/static/search.js).

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -161,8 +161,8 @@ include_content = true
 # truncate_content_length = 100
 
 # Wether to produce the search index as a javascript file or as a JSON file
-# Accepted value "javascript" or "json"
-index_format = "javascript"
+# Accepted value "elasticlunr_javascript" or "elasticlunr_json"
+index_format = "elasticlunr_javascript"
 
 # Optional translation object for the default language
 # Example:

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -160,6 +160,10 @@ include_content = true
 # become too big to load on the site. Defaults to not being set.
 # truncate_content_length = 100
 
+# Wether to produce the search index as a javascript file or as a JSON file
+# Accepted value "javascript" or "json"
+index_format = "javascript"
+
 # Optional translation object for the default language
 # Example:
 #     default_language = "fr"

--- a/docs/static/search.js
+++ b/docs/static/search.js
@@ -142,11 +142,24 @@ function initSearch() {
     }
   };
   var currentTerm = "";
-  var index = elasticlunr.Index.load(window.searchIndex);
+  var index;
+  
+  var initIndex = async function () {
+    if (index === undefined) {
+      index = fetch("/search_index.en.json")
+        .then(
+          async function(response) {
+            return await elasticlunr.Index.load(await response.json());
+        }
+      );
+    }
+    let res = await index;
+    return res;
+  }
 
-  $searchInput.addEventListener("keyup", debounce(function() {
+  $searchInput.addEventListener("keyup", debounce(async function() {
     var term = $searchInput.value.trim();
-    if (term === currentTerm || !index) {
+    if (term === currentTerm) {
       return;
     }
     $searchResults.style.display = term === "" ? "none" : "block";
@@ -156,7 +169,7 @@ function initSearch() {
       return;
     }
 
-    var results = index.search(term, options);
+    var results = (await initIndex()).search(term, options);
     if (results.length === 0) {
       $searchResults.style.display = "none";
       return;

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -103,7 +103,6 @@
         </footer>
 
         <script type="text/javascript" src="{{ get_url(path="elasticlunr.min.js") }}"></script>
-        <script type="text/javascript" src="{{ get_url(path="search_index.en.js") }}"></script>
         <script type="text/javascript" src="{{ get_url(path="search.js") }}"></script>
     </body>
 </html>


### PR DESCRIPTION
Based on [this discussion](https://zola.discourse.group/t/make-zola-ability-to-export-search-index-into-json-instead-of-js/1032/3)

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?

Description
=========

This PR adds an `index_format` configuration item.
```
[search]
index_format = "javascript" | "json"
```

When set to Javascript, a JSON file is created instead of a `js` file for the index.

This is:

- More convenient. Lazy-loading Json is easier than a script
- More flexible. The JSON file can be loaded with the `fetch` API and be manipulated more easily than a script that sets a global variable for which you don't control the name. While it's not a use case I encountered, I don't think the current setup makes it easy to load multiple search index at the same time, for example for multiple languages.

The docs are updated to 
- Document the feature
- Use the feature and lazy-load the index, saving more than 1MB (200KB with compression) from loading when just loading the site.