### PR TITLE
Fix sup summary

### DIFF
--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -31,7 +31,7 @@ static RFC3339_DATE: Lazy<Regex> = Lazy::new(|| {
     ).unwrap()
 });
 
-static FOOTNOTES_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"<sup\s*.*?>\s*.*?</sup>").unwrap());
+static FOOTNOTES_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"<sup class="footnote-reference"><a href=\s*.*?>\s*.*?</a></sup>"#).unwrap());
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Page {
@@ -513,7 +513,7 @@ Hello world
         let content = r#"
 +++
 +++
-This page has footnotes, here's one. [^1]
+This page use <sup>1.5</sup> and has footnotes, here's one. [^1]
 
 <!-- more -->
 
@@ -536,7 +536,7 @@ And here's another. [^2]
         .unwrap();
         assert_eq!(
             page.summary,
-            Some("<p>This page has footnotes, here\'s one. </p>\n".to_string())
+            Some("<p>This page use <sup>1.5</sup> and has footnotes, here\'s one. </p>\n".to_string())
         );
     }
 


### PR DESCRIPTION
If the summary contain HTML using &lt;sup&gt; like "the 1&lt;sup&gt;st&lt;sup&gt;", it get filtered as the regexp that remove footnotes is not precise enough to remove just the footnotes.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?



