### PR TITLE
Quotation mark bug fix in docs

### DIFF
--- a/docs/content/documentation/getting-started/overview.md
+++ b/docs/content/documentation/getting-started/overview.md
@@ -220,7 +220,7 @@ The `index.html` file inside the `templates` directory should be:
 <h1 class="title">
   This is my blog made with Zola.
 </h1>
-<p>Click <a href="{{/* get_url(path="@/blog/_index.md") */}}">here</a> to see my posts.</p>
+<p>Click <a href="{{/* get_url(path='@/blog/_index.md') */}}">here</a> to see my posts.</p>
 {% endblock content %}
 ```  
 


### PR DESCRIPTION
Changed double quotation mark " to single quotation ', otherwise the code doesn't work.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
