### PR TITLE
always sort assets by filename (Windows/Linux difference)

### DIFF
--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -87,13 +87,20 @@ mod tests {
         create_dir(path.join("subdir")).expect("create subdir temp dir");
         File::create(path.join("subdir").join("index.md")).unwrap();
         File::create(path.join("subdir").join("example.js")).unwrap();
+        File::create(path.join("FFF.txt")).unwrap();
+        File::create(path.join("GRAPH.txt")).unwrap();
+        File::create(path.join("subdir").join("GGG.txt")).unwrap();
 
         let assets = find_related_assets(path, &Config::default(), true);
-        assert_eq!(assets.len(), 4);
-        assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or_default() != "md").count(), 4);
+        assert_eq!(assets.len(), 7);
+        assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or_default() != "md").count(), 7);
 
-        for asset in ["example.js", "graph.jpg", "fail.png", "subdir/example.js"] {
+        for asset in ["example.js", "graph.jpg", "fail.png", "subdir/example.js", "FFF.txt", "GRAPH.txt", "subdir/GGG.txt"] {
             assert!(assets.iter().any(|p| p.strip_prefix(path).unwrap() == Path::new(asset)))
+        }
+
+        for w in assets.windows(2) {
+	        assert!(w[0].to_str().unwrap().to_ascii_lowercase() < w[1].to_str().unwrap().to_ascii_lowercase());
         }
     }
 

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -122,12 +122,18 @@ mod tests {
         create_dir(path.join("subdir")).expect("create subdir temp dir");
         File::create(path.join("subdir").join("index.md")).unwrap();
         File::create(path.join("subdir").join("example.js")).unwrap();
-        let assets = find_related_assets(path, &Config::default(), false);
-        assert_eq!(assets.len(), 3);
-        assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or_default() != "md").count(), 3);
+        File::create(path.join("FFF.txt")).unwrap();
+        File::create(path.join("GRAPH.txt")).unwrap();
+        File::create(path.join("subdir").join("GGG.txt")).unwrap();
 
-        for asset in ["example.js", "graph.jpg", "fail.png"] {
-            assert!(assets.iter().any(|p| p.strip_prefix(path).unwrap() == Path::new(asset)))
+        let assets = find_related_assets(path, &Config::default(), false);
+        assert_eq!(assets.len(), 5);
+        assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or_default() != "md").count(), 5);
+
+        let mut assets_iter = assets.iter();
+        // Use case-insensitive ordering
+        for asset in ["example.js", "fail.png", "FFF.txt", "graph.jpg", "GRAPH.txt"] {
+            assert!(assets_iter.next().unwrap().strip_prefix(path).unwrap() == Path::new(asset));
         }
     }
     #[test]

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -95,9 +95,8 @@ mod tests {
         assert_eq!(assets.len(), 7);
         assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or_default() != "md").count(), 7);
 
-        let mut assets_iter = assets.iter();
-        // Use case-insensitive ordering
-        for asset in [
+        // Use case-insensitive ordering for testassets
+        let testassets = [
             "example.js",
             "fail.png",
             "FFF.txt",
@@ -105,8 +104,14 @@ mod tests {
             "GRAPH.txt",
             "subdir/example.js",
             "subdir/GGG.txt",
-        ] {
-            assert!(assets_iter.next().unwrap().strip_prefix(path).unwrap() == Path::new(asset));
+        ];
+        for (asset, testasset) in assets.iter().zip(testassets.iter()) {
+            assert!(
+                asset.strip_prefix(path).unwrap() == Path::new(testasset),
+                "Mismatch between asset {} and testasset {}",
+                asset.to_str().unwrap(),
+                testasset
+            );
         }
     }
 
@@ -130,10 +135,15 @@ mod tests {
         assert_eq!(assets.len(), 5);
         assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or_default() != "md").count(), 5);
 
-        let mut assets_iter = assets.iter();
-        // Use case-insensitive ordering
-        for asset in ["example.js", "fail.png", "FFF.txt", "graph.jpg", "GRAPH.txt"] {
-            assert!(assets_iter.next().unwrap().strip_prefix(path).unwrap() == Path::new(asset));
+        // Use case-insensitive ordering for testassets
+        let testassets = ["example.js", "fail.png", "FFF.txt", "graph.jpg", "GRAPH.txt"];
+        for (asset, testasset) in assets.iter().zip(testassets.iter()) {
+            assert!(
+                asset.strip_prefix(path).unwrap() == Path::new(testasset),
+                "Mismatch between asset {} and testasset {}",
+                asset.to_str().unwrap(),
+                testasset
+            );
         }
     }
     #[test]

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -95,12 +95,23 @@ mod tests {
         assert_eq!(assets.len(), 7);
         assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or_default() != "md").count(), 7);
 
