### PR TITLE
Speedup "zola check" command by reusing the Client

### DIFF
--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::result;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use libs::once_cell::sync::Lazy;
 use libs::reqwest::header::{HeaderMap, ACCEPT};
@@ -30,6 +31,13 @@ pub fn message(res: &Result) -> String {
 // Keep history of link checks so a rebuild doesn't have to check again
 static LINKS: Lazy<Arc<RwLock<HashMap<String, Result>>>> =
     Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
+// Make sure to create only a single Client so that we can reuse the connections
+static CLIENT: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
+        .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("reqwest client build")
+});
 
 pub fn check_url(url: &str, config: &LinkChecker) -> Result {
     {
@@ -44,15 +52,11 @@ pub fn check_url(url: &str, config: &LinkChecker) -> Result {
     headers.append(ACCEPT, "*/*".parse().unwrap());
 
     // TODO: pass the client to the check_url, do not pass the config
-    let client = Client::builder()
-        .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .expect("reqwest client build");
 
     let check_anchor = !config.skip_anchor_prefixes.iter().any(|prefix| url.starts_with(prefix));
 
     // Need to actually do the link checking
-    let res = match client.get(url).headers(headers).send() {
+    let res = match CLIENT.get(url).headers(headers).send() {
         Ok(ref mut response) if check_anchor && has_anchor(url) => {
             let body = {
                 let mut buf: Vec<u8> = vec![];

--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::result;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 use libs::once_cell::sync::Lazy;
 use libs::reqwest::header::{HeaderMap, ACCEPT};


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
The code changes that `zola check` reuses the reqwest Client instead of creating it for every single request.
The benefit of this is a major speedup since it is able to reuse the connections. This is especially helpful for big pages like the one I am working on (17733 external links). The current stable way takes multiple hours, while this PR makes it go down to way less (as of writing it is still running but the progress bar I added in my local code predicts it to take 30-40 minutes instead of 14h+).

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



