### PR TITLE
installing-and-using-themes.md: Change placeholder format for git repo URL

### DIFF
--- a/docs/content/documentation/themes/installing-and-using-themes.md
+++ b/docs/content/documentation/themes/installing-and-using-themes.md
@@ -7,11 +7,11 @@ weight = 20
 ## Installing a theme
 
 The easiest way to install a theme is to clone its repository in the `themes`
-directory.
+directory:
 
 ```bash
 $ cd themes
-$ git clone THEME_REPO_URL
+$ git clone <theme repository URL>
 ```
 
 Cloning the repository using Git or another VCS will allow you to easily


### PR DESCRIPTION
The all-caps syntax makes it seem like an environment variable. Changing to angle brackets makes it more evident that this is a placeholder value to be replaced when running the actual command.