### PR TITLE
Add support for lazy loading images

### DIFF
--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -51,6 +51,8 @@ pub struct Markdown {
     /// The compiled extra themes into a theme set
     #[serde(skip_serializing, skip_deserializing)] // not a typo, 2 are need
     pub extra_theme_set: Arc<Option<ThemeSet>>,
+    /// Add loading="lazy" decoding="async" to img tags. When turned on, the alt text must be plain text. Defaults to false
+    pub lazy_async_image: bool,
 }
 
 impl Markdown {
@@ -204,6 +206,7 @@ impl Default for Markdown {
             extra_syntaxes_and_themes: vec![],
             extra_syntax_set: None,
             extra_theme_set: Arc::new(None),
+            lazy_async_image: false,
         }
     }
 }

--- a/components/markdown/tests/img.rs
+++ b/components/markdown/tests/img.rs
@@ -1,0 +1,48 @@
+mod common;
+use config::Config;
+
+#[test]
+fn can_transform_image() {
+    // normal image
+    let rendered = common::render("![haha](https://example.com/abc.jpg)").unwrap().body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" /></p>\n");
+
+    // alt text with style
+    let rendered = common::render("![__ha__*ha*](https://example.com/abc.jpg)").unwrap().body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" /></p>\n");
+
+    // alt text with link
+    let rendered =
+        common::render("![ha[ha](https://example.com)](https://example.com/abc.jpg)").unwrap().body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" /></p>\n");
+}
+
+#[test]
+fn can_add_lazy_loading_and_async_decoding() {
+    // normal alt text
+    let mut config = Config::default_for_test();
+    config.markdown.lazy_async_image = true;
+    let rendered =
+        common::render_with_config("![haha](https://example.com/abc.jpg)", config.clone())
+            .unwrap()
+            .body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" loading=\"lazy\" decoding=\"async\" /></p>\n");
+
+    // Below is acceptable, but not recommended by CommonMark
+
+    // alt text with style
+    let rendered =
+        common::render_with_config("![__ha__*ha*](https://example.com/abc.jpg)", config.clone())
+            .unwrap()
+            .body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"<strong>ha</strong><em>ha</em>\" loading=\"lazy\" decoding=\"async\" /></p>\n");
+
+    // alt text with link
+    let rendered = common::render_with_config(
+        "![ha[ha](https://example.com)](https://example.com/abc.jpg)",
+        config.clone(),
+    )
+    .unwrap()
+    .body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"ha<a href=\"https://example.com\">ha</a>\" loading=\"lazy\" decoding=\"async\" /></p>\n");
+}

--- a/components/markdown/tests/img.rs
+++ b/components/markdown/tests/img.rs
@@ -7,6 +7,14 @@ fn can_transform_image() {
     let rendered = common::render("![haha](https://example.com/abc.jpg)").unwrap().body;
     assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" /></p>\n");
 
+    // empty alt text
+    let rendered = common::render("![](https://example.com/abc.jpg)").unwrap().body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"\" /></p>\n");
+
+    // alt text needs to be escaped
+    let rendered = common::render("![ha\"h>a](https://example.com/abc.jpg)").unwrap().body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"ha&quot;h&gt;a\" /></p>\n");
+
     // alt text with style
     let rendered = common::render("![__ha__*ha*](https://example.com/abc.jpg)").unwrap().body;
     assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" /></p>\n");
@@ -19,14 +27,28 @@ fn can_transform_image() {
 
 #[test]
 fn can_add_lazy_loading_and_async_decoding() {
-    // normal alt text
     let mut config = Config::default_for_test();
     config.markdown.lazy_async_image = true;
+
+    // normal alt text
     let rendered =
         common::render_with_config("![haha](https://example.com/abc.jpg)", config.clone())
             .unwrap()
             .body;
     assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" loading=\"lazy\" decoding=\"async\" /></p>\n");
+
+    // empty alt text
+    let rendered = common::render_with_config("![](https://example.com/abc.jpg)", config.clone())
+        .unwrap()
+        .body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"\" loading=\"lazy\" decoding=\"async\" /></p>\n");
+
+    // alt text needs to be escaped
+    let rendered =
+        common::render_with_config("![ha\"h>a](https://example.com/abc.jpg)", config.clone())
+            .unwrap()
+            .body;
+    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"ha&quot;h&gt;a\" loading=\"lazy\" decoding=\"async\" /></p>\n");
 
     // Below is acceptable, but not recommended by CommonMark
 

--- a/components/markdown/tests/img.rs
+++ b/components/markdown/tests/img.rs
@@ -3,68 +3,31 @@ use config::Config;
 
 #[test]
 fn can_transform_image() {
-    // normal image
-    let rendered = common::render("![haha](https://example.com/abc.jpg)").unwrap().body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" /></p>\n");
+    let cases = vec![
+        "![haha](https://example.com/abc.jpg)",
+        "![](https://example.com/abc.jpg)",
+        "![ha\"h>a](https://example.com/abc.jpg)",
+        "![__ha__*ha*](https://example.com/abc.jpg)",
+        "![ha[ha](https://example.com)](https://example.com/abc.jpg)",
+    ];
 
