### PR TITLE
Complete output for get_taxonomy in the documentation

### DIFF
--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -172,6 +172,8 @@ The type of the output is:
 ```ts
 kind: TaxonomyConfig;
 items: Array<TaxonomyTerm>;
+lang: String;
+permalink: String;
 ```
 
 `lang` (optional) default to `config.default_language` in config.toml


### PR DESCRIPTION
The current documentation on the tera function `get_taxonomy` does not mention either `lang` or `permalink` fields, that are nonetheless returned by the function as the following template extract shows:
```jinja2
{%- set taxonomy_config = get_taxonomy(kind="tags", lang="en") %}
<ul>
    <li>taxonomy_config.lang = {{ taxonomy_config.lang }}</li>
    <li>taxonomy_config.kind = {{ taxonomy_config.kind }}</li>
    <li>taxonomy_config.permalink = {{ taxonomy_config.permalink }}</li>
    <li>taxonomy_config.items = {{ taxonomy_config.items }}</li>
</ul>
```
This PR simply adds the two fields to the type of output for `get_taxonomy` in the documentation.