### PR TITLE
Fix index errors

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -183,7 +183,7 @@ impl Site {
         // at the end to detect pages that are actually errors:
         // when there is both a _index.md and index.md in the same folder
         let mut pages = Vec::new();
-        let mut components = HashSet::new();
+        let mut sections = HashSet::new();
 
         loop {
             let entry: DirEntry = match dir_walker.next() {
@@ -248,7 +248,7 @@ impl Site {
                 for index_file in index_files {
                     let section =
                         Section::from_file(index_file.path(), &self.config, &self.base_path)?;
-                    components.extend(section.file.components.clone());
+                    sections.insert(section.components.join("/"));
 
                     // if the section is drafted we can skip the entire dir
                     if section.meta.draft && !self.include_drafts {
@@ -275,7 +275,7 @@ impl Site {
             // all the components there.
             if page.file.filename == "index.md" {
                 let is_invalid = match page.components.last() {
-                    Some(last) => components.contains(last),
+                    Some(_) => sections.contains(&page.components.join("/")),
                     // content/index.md is always invalid, but content/colocated/index.md is ok
                     None => page.file.colocated_path.is_none(),
                 };

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -21,7 +21,7 @@ fn can_parse_site() {
     let library = site.library.read().unwrap();
 
     // Correct number of pages (sections do not count as pages, draft are ignored)
-    assert_eq!(library.pages.len(), 34);
+    assert_eq!(library.pages.len(), 35);
     let posts_path = path.join("content").join("posts");
 
     // Make sure the page with a url doesn't have any sections
@@ -34,7 +34,7 @@ fn can_parse_site() {
     assert_eq!(asset_folder_post.file.components, vec!["posts".to_string()]);
 
     // That we have the right number of sections
-    assert_eq!(library.sections.len(), 12);
+    assert_eq!(library.sections.len(), 13);
 
     // And that the sections are correct
     let index_section = library.sections.get(&path.join("content").join("_index.md")).unwrap();

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -39,7 +39,7 @@ fn can_parse_site() {
     // And that the sections are correct
     let index_section = library.sections.get(&path.join("content").join("_index.md")).unwrap();
     assert_eq!(index_section.subsections.len(), 5);
-    assert_eq!(index_section.pages.len(), 4);
+    assert_eq!(index_section.pages.len(), 5);
     assert!(index_section.ancestors.is_empty());
 
     let posts_section = library.sections.get(&posts_path.join("_index.md")).unwrap();
@@ -279,7 +279,7 @@ fn can_build_site_with_live_reload_and_drafts() {
 
     // drafted sections are included
     let library = site.library.read().unwrap();
-    assert_eq!(library.sections.len(), 14);
+    assert_eq!(library.sections.len(), 15);
 
     assert!(file_exists!(public, "secret_section/index.html"));
     assert!(file_exists!(public, "secret_section/draft-page/index.html"));
@@ -545,13 +545,13 @@ fn can_build_site_with_pagination_for_index() {
         "page/1/index.html",
         "<a href=\"https://replace-this-with-your-url.com/\">Click here</a>"
     ));
-    assert!(file_contains!(public, "index.html", "Num pages: 2"));
+    assert!(file_contains!(public, "index.html", "Num pages: 3"));
     assert!(file_contains!(public, "index.html", "Current index: 1"));
     assert!(file_contains!(public, "index.html", "First: https://replace-this-with-your-url.com/"));
     assert!(file_contains!(
         public,
         "index.html",
-        "Last: https://replace-this-with-your-url.com/page/2/"
+        "Last: https://replace-this-with-your-url.com/page/3/"
     ));
     assert!(!file_contains!(public, "index.html", "has_prev"));
     assert!(file_contains!(public, "index.html", "has_next"));

--- a/test_site/content/2018/index.md
+++ b/test_site/content/2018/index.md
@@ -1,0 +1,3 @@
++++
+title = "index page in a direction with the same name as a section"
++++

--- a/test_site/content/colocated-assets/with_subfolder/_index.md
+++ b/test_site/content/colocated-assets/with_subfolder/_index.md
@@ -1,0 +1,3 @@
++++
+title = "Assets in root content directory"
++++


### PR DESCRIPTION
It is still possible to have cases of `Error: We can't have a page called index.md in the same folder as an index section...`:
* if a folder containing an `index.md` has a subfolder containing a `_index.md`
* if a folder containing an `index.md` has the same name as a folder containing a `_index.md` but not the same path

To fix both those cases, keep track of sections as their complete path instead of their separate components

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?
