### PR TITLE
Add default template warning

### DIFF
--- a/components/content/src/library.rs
+++ b/components/content/src/library.rs
@@ -26,6 +26,9 @@ macro_rules! set {
 pub struct Library {
     pub pages: AHashMap<PathBuf, Page>,
     pub sections: AHashMap<PathBuf, Section>,
+    // NOTE FOR REVIEW perhaps I can put a property on Page and Section and compute this collection
+    // we want to warn users of potentially unexpected default template renders
+    pub default_templates: Vec<String>,
     // aliases -> files, so we can easily check for conflicts
     pub reverse_aliases: AHashMap<String, AHashSet<PathBuf>>,
     pub translations: AHashMap<PathBuf, AHashSet<PathBuf>>,

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -11,7 +11,9 @@ use errors::{Context, Result};
 use markdown::{render_content, RenderContext};
 use utils::slugs::slugify_paths;
 use utils::table_of_contents::Heading;
-use utils::templates::{render_retrieved_template, retrieve_template_and_default_status, ShortcodeDefinition};
+use utils::templates::{
+    render_retrieved_template, retrieve_template_and_default_status, ShortcodeDefinition,
+};
 use utils::types::InsertAnchor;
 
 use crate::file_info::FileInfo;
@@ -245,10 +247,15 @@ impl Page {
     }
 
     /// Renders the page using the default layout, unless specified in front-matter
-    pub fn render_html_and_get_default_status(&self, tera: &Tera, config: &Config, library: &Library) -> Result<(String, bool)> {
+    pub fn render_html_and_get_default_status(
+        &self,
+        tera: &Tera,
+        config: &Config,
+        library: &Library,
+    ) -> Result<(String, bool)> {
         let tpl_name = match self.meta.template {
             Some(ref l) => l,
-            None => "page.html"
+            None => "page.html",
         };
 
         let mut context = TeraContext::new();
@@ -258,12 +265,13 @@ impl Page {
         context.insert("page", &self.serialize(library));
         context.insert("lang", &self.lang);
 
-        let (retrieved_template, is_default) = retrieve_template_and_default_status(tpl_name, tera, &config.theme)
-            .with_context(|| format!("Failed to retrieve template '{}'", self.file.path.display()))?;
+        let (retrieved_template, is_default) =
+            retrieve_template_and_default_status(tpl_name, tera, &config.theme).with_context(
+                || format!("Failed to retrieve template '{}'", self.file.path.display()),
+            )?;
         let result = render_retrieved_template(retrieved_template, is_default, tera, &context)
             .with_context(|| format!("Failed to render page '{}'", self.file.path.display()))?;
         Ok((result, is_default))
-
     }
 
     /// Creates a vectors of asset URLs.

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -11,7 +11,7 @@ use errors::{Context, Result};
 use markdown::{render_content, RenderContext};
 use utils::slugs::slugify_paths;
 use utils::table_of_contents::Heading;
-use utils::templates::{render_template, ShortcodeDefinition};
+use utils::templates::{render_retrieved_template, retrieve_template_and_default_status, ShortcodeDefinition};
 use utils::types::InsertAnchor;
 
 use crate::file_info::FileInfo;
@@ -245,10 +245,10 @@ impl Page {
     }
 
     /// Renders the page using the default layout, unless specified in front-matter
-    pub fn render_html(&self, tera: &Tera, config: &Config, library: &Library) -> Result<String> {
+    pub fn render_html_and_get_default_status(&self, tera: &Tera, config: &Config, library: &Library) -> Result<(String, bool)> {
         let tpl_name = match self.meta.template {
             Some(ref l) => l,
-            None => "page.html",
+            None => "page.html"
         };
 
         let mut context = TeraContext::new();
@@ -258,8 +258,12 @@ impl Page {
         context.insert("page", &self.serialize(library));
         context.insert("lang", &self.lang);
 
-        render_template(tpl_name, tera, context, &config.theme)
-            .with_context(|| format!("Failed to render page '{}'", self.file.path.display()))
+        let (retrieved_template, is_default) = retrieve_template_and_default_status(tpl_name, tera, &config.theme)
+            .with_context(|| format!("Failed to retrieve template '{}'", self.file.path.display()))?;
+        let result = render_retrieved_template(retrieved_template, is_default, tera, &context)
+            .with_context(|| format!("Failed to render page '{}'", self.file.path.display()))?;
+        Ok((result, is_default))
+
     }
 
     /// Creates a vectors of asset URLs.

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -9,7 +9,9 @@ use markdown::{render_content, RenderContext};
 use utils::fs::read_file;
 use utils::net::is_external_link;
 use utils::table_of_contents::Heading;
-use utils::templates::{render_retrieved_template, retrieve_template_and_default_status, ShortcodeDefinition};
+use utils::templates::{
+    render_retrieved_template, retrieve_template_and_default_status, ShortcodeDefinition,
+};
 
 use crate::file_info::FileInfo;
 use crate::front_matter::{split_section_content, SectionFrontMatter};
@@ -183,7 +185,12 @@ impl Section {
     }
 
     /// Renders the section using the default layout, unless specified in front-matter
-    pub fn render_html_and_get_default_status(&self, tera: &Tera, config: &Config, library: &Library) -> Result<(String, bool)> {
+    pub fn render_html_and_get_default_status(
+        &self,
+        tera: &Tera,
+        config: &Config,
+        library: &Library,
+    ) -> Result<(String, bool)> {
         let tpl_name = self.get_template_name();
 
         let mut context = TeraContext::new();
@@ -193,8 +200,10 @@ impl Section {
         context.insert("section", &SerializingSection::new(self, SectionSerMode::Full(library)));
         context.insert("lang", &self.lang);
 
-        let (retrieved_template, is_default) = retrieve_template_and_default_status(tpl_name, tera, &config.theme)
-            .with_context(|| format!("Failed to retrieve template '{}'", self.file.path.display()))?;
+        let (retrieved_template, is_default) =
+            retrieve_template_and_default_status(tpl_name, tera, &config.theme).with_context(
+                || format!("Failed to retrieve template '{}'", self.file.path.display()),
+            )?;
         let result = render_retrieved_template(retrieved_template, is_default, tera, &context)
             .with_context(|| format!("Failed to render section '{}'", self.file.path.display()))?;
         Ok((result, is_default))

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -9,7 +9,7 @@ use markdown::{render_content, RenderContext};
 use utils::fs::read_file;
 use utils::net::is_external_link;
 use utils::table_of_contents::Heading;
-use utils::templates::{render_template, ShortcodeDefinition};
+use utils::templates::{render_retrieved_template, retrieve_template_and_default_status, ShortcodeDefinition};
 
 use crate::file_info::FileInfo;
 use crate::front_matter::{split_section_content, SectionFrontMatter};
@@ -182,8 +182,8 @@ impl Section {
         Ok(())
     }
 
-    /// Renders the page using the default layout, unless specified in front-matter
-    pub fn render_html(&self, tera: &Tera, config: &Config, library: &Library) -> Result<String> {
+    /// Renders the section using the default layout, unless specified in front-matter
+    pub fn render_html_and_get_default_status(&self, tera: &Tera, config: &Config, library: &Library) -> Result<(String, bool)> {
         let tpl_name = self.get_template_name();
 
         let mut context = TeraContext::new();
@@ -193,8 +193,11 @@ impl Section {
         context.insert("section", &SerializingSection::new(self, SectionSerMode::Full(library)));
         context.insert("lang", &self.lang);
 
-        render_template(tpl_name, tera, context, &config.theme)
-            .with_context(|| format!("Failed to render section '{}'", self.file.path.display()))
+        let (retrieved_template, is_default) = retrieve_template_and_default_status(tpl_name, tera, &config.theme)
+            .with_context(|| format!("Failed to retrieve template '{}'", self.file.path.display()))?;
+        let result = render_retrieved_template(retrieved_template, is_default, tera, &context)
+            .with_context(|| format!("Failed to render section '{}'", self.file.path.display()))?;
+        Ok((result, is_default))
     }
 
     /// Is this the index section?

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -1121,26 +1121,16 @@ impl Site {
                 .pages
                 .par_iter()
                 .map(|k| {
-                    Ok((self.render_page(self.library.read().unwrap().pages.get(k).unwrap())?,
-                    k.display().to_string()))
+                    Ok((
+                        self.render_page(self.library.read().unwrap().pages.get(k).unwrap())?,
+                        k.display().to_string(),
+                    ))
                 })
-                .filter(|item| {
-                    if let Ok(inner) = item {
-                        inner.0
-                    } else {
-                        false
-                    }
-                })
+                .filter(|item| if let Ok(inner) = item { inner.0 } else { false })
                 .collect::<Result<Vec<(bool, String)>>>()?;
 
-            default_path_strings.append(
-                &mut default_info
-                    .into_iter()
-                    .map(|info| {
-                        info.1
-                    })
-                    .collect::<Vec<String>>()
-            );
+            default_path_strings
+                .append(&mut default_info.into_iter().map(|info| info.1).collect::<Vec<String>>());
         }
 
         if !section.meta.render {
@@ -1188,20 +1178,17 @@ impl Site {
     pub fn render_sections(&self) -> Result<()> {
         let nested_info;
         {
-            nested_info = self.library
+            nested_info = self
+                .library
                 .read()
                 .unwrap()
                 .sections
                 .par_iter()
-                .map(|(_, s)| {
-                    self.render_section(s, true)
-                })
+                .map(|(_, s)| self.render_section(s, true))
                 .collect::<Result<Vec<Vec<String>>>>()?;
         }
         let mut default_info = nested_info.into_iter().flatten().collect::<Vec<String>>();
-        self.library.write().unwrap().default_templates.append(
-            &mut default_info
-        );
+        self.library.write().unwrap().default_templates.append(&mut default_info);
         Ok(())
     }
 

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -673,9 +673,17 @@ impl Site {
 
     /// Renders a single content page
     pub fn render_page(&self, page: &Page) -> Result<()> {
-        let (output, is_default) = page.render_html_and_get_default_status(&self.tera, &self.config, &self.library.read().unwrap())?;
+        let (output, is_default) = page.render_html_and_get_default_status(
+            &self.tera,
+            &self.config,
+            &self.library.read().unwrap(),
+        )?;
         if is_default {
-            self.library.write().unwrap().default_templates.push(page.file.path.display().to_string());
+            self.library
+                .write()
+                .unwrap()
+                .default_templates
+                .push(page.file.path.display().to_string());
         }
         let content = self.inject_livereload(output);
         let components: Vec<&str> = page.path.split('/').collect();
@@ -1136,10 +1144,17 @@ impl Site {
                 &Paginator::from_section(section, &self.library.read().unwrap()),
             )?;
         } else {
-            let (output, is_default) =
-                section.render_html_and_get_default_status(&self.tera, &self.config, &self.library.read().unwrap())?;
+            let (output, is_default) = section.render_html_and_get_default_status(
+                &self.tera,
+                &self.config,
+                &self.library.read().unwrap(),
+            )?;
             if is_default {
-                self.library.write().unwrap().default_templates.push(section.file.path.display().to_string());
+                self.library
+                    .write()
+                    .unwrap()
+                    .default_templates
+                    .push(section.file.path.display().to_string());
             }
             let content = self.inject_livereload(output);
             self.write_content(&components, "index.html", content, false)?;

--- a/components/utils/src/templates.rs
+++ b/components/utils/src/templates.rs
@@ -83,7 +83,7 @@ pub fn retrieve_template_and_default_status<'a>(
     match name {
         "index.html" | "section.html" | "page.html" | "single.html" | "list.html" => {
             return Ok((name, true))
-        },
+        }
         _ => bail!("Tried to resolve `{}` but the template wasn't found", name),
     }
 }
@@ -112,8 +112,11 @@ pub fn render_retrieved_template(
                 "https://www.getzola.org/documentation/templates/pages-sections/#page-variables"
             ),
             "single.html" | "list.html" => {
-                render_default_tpl!(template, "https://www.getzola.org/documentation/templates/taxonomies/")
-            },
+                render_default_tpl!(
+                    template,
+                    "https://www.getzola.org/documentation/templates/taxonomies/"
+                )
+            }
             // This is technically unreachable if retrieve_template_and_default_status is called
             // before this function
             _ => bail!("Tried to render `{}` but the template wasn't found", template),

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -32,6 +32,7 @@ pub fn build(
     }
     site.load()?;
     messages::notify_site_size(&site);
+    messages::warn_about_default_templates(&site);
     messages::warn_about_ignored_pages(&site);
     site.build()
 }

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -24,6 +24,7 @@ pub fn check(
     }
     site.load()?;
     messages::check_site_summary(&site);
+    messages::warn_about_default_templates(&site);
     messages::warn_about_ignored_pages(&site);
     Ok(())
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -280,6 +280,7 @@ fn create_new_site(
         site.enable_live_reload(interface_port);
     }
     messages::notify_site_size(&site);
+    messages::warn_about_default_templates(&site);
     messages::warn_about_ignored_pages(&site);
     site.build()?;
     Ok((site, address))

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -280,9 +280,10 @@ fn create_new_site(
         site.enable_live_reload(interface_port);
     }
     messages::notify_site_size(&site);
-    messages::warn_about_default_templates(&site);
+    println!("CANARY 1");
     messages::warn_about_ignored_pages(&site);
     site.build()?;
+    messages::warn_about_default_templates(&site);
     Ok((site, address))
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -32,6 +32,14 @@ pub fn check_site_summary(site: &Site) {
     }
 }
 
+/// Display a warning in the console if there are default templates rendered
+pub fn warn_about_default_templates(site: &Site) {
+    let library = site.library.read().unwrap();
+    for path_string in &library.default_templates {
+        console::warn(&format!("- {} is using the default template", path_string));
+    }
+}
+
 /// Display a warning in the console if there are ignored pages in the site
 pub fn warn_about_ignored_pages(site: &Site) {
     let library = site.library.read().unwrap();

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -34,7 +34,9 @@ pub fn check_site_summary(site: &Site) {
 
 /// Display a warning in the console if there are default templates rendered
 pub fn warn_about_default_templates(site: &Site) {
+    println!("CANARY 2");
     let library = site.library.read().unwrap();
+    println!("{:?}", library.default_templates);
     for path_string in &library.default_templates {
         console::warn(&format!("- {} is using the default template", path_string));
     }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?

---
Issue #2135 
SO, I manually tested this a bit and it worked as best I could tell.
I ended up having to dig pretty far into code for rendering templates and then bubble information up about whether or not a default template was rendered.
Besides the arguable ugliness of this approach, it also means that it doesn't work for zola check as the build has to happen.
There should be some simpler way to check all of the templates without building...I will think about it now that I'm getting more familiar with the code and I am also open to suggestions. I may be able to work on this later today yet, we'll see.

IF this approach is acceptable, at the very least I want to do a cleanup pass and add some comments/documentation.

