### PR TITLE
fix `zola serve` not  respecting `preserve_dotfiles_in_output`

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -22,8 +22,8 @@ use libs::relative_path::RelativePathBuf;
 use std::time::Instant;
 use templates::{load_tera, render_redirect_template};
 use utils::fs::{
-    copy_directory, copy_file_if_needed, create_directory, create_file, ensure_directory_exists,
-    clean_site_output_folder,
+    clean_site_output_folder, copy_directory, copy_file_if_needed, create_directory, create_file,
+    ensure_directory_exists,
 };
 use utils::net::{get_available_port, is_external_link};
 use utils::templates::{render_template, ShortcodeDefinition};

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -209,7 +209,7 @@ pub fn clean_site_output_folder(
 ) -> Result<()> {
     if output_path.exists() {
         if !preserve_dotfiles_in_output {
-            return remove_dir_all(&output_path).context("Couldn't delete output directory");
+            return remove_dir_all(output_path).context("Couldn't delete output directory");
         }
 
         for entry in output_path

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -1,6 +1,6 @@
 use libs::filetime::{set_file_mtime, FileTime};
 use libs::walkdir::WalkDir;
-use std::fs::{copy, create_dir_all, metadata, File, remove_dir_all, remove_file};
+use std::fs::{copy, create_dir_all, metadata, remove_dir_all, remove_file, File};
 use std::io::prelude::*;
 use std::path::Path;
 use std::time::SystemTime;

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -201,6 +201,8 @@ pub fn is_temp_file(path: &Path) -> bool {
     }
 }
 
+/// Deletes the `output_path` directory if it exists and `preserve_dotfiles_in_output` is set to false,
+/// or if set to true: its contents except for the dotfiles at the root level.
 pub fn clean_site_output_folder(
     output_path: &Path,
     preserve_dotfiles_in_output: bool,

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -1,6 +1,6 @@
 use libs::filetime::{set_file_mtime, FileTime};
 use libs::walkdir::WalkDir;
-use std::fs::{copy, create_dir_all, metadata, File};
+use std::fs::{copy, create_dir_all, metadata, File, remove_dir_all, remove_file};
 use std::io::prelude::*;
 use std::path::Path;
 use std::time::SystemTime;
@@ -199,6 +199,39 @@ pub fn is_temp_file(path: &Path) -> bool {
         },
         None => true,
     }
+}
+
+pub fn clean_site_output_folder(
+    output_path: &Path,
+    preserve_dotfiles_in_output: bool,
+) -> Result<()> {
+    if output_path.exists() {
+        if !preserve_dotfiles_in_output {
+            return remove_dir_all(&output_path).context("Couldn't delete output directory");
+        }
+
+        for entry in output_path
+            .read_dir()
+            .context(format!("Couldn't read output directory `{}`", output_path.display()))?
+        {
+            let entry = entry.context("Couldn't read entry in output directory")?.path();
+
+            // Skip dotfiles if the preserve_dotfiles_in_output configuration option is set
+            if is_dotfile(&entry) {
+                continue;
+            }
+
+            if entry.is_dir() {
+                remove_dir_all(entry)
+                    .context("Couldn't delete folder while cleaning the output directory")?;
+            } else {
+                remove_file(entry)
+                    .context("Couldn't delete file while cleaning the output directory")?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -21,7 +21,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::fs::{read_dir, remove_dir_all};
+use std::fs::read_dir;
 use std::net::{SocketAddrV4, TcpListener};
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::sync::mpsc::channel;
@@ -47,7 +47,7 @@ use errors::{anyhow, Context, Result};
 use pathdiff::diff_paths;
 use site::sass::compile_sass;
 use site::{Site, SITE_CONTENT};
-use utils::fs::{copy_file, is_temp_file};
+use utils::fs::{clean_site_output_folder, copy_file, is_temp_file};
 
 use crate::messages;
 use std::ffi::OsStr;
@@ -441,12 +441,14 @@ pub fn serve(
         watchers.join(",")
     );
 
+    let preserve_dotfiles_in_output = site.config.preserve_dotfiles_in_output;
+
     println!("Press Ctrl+C to stop\n");
-    // Delete the output folder on ctrl+C
+    // Clean the output folder on ctrl+C
     ctrlc::set_handler(move || {
-        match remove_dir_all(&output_path) {
+        match clean_site_output_folder(&output_path, preserve_dotfiles_in_output) {
             Ok(()) => (),
-            Err(e) => println!("Errored while deleting output folder: {}", e),
+            Err(e) => println!("Errored while cleaning output folder: {}", e),
         }
         ::std::process::exit(0);
     })


### PR DESCRIPTION
This PR fixes the behaviour of `zola serve` to respect the `preserve_dotfiles_in_output` configuration option. Currently the output -dir is always deleted when the user presses "Ctrl+C" and serve exits. It was an oversight when adding `preserve_dotfiles_in_output` in #1985 .

Things to discuss:

- the location of the `clean_site_output_folder()` function. Is `utils::fs` the right place for it?

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?



