### PR TITLE
Documentation: minor updates to the GettingStarted/Overview page

### DIFF
--- a/docs/content/documentation/getting-started/overview.md
+++ b/docs/content/documentation/getting-started/overview.md
@@ -19,7 +19,7 @@ Unlike some SSGs, Zola makes no assumptions regarding the structure of your site
 
 ### Initialize Site
 
-> This overview is based on Zola 0.9.
+> This overview is based on Zola 0.17.1.
 
 Please see the detailed [installation instructions for your platform](@/documentation/getting-started/installation.md). With Zola installed, let's initialize our site:
 
@@ -66,15 +66,22 @@ For reference, by the **end** of this overview, our `myblog` directory will have
 └── themes/
 ```
 
-Let's start the Zola development server with:
+Let's start the Zola development server within the newly created `myblog` directory:
 
 ```bash
+$ cd myblog
 $ zola serve
 Building site...
--> Creating 0 pages (0 orphan), 0 sections, and processing 0 images
-```
+Checking all internal links with anchors.
+> Successfully checked 0 internal link(s) with anchors.
+-> Creating 0 pages (0 orphan) and 0 sections
+Done in 13ms.
 
-> This command must be run in the base Zola directory, which contains `config.toml`.
+Listening for changes in .../myblog/{config.toml,content,sass,static,templates}
+Press Ctrl+C to stop
+
+Web server is available at http://127.0.0.1:1111
+```
 
 If you point your web browser to <http://127.0.0.1:1111>, you should see a "Welcome to Zola" message.
 


### PR DESCRIPTION
While working through the docs I noticed that the GettingStarted/Overview is based on Zola 0.9, which I guess is pretty old.

I went through the tutorial using the current version 0.17.1 and can confirm that it still works as described in the docs. The only difference was the output generated by `zola serve`, which I updated in the docs. I also put the instruction to `cd` into the `myblog` directory before running `zola serve` and removed the hint that talked about it afterwards. I think it's more user-friendly this way.

That's all! Let me know if you want something changed.

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?