### PR TITLE
Update word count implementation to handle raw HTML content

### DIFF
--- a/components/content/Cargo.toml
+++ b/components/content/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 serde = {version = "1.0", features = ["derive"] }
 time = { version = "0.3", features = ["macros"] }
+once_cell = "1.17.1"
+fancy-regex = "0.11.0"
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -7,6 +7,9 @@ use config::Config;
 use utils::fs::is_temp_file;
 use utils::table_of_contents::Heading;
 
+use once_cell::sync::Lazy;
+use fancy_regex::Regex;
+
 pub fn has_anchor(headings: &[Heading], anchor: &str) -> bool {
     for heading in headings {
         if heading.id == anchor {
@@ -55,6 +58,12 @@ pub fn find_related_assets(path: &Path, config: &Config, recursive: bool) -> Vec
 
 /// Get word count and estimated reading time
 pub fn get_reading_analytics(content: &str) -> (usize, usize) {
+    // extract words out of raw html
+    let extract_words_regex: Lazy<Regex> = Lazy::new(||
+        Regex::new(r#"<(script|style)((.|\n)*)</\1>|<.*?>"#).unwrap()
+    );
+    let content = extract_words_regex.replace_all(content, "");
+
     let word_count: usize = content.unicode_words().count();
 
     // https://help.medium.com/hc/en-us/articles/214991667-Read-time


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?

---

Noticed the word count implementation treated HTML/CSS/JS inside the Markdown as words after unicode separated word counting. This PR introduces a way to extract words from raw HTML content by removing the `<script>` and `<style>` chunks along with HTML tags.

This introduces one new dependency [`fancy-regex`](https://docs.rs/fancy-regex/latest/fancy_regex/), [`once_cell`](https://docs.rs/once_cell/latest/once_cell/) is already being [used](https://github.com/getzola/zola/blob/next/components/libs/Cargo.toml#L22) in the codebase. Added `once_cell` since the regex shouldn't be compiled for every page it process.

This should address #2053! :raised_hands: 