-        for asset in ["example.js", "graph.jpg", "fail.png", "subdir/example.js", "FFF.txt", "GRAPH.txt", "subdir/GGG.txt"] {
+        for asset in [
+            "example.js",
+            "graph.jpg",
+            "fail.png",
+            "subdir/example.js",
+            "FFF.txt",
+            "GRAPH.txt",
+            "subdir/GGG.txt",
+        ] {
             assert!(assets.iter().any(|p| p.strip_prefix(path).unwrap() == Path::new(asset)))
         }
 
         for w in assets.windows(2) {
-	        assert!(w[0].to_str().unwrap().to_ascii_lowercase() < w[1].to_str().unwrap().to_ascii_lowercase());
+            assert!(
+                w[0].to_str().unwrap().to_ascii_lowercase()
+                    < w[1].to_str().unwrap().to_ascii_lowercase()
+            );
         }
     }
 

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -95,23 +95,18 @@ mod tests {
         assert_eq!(assets.len(), 7);
         assert_eq!(assets.iter().filter(|p| p.extension().unwrap_or_default() != "md").count(), 7);
 
+        let mut assets_iter = assets.iter();
+        // Use case-insensitive ordering
         for asset in [
             "example.js",
-            "graph.jpg",
             "fail.png",
-            "subdir/example.js",
             "FFF.txt",
+            "graph.jpg",
             "GRAPH.txt",
+            "subdir/example.js",
             "subdir/GGG.txt",
         ] {
-            assert!(assets.iter().any(|p| p.strip_prefix(path).unwrap() == Path::new(asset)))
-        }
-
-        for w in assets.windows(2) {
-            assert!(
-                w[0].to_str().unwrap().to_ascii_lowercase()
-                    < w[1].to_str().unwrap().to_ascii_lowercase()
-            );
+            assert!(assets_iter.next().unwrap().strip_prefix(path).unwrap() == Path::new(asset));
         }
     }
 

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -25,6 +25,7 @@ pub fn has_anchor(headings: &[Heading], anchor: &str) -> bool {
 /// If `recursive` is set to `true`, it will add all subdirectories assets as well. This should
 /// only be set when finding page assets currently.
 /// TODO: remove this flag once sections with assets behave the same as pages with assets
+/// The returned vector with assets is sorted in case-sensitive order (using `to_ascii_lowercase()`)
 pub fn find_related_assets(path: &Path, config: &Config, recursive: bool) -> Vec<PathBuf> {
     let mut assets = vec![];
 
@@ -49,6 +50,10 @@ pub fn find_related_assets(path: &Path, config: &Config, recursive: bool) -> Vec
     if let Some(ref globset) = config.ignored_content_globset {
         assets.retain(|p| !globset.is_match(p));
     }
+
+    assets.sort_by(|a, b| {
+        a.to_str().unwrap().to_ascii_lowercase().cmp(&b.to_str().unwrap().to_ascii_lowercase())
+    });
 
     assets
 }


### PR DESCRIPTION
For me the `page.assets` items are sorted differently on Windows and Linux. Zola on Windows sorts assets alphabetically, for Linux the sorting is kinda arbitrary as shown below:
```
aaa.txt
ddd.txt
ccc.txt
bbb.txt
```

It's no big deal, and could also be fixed using `page.assets | sort`, but this differing  between platforms is not what one would expect.

A small patch is attached. The patch modifies `find_related_assets` to use the walkdir option [`sort_by_file_name`](https://docs.rs/walkdir/latest/walkdir/struct.WalkDir.html#method.sort_by_file_name) (docs hints that the order isn't guaranteed  otherwise). Feel free to accept or reject the patch.

## Using
Zola version: 1.7.2
Windows 11 + Debian (PopOS 22.04)

## Step to reproduce

Re-create the asset files using the scripts below. They're reversed, checking if Linux sorts by date (it does not).

### Windows powershell
```
New-Item ddd.txt
sleep 2
New-Item ccc.txt
sleep 2
New-Item bbb.txt
sleep 2
New-Item aaa.txt
```

### Linux/BSD
```
touch ddd.txt
sleep 2
touch ccc.txt
sleep 2
touch bbb.txt
sleep 2
touch aaa.txt
```