### PR TITLE
Add supported Zola version by Cloudflare in the doc

### DIFF
--- a/docs/content/documentation/deployment/cloudflare-pages.md
+++ b/docs/content/documentation/deployment/cloudflare-pages.md
@@ -13,7 +13,7 @@ Cloudflare is a cloud solutions provider with a huge proprietary content deliver
 4. Click _"Begin setup"_
 5. Enter your project name. Keep in mind that if you would like to use the default Pages domain (pages.dev), this will be your website's future URL ("yourprojectname.pages.dev"). Additionally, select a production branch.
 6. In _Build settings_, select Zola as the _Framework preset_. _Build command_ and _Build output directory_ will be filled automatically. 
-7. Toggle _Environment variables_ below and add `ZOLA_VERSION` as _a variable name_. Use `0.13.0` or a different Zola version as the _value_.
+7. Toggle _Environment variables_ below and add `ZOLA_VERSION` as _a variable name_. Currently, Cloudflare Pages only supports `ZOLA_VERSION`: <=0.14.0 in builds, so use `0.14.0` or earlier as the _value_.
 8. Finally, save and deploy.
 
 Your website is now built and deployed to Cloudflare's network! You can add a custom domain or modify settings in the Pages dashboard.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

This PR adds info about the supported Zola version by Cloudflare, which is 0.14.0 or earlier for now. This trapped me a few minutes ago, so I thought someone needs this clarification on the doc.