### PR TITLE
elasticlunr-rs 3.0.2, hu language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,9 +754,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elasticlunr-rs"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94d9c8df0fe6879ca12e7633fdfe467c503722cc981fc463703472d2b876448"
+checksum = "41e83863a500656dfa214fee6682de9c5b9f03de6860fec531235ed2ae9f6571"
 dependencies = [
  "jieba-rs",
  "lindera",

--- a/components/libs/Cargo.toml
+++ b/components/libs/Cargo.toml
@@ -9,7 +9,7 @@ ammonia = "3"
 atty = "0.2.11"
 base64 = "0.21"
 csv = "1"
-elasticlunr-rs = { version = "3.0.0", features = ["da", "no", "de", "du", "es", "fi", "fr", "it", "pt", "ro", "ru", "sv", "tr"] }
+elasticlunr-rs = { version = "3.0.2", features = ["da", "no", "de", "du", "es", "fi", "fr", "hu", "it", "pt", "ro", "ru", "sv", "tr"] }
 filetime = "0.2"
 gh-emoji = "1"
 glob = "0.3"


### PR DESCRIPTION
Hi,

please update elasticlunr-rs dependency  to 3.0.2 version to add hungarian language support.



