### PR TITLE
Reduced cachebust fingerprint to be more reasonable

### DIFF
--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -777,7 +777,7 @@ fn can_ignore_markdown_content() {
 fn can_cachebust_static_files() {
     let (_, _tmp_dir, public) = build_site("test_site");
     assert!(file_contains!(public, "index.html",
-        "<link href=\"https://replace-this-with-your-url.com/site.css?h=83bd983e8899946ee33d0fde18e82b04d7bca1881d10846c769b486640da3de9\" rel=\"stylesheet\">"));
+        "<link href=\"https://replace-this-with-your-url.com/site.css?h=83bd983e8899946ee33d\" rel=\"stylesheet\">"));
 }
 
 #[test]

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -135,7 +135,9 @@ impl TeraFn for GetUrl {
                     Some(compute_hash::<Sha256>(contents, false))
                 }) {
                     Some(hash) => {
-                        permalink = format!("{}?h={}", permalink, hash);
+                        let fullhash = format!("{}", hash);
+                        let shorthash = &fullhash[..20]; // 2^-80 chance of false positive
+                        permalink = format!("{}?h={}", permalink, shorthash);
                     }
                     None => {
                         return Err(format!(

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -304,7 +304,7 @@ title = "A title"
         let mut args = HashMap::new();
         args.insert("path".to_string(), to_value("app.css").unwrap());
         args.insert("cachebust".to_string(), to_value(true).unwrap());
-        assert_eq!(static_fn.call(&args).unwrap(), "http://a-website.com/app.css?h=572e691dc68c3fcd653ae463261bdb38f35dc6f01715d9ce68799319dd158840");
+        assert_eq!(static_fn.call(&args).unwrap(), "http://a-website.com/app.css?h=572e691dc68c3fcd653a");
     }
 
     #[test]
@@ -335,7 +335,7 @@ title = "A title"
         args.insert("path".to_string(), to_value("app.css").unwrap());
         args.insert("trailing_slash".to_string(), to_value(true).unwrap());
         args.insert("cachebust".to_string(), to_value(true).unwrap());
-        assert_eq!(static_fn.call(&args).unwrap(), "http://a-website.com/app.css/?h=572e691dc68c3fcd653ae463261bdb38f35dc6f01715d9ce68799319dd158840");
+        assert_eq!(static_fn.call(&args).unwrap(), "http://a-website.com/app.css/?h=572e691dc68c3fcd653a");
     }
 
     #[test]


### PR DESCRIPTION
Using a full 256-bit hash for cachebusting is complete overkill (and a waste of pagesize bytes). It isn't for security, simply to invalidate the browser cache if the file changes.

I've changed it to 80 bits. Since you'll see on average a collision from a collection of n elements after sqrt(n) random samples, this means you'd have to do 2^40 edits on the same file, with the browser caching all of them, before you would load a stale version. That is, even if you edited your CSS file every second and cached all of them for eternity it would still take you ~34865 years before seeing a collision. I think that's plenty.

So instead of this:

```html
<link rel="stylesheet" href="/assets/style.css?h=23d9476e2b2eb5b846066019f1ffecec1be0e80ce171161175b5441699b24ccf">
```

You would see:

```html
<link rel="stylesheet" href="/assets/style.css?h=23d9476e2b2eb5b84606">
```