### PR TITLE
docs: update expired Documents  documentation

### DIFF
--- a/docs/content/documentation/content/multilingual.md
+++ b/docs/content/documentation/content/multilingual.md
@@ -33,7 +33,7 @@ summary = "My blog"
 ```
 
 Note: By default, Chinese and Japanese search indexing is not included. You can include
-the support by building `zola` using `cargo build --features search/indexing-ja --features search/indexing-zh`.
+the support by building `zola` using `cargo build --features indexing-ja --features indexing-zh`.
 Please also note that, enabling Chinese indexing will increase the binary size by approximately
 5 MB while enabling Japanese indexing will increase the binary size by approximately 70 MB
 due to the incredibly large dictionaries.


### PR DESCRIPTION
  Due to Cargo.toml:54-55 has changed this feature from
  `search/indexing-ja/zh` into `indexing-ja/zh`

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
