### PR TITLE
Cargo fmt

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,8 @@ stages:
             displayName: Cargo build (Rust TLS)
           - script: cargo test --all
             displayName: Cargo test
+          - script: cargo fmt --check
+            displayName: Cargo fmt
 
 
   - stage: Release

--- a/components/content/src/taxonomies.rs
+++ b/components/content/src/taxonomies.rs
@@ -222,8 +222,11 @@ impl Taxonomy {
     ) -> Result<String> {
         let mut context = Context::new();
         context.insert("config", &config.serialize(&self.lang));
-        let terms: Vec<SerializedTaxonomyTerm> =
-            self.items.iter().map(|i| SerializedTaxonomyTerm::from_item(i, library, true)).collect();
+        let terms: Vec<SerializedTaxonomyTerm> = self
+            .items
+            .iter()
+            .map(|i| SerializedTaxonomyTerm::from_item(i, library, true))
+            .collect();
         context.insert("terms", &terms);
         context.insert("lang", &self.lang);
         context.insert("taxonomy", &self.kind);

--- a/components/imageproc/src/lib.rs
+++ b/components/imageproc/src/lib.rs
@@ -4,7 +4,10 @@ use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
-use std::{collections::hash_map::DefaultHasher, io::{Write, BufWriter}};
+use std::{
+    collections::hash_map::DefaultHasher,
+    io::{BufWriter, Write},
+};
 
 use image::error::ImageResult;
 use image::io::Reader as ImgReader;

--- a/components/site/src/minify.rs
+++ b/components/site/src/minify.rs
@@ -142,4 +142,3 @@ mod tests {
         assert_eq!(res, expected);
     }
 }
-

--- a/components/site/src/sass.rs
+++ b/components/site/src/sass.rs
@@ -1,9 +1,9 @@
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 
-use libs::walkdir::{WalkDir, DirEntry};
-use libs::globset::{Glob};
+use libs::globset::Glob;
 use libs::sass_rs::{compile_file, Options, OutputStyle};
+use libs::walkdir::{DirEntry, WalkDir};
 
 use crate::anyhow;
 use errors::{bail, Result};
@@ -67,16 +67,13 @@ fn compile_sass_glob(
 }
 
 fn is_partial_scss(entry: &DirEntry) -> bool {
-    entry.file_name()
-         .to_str()
-         .map(|s| s.starts_with("_"))
-         .unwrap_or(false)
+    entry.file_name().to_str().map(|s| s.starts_with("_")).unwrap_or(false)
 }
 
 fn get_non_partial_scss(sass_path: &Path, extension: &str) -> Vec<PathBuf> {
     let glob_string = format!("*.{}", extension);
     let glob = Glob::new(glob_string.as_str()).expect("Invalid glob for sass").compile_matcher();
-    
+
     WalkDir::new(sass_path)
         .into_iter()
         .filter_entry(|e| !is_partial_scss(e))

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::fs;
 use std::io::Read;
+use std::path::PathBuf;
 
 use crate::global_fns::helpers::search_for_file;
 use config::Config;
@@ -11,10 +11,7 @@ use libs::tera::{from_value, to_value, Function as TeraFn, Result, Value};
 use libs::url;
 use utils::site::resolve_internal_link;
 
-fn compute_hash<D: digest::Digest>(
-    literal: String,
-    as_base64: bool,
-) -> String
+fn compute_hash<D: digest::Digest>(literal: String, as_base64: bool) -> String
 where
     digest::Output<D>: core::fmt::LowerHex,
     D: std::io::Write,
@@ -135,8 +132,7 @@ impl TeraFn for GetUrl {
                     f.read_to_string(&mut contents).ok()?;
 
                     Some(compute_hash::<Sha256>(contents, false))
-                })
-                {
+                }) {
                     Some(hash) => {
                         permalink = format!("{}?h={}", permalink, hash);
                     }
@@ -201,14 +197,16 @@ impl TeraFn for GetHash {
         let contents = match (path, literal) {
             (Some(_), Some(_)) => {
                 return Err("`get_hash`: must have only one of `path` or `literal` argument".into());
-            },
+            }
             (None, None) => {
-                return Err("`get_hash`: must have at least one of `path` or `literal` argument".into());
-            },
+                return Err(
+                    "`get_hash`: must have at least one of `path` or `literal` argument".into()
+                );
+            }
             (Some(path_v), None) => {
                 let file_path =
                     match search_for_file(&self.base_path, &path_v, &self.theme, &self.output_path)
-                    .map_err(|e| format!("`get_hash`: {}", e))?
+                        .map_err(|e| format!("`get_hash`: {}", e))?
                     {
                         Some((f, _)) => f,
                         None => {
@@ -234,9 +232,8 @@ impl TeraFn for GetHash {
 
                 contents
             }
-            (None, Some(literal_v)) => { literal_v }
+            (None, Some(literal_v)) => literal_v,
         };
-
 
         let sha_type = optional_arg!(
             u16,
@@ -244,13 +241,10 @@ impl TeraFn for GetHash {
             "`get_hash`: `sha_type` must be 256, 384 or 512"
         )
         .unwrap_or(384);
-        
-        let base64 = optional_arg!(
-            bool,
-            args.get("base64"),
-            "`get_hash`: `base64` must be true or false"
-        )
-        .unwrap_or(true);
+
+        let base64 =
+            optional_arg!(bool, args.get("base64"), "`get_hash`: `base64` must be true or false")
+                .unwrap_or(true);
 
         let hash = match sha_type {
             256 => compute_hash::<Sha256>(contents, base64),
@@ -587,9 +581,7 @@ title = "A title"
         args.insert("literal".to_string(), to_value("Hello World").unwrap());
         args.insert("sha_type".to_string(), to_value(256).unwrap());
         args.insert("base64".to_string(), to_value(true).unwrap());
-        assert_eq!(
-            static_fn.call(&args).unwrap(),
-            "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4=");
+        assert_eq!(static_fn.call(&args).unwrap(), "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4=");
     }
 
     #[test]
@@ -654,7 +646,7 @@ title = "A title"
         args.insert(
             "path".to_string(),
             to_value(dir.path().join("app.css").strip_prefix(std::env::temp_dir()).unwrap())
-            .unwrap(),
+                .unwrap(),
         );
         assert_eq!(
             static_fn.call(&args).unwrap(),


### PR DESCRIPTION
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

* [x] Are you doing the PR on the `next` branch?


This PR runs `cargo fmt` and adds `cargo fmt --check` to the pipeline to prevent future PRs from being merged without proper formatting in the future. This is something that has happened in the past: 
- https://github.com/getzola/zola/pull/896
- https://github.com/getzola/zola/pull/1420
- https://github.com/getzola/zola/pull/850

Having everything be formatted always avoids having unexpectedly large diffs when someone uses format-on-save and doesn't turn it off.

The formatting was not that far off from what `cargo fmt` gives us so it shouldn't cause that many conflicts.