### PR TITLE
Using cargo install

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -199,10 +199,13 @@ Zola does not work in PowerShell ISE.
 To build Zola from source, you will need to have Git, [Rust and Cargo](https://www.rust-lang.org/)
 installed.
 
-From a terminal, you can now run the following command:
+From a terminal, you can now run the following commands:
 
 ```sh
-$ cargo build --release
+$ git clone https://github.com/getzola/zola.git
+$ cd zola
+$ cargo install --path .
+$ zola --version
 ```
 
 If you encountered compilation errors like `error: failed to run custom build command for 'ring v0.16.20'`, you can try the command below instead:
@@ -212,5 +215,10 @@ $ cargo build --release --no-default-features --features=native-tls
 ```
 
 The binary will be available in the `target/release` directory. You can move it in your `$PATH` to have the
-`zola` command available globally or in a directory if you want for example to have the binary in the
-same repository as the site.
+`zola` command available globally:
+
+```sh
+$ cp target/release/zola ~/.cargo/bin/zola
+```
+
+or in a directory if you want for example to have the binary in the same repository as the site.


### PR DESCRIPTION
The tool is automatically built and added to the path when using `$ cargo install --path .`. It simplifies running Zola from the source.