### PR TITLE
Update `zola-deploy-action` version on docs

### DIFF
--- a/docs/content/documentation/deployment/github-pages.md
+++ b/docs/content/documentation/deployment/github-pages.md
@@ -48,7 +48,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3.0.0
       - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.16.1
+        uses: shalzz/zola-deploy-action@v0.16.1-1
         env:
           # Target branch
           PAGES_BRANCH: gh-pages


### PR DESCRIPTION
Old version was not able to fetch theme submodules: https://github.com/shalzz/zola-deploy-action/issues/50

It was fixed in this PR: https://github.com/shalzz/zola-deploy-action/pull/52

This commit changes the docs to match the newest  `zola-deploy-action`  version, without the problem above.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?



