### PR TITLE
Allow external links to start with "www.*"

### DIFF
--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -593,6 +593,7 @@ mod tests {
     fn test_is_external_link() {
         assert!(is_external_link("http://example.com/"));
         assert!(is_external_link("https://example.com/"));
+        assert!(is_external_link("www.example.com"));
         assert!(is_external_link("https://example.com/index.html#introduction"));
 
         assert!(!is_external_link("mailto:user@example.com"));

--- a/components/utils/src/net.rs
+++ b/components/utils/src/net.rs
@@ -12,5 +12,5 @@ pub fn port_is_available(port: u16) -> bool {
 
 /// Returns whether a link starts with an HTTP(s) scheme.
 pub fn is_external_link(link: &str) -> bool {
-    link.starts_with("http:") || link.starts_with("https:")
+    link.starts_with("http:") || link.starts_with("https:") || link.starts_with("www.")
 }

--- a/components/utils/src/net.rs
+++ b/components/utils/src/net.rs
@@ -10,7 +10,7 @@ pub fn port_is_available(port: u16) -> bool {
     TcpListener::bind(("127.0.0.1", port)).is_ok()
 }
 
-/// Returns whether a link starts with an HTTP(s) scheme.
+/// Returns whether a link starts with an HTTP(s) scheme or "www.".
 pub fn is_external_link(link: &str) -> bool {
     link.starts_with("http:") || link.starts_with("https:") || link.starts_with("www.")
 }


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

* [x] Have you created/updated the relevant documentation page(s)?

## Description

This PR addresses #1967 by changing `is_external_link` to consider links with URLs starting with `"www."` as external links.