-    // empty alt text
-    let rendered = common::render("![](https://example.com/abc.jpg)").unwrap().body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"\" /></p>\n");
-
-    // alt text needs to be escaped
-    let rendered = common::render("![ha\"h>a](https://example.com/abc.jpg)").unwrap().body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"ha&quot;h&gt;a\" /></p>\n");
-
-    // alt text with style
-    let rendered = common::render("![__ha__*ha*](https://example.com/abc.jpg)").unwrap().body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" /></p>\n");
-
-    // alt text with link
-    let rendered =
-        common::render("![ha[ha](https://example.com)](https://example.com/abc.jpg)").unwrap().body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" /></p>\n");
+    let body = common::render(&cases.join("\n")).unwrap().body;
+    insta::assert_snapshot!(body);
 }
 
 #[test]
 fn can_add_lazy_loading_and_async_decoding() {
+    let cases = vec![
+        "![haha](https://example.com/abc.jpg)",
+        "![](https://example.com/abc.jpg)",
+        "![ha\"h>a](https://example.com/abc.jpg)",
+        "![__ha__*ha*](https://example.com/abc.jpg)",
+        "![ha[ha](https://example.com)](https://example.com/abc.jpg)",
+    ];
+
     let mut config = Config::default_for_test();
     config.markdown.lazy_async_image = true;
 
-    // normal alt text
-    let rendered =
-        common::render_with_config("![haha](https://example.com/abc.jpg)", config.clone())
-            .unwrap()
-            .body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"haha\" loading=\"lazy\" decoding=\"async\" /></p>\n");
-
-    // empty alt text
-    let rendered = common::render_with_config("![](https://example.com/abc.jpg)", config.clone())
-        .unwrap()
-        .body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"\" loading=\"lazy\" decoding=\"async\" /></p>\n");
-
-    // alt text needs to be escaped
-    let rendered =
-        common::render_with_config("![ha\"h>a](https://example.com/abc.jpg)", config.clone())
-            .unwrap()
-            .body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"ha&quot;h&gt;a\" loading=\"lazy\" decoding=\"async\" /></p>\n");
-
-    // Below is acceptable, but not recommended by CommonMark
-
-    // alt text with style
-    let rendered =
-        common::render_with_config("![__ha__*ha*](https://example.com/abc.jpg)", config.clone())
-            .unwrap()
-            .body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"<strong>ha</strong><em>ha</em>\" loading=\"lazy\" decoding=\"async\" /></p>\n");
-
-    // alt text with link
-    let rendered = common::render_with_config(
-        "![ha[ha](https://example.com)](https://example.com/abc.jpg)",
-        config.clone(),
-    )
-    .unwrap()
-    .body;
-    assert_eq!(rendered, "<p><img src=\"https://example.com/abc.jpg\" alt=\"ha<a href=\"https://example.com\">ha</a>\" loading=\"lazy\" decoding=\"async\" /></p>\n");
+    let body = common::render_with_config(&cases.join("\n"), config).unwrap().body;
+    insta::assert_snapshot!(body);
 }

--- a/components/markdown/tests/snapshots/img__can_add_lazy_loading_and_async_decoding.snap
+++ b/components/markdown/tests/snapshots/img__can_add_lazy_loading_and_async_decoding.snap
@@ -1,0 +1,10 @@
+---
+source: components/markdown/tests/img.rs
+expression: body
+---
+<p><img src="https://example.com/abc.jpg" alt="haha" loading="lazy" decoding="async" />
+<img src="https://example.com/abc.jpg" alt="" loading="lazy" decoding="async" />
+<img src="https://example.com/abc.jpg" alt="ha&quot;h&gt;a" loading="lazy" decoding="async" />
+<img src="https://example.com/abc.jpg" alt="<strong>ha</strong><em>ha</em>" loading="lazy" decoding="async" />
+<img src="https://example.com/abc.jpg" alt="ha<a href="https://example.com">ha</a>" loading="lazy" decoding="async" /></p>
+

--- a/components/markdown/tests/snapshots/img__can_transform_image.snap
+++ b/components/markdown/tests/snapshots/img__can_transform_image.snap
@@ -1,0 +1,10 @@
+---
+source: components/markdown/tests/img.rs
+expression: body
+---
+<p><img src="https://example.com/abc.jpg" alt="haha" />
+<img src="https://example.com/abc.jpg" alt="" />
+<img src="https://example.com/abc.jpg" alt="ha&quot;h&gt;a" />
+<img src="https://example.com/abc.jpg" alt="haha" />
+<img src="https://example.com/abc.jpg" alt="haha" /></p>
+

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -122,6 +122,11 @@ external_links_no_referrer = false
 # For example, `...` into `…`, `"quote"` into `“curly”` etc
 smart_punctuation = false
 
+# Whether to set decoding="async" and loading="lazy" for all images
+# When turned on, the alt text must be plain text.
+# For example, `![xx](...)` is ok but `![*x*x](...)` isn’t ok
+lazy_async_image = false
+
 # Configuration of the link checker.
 [link_checker]
 # Skip link checking for external URLs that start with these prefixes


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?

---

Recently I learnt `loading="lazy" decoding="async"` and wanted to try them in my Zola-powered blog, then I found issue #2055 requesting `loading="lazy"`.
Given that issue has been marked by “help wanted”, I decided to give it a try, hence this PR.

This PR adds an option `lazy_async_image` to set `loading="lazy" decoding="async"` for images.
The `loading="lazy"` part is discussed in the issue, I can delete `decoding="async"` part if that’s too far.

The alt text in pulldown-cmark is enclosed within `Start(Image)` and `End(Image)`, and can contain styles (<https://github.com/raphlinus/pulldown-cmark/issues/394#issuecomment-527197423>).
I think most people will only use plain text in alt text so I didn’t bother cleaning the styles because “Having something simple and easy to use for 90% of the usecases is more interesting than covering 100% usecases after sacrificing simplicity.”
That said, there might be people want to use styles, links or even inline HTML for alt text, so the documentation includes a note on the limitation of the `lazy_async_image` option.

I added a small test to demonstrate the difference between the output of pulldown-cmark and mine. I also tested the program against my blog.