### PR TITLE
Prevent spans crossing line boundaries in class-based code block formatter

### DIFF
--- a/components/markdown/src/codeblock/mod.rs
+++ b/components/markdown/src/codeblock/mod.rs
@@ -168,10 +168,6 @@ impl<'config> CodeBlock<'config> {
             }
         }
 
-        if let Some(rest) = self.highlighter.finalize() {
-            buffer.push_str(&rest);
-        }
-
         if self.line_numbers {
             buffer.push_str("</tbody></table>");
         }

--- a/components/markdown/tests/codeblocks.rs
+++ b/components/markdown/tests/codeblocks.rs
@@ -2,9 +2,24 @@ use config::Config;
 
 mod common;
 
-fn render_codeblock(content: &str, highlight_code: bool) -> String {
+enum HighlightMode {
+    None,
+    Inlined,
+    Classed,
+}
+
+fn render_codeblock(content: &str, highlight_mode: HighlightMode) -> String {
     let mut config = Config::default_for_test();
-    config.markdown.highlight_code = highlight_code;
+    match highlight_mode {
+        HighlightMode::None => {}
+        HighlightMode::Inlined => {
+            config.markdown.highlight_code = true;
+        }
+        HighlightMode::Classed => {
+            config.markdown.highlight_code = true;
+            config.markdown.highlight_theme = "css".to_owned();
+        }
+    }
     common::render_with_config(content, config).unwrap().body
 }
 
@@ -17,7 +32,7 @@ foo
 bar
 ```
     "#,
-        false,
+        HighlightMode::None,
     );
     insta::assert_snapshot!(body);
 }
@@ -33,7 +48,7 @@ baz
 bat
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -49,7 +64,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -65,7 +80,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -81,7 +96,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -97,7 +112,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     let body2 = render_codeblock(
         r#"
@@ -108,7 +123,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     assert_eq!(body, body2);
 }
@@ -124,7 +139,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -140,7 +155,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -156,7 +171,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -172,7 +187,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -188,7 +203,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -204,7 +219,7 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -220,7 +235,24 @@ bar
 baz
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
+    );
+    insta::assert_snapshot!(body);
+}
+
+#[test]
+fn can_highlight_with_classes() {
+    let body = render_codeblock(
+        r#"
+```html,hl_lines=3-4
+<link
+    rel="stylesheet"
+    type="text/css"
+    href="main.css"
+/>
+```
+    "#,
+        HighlightMode::Classed,
     );
     insta::assert_snapshot!(body);
 }
@@ -234,14 +266,14 @@ foo
 bar
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
 
 #[test]
 fn can_add_line_numbers_windows_eol() {
-    let body = render_codeblock("```linenos\r\nfoo\r\nbar\r\n```\r\n", true);
+    let body = render_codeblock("```linenos\r\nfoo\r\nbar\r\n```\r\n", HighlightMode::Inlined);
     insta::assert_snapshot!(body);
 }
 
@@ -254,7 +286,7 @@ foo
 bar
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -268,7 +300,24 @@ foo
 bar
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
+    );
+    insta::assert_snapshot!(body);
+}
+
+#[test]
+fn can_add_line_numbers_with_classes() {
+    let body = render_codeblock(
+        r#"
+```html,linenos
+<link
+    rel="stylesheet"
+    type="text/css"
+    href="main.css"
+/>
+```
+    "#,
+        HighlightMode::Classed,
     );
     insta::assert_snapshot!(body);
 }
@@ -283,7 +332,7 @@ fn can_render_shortcode_in_codeblock() {
 </div>
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -300,7 +349,7 @@ text2
 text3
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -323,7 +372,7 @@ A quote
 <!-- end text goes here -->
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }
@@ -337,7 +386,7 @@ foo
 bar
 ```
     "#,
-        true,
+        HighlightMode::Inlined,
     );
     insta::assert_snapshot!(body);
 }

--- a/components/markdown/tests/snapshots/codeblocks__can_add_line_numbers_with_classes.snap
+++ b/components/markdown/tests/snapshots/codeblocks__can_add_line_numbers_with_classes.snap
@@ -1,0 +1,11 @@
+---
+source: components/markdown/tests/codeblocks.rs
+expression: body
+---
+<pre data-linenos data-lang="html" class="language-html z-code"><code class="language-html" data-lang="html"><table><tbody><tr><td>1</td><td><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html"><span class="z-punctuation z-definition z-tag z-begin z-html">&lt;</span><span class="z-entity z-name z-tag z-inline z-any z-html">link</span>
+</span></span></td></tr><tr><td>2</td><td><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html">    <span class="z-meta z-attribute-with-value z-html"><span class="z-entity z-other z-attribute-name z-html">rel</span><span class="z-punctuation z-separator z-key-value z-html">=</span><span class="z-string z-quoted z-double z-html"><span class="z-punctuation z-definition z-string z-begin z-html">&quot;</span>stylesheet<span class="z-punctuation z-definition z-string z-end z-html">&quot;</span></span></span>
+</span></span></td></tr><tr><td>3</td><td><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html">    <span class="z-meta z-attribute-with-value z-html"><span class="z-entity z-other z-attribute-name z-html">type</span><span class="z-punctuation z-separator z-key-value z-html">=</span><span class="z-string z-quoted z-double z-html"><span class="z-punctuation z-definition z-string z-begin z-html">&quot;</span>text/css<span class="z-punctuation z-definition z-string z-end z-html">&quot;</span></span></span>
+</span></span></td></tr><tr><td>4</td><td><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html">    <span class="z-meta z-attribute-with-value z-html"><span class="z-entity z-other z-attribute-name z-html">href</span><span class="z-punctuation z-separator z-key-value z-html">=</span><span class="z-string z-quoted z-double z-html"><span class="z-punctuation z-definition z-string z-begin z-html">&quot;</span>main.css<span class="z-punctuation z-definition z-string z-end z-html">&quot;</span></span></span>
+</span></span></td></tr><tr><td>5</td><td><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html"><span class="z-punctuation z-definition z-tag z-end z-html">/&gt;</span></span>
+</span></td></tr></tbody></table></code></pre>
+

--- a/components/markdown/tests/snapshots/codeblocks__can_highlight_with_classes.snap
+++ b/components/markdown/tests/snapshots/codeblocks__can_highlight_with_classes.snap
@@ -1,0 +1,11 @@
+---
+source: components/markdown/tests/codeblocks.rs
+expression: body
+---
+<pre data-lang="html" class="language-html z-code"><code class="language-html" data-lang="html"><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html"><span class="z-punctuation z-definition z-tag z-begin z-html">&lt;</span><span class="z-entity z-name z-tag z-inline z-any z-html">link</span>
+</span></span><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html">    <span class="z-meta z-attribute-with-value z-html"><span class="z-entity z-other z-attribute-name z-html">rel</span><span class="z-punctuation z-separator z-key-value z-html">=</span><span class="z-string z-quoted z-double z-html"><span class="z-punctuation z-definition z-string z-begin z-html">&quot;</span>stylesheet<span class="z-punctuation z-definition z-string z-end z-html">&quot;</span></span></span>
+</span></span><mark><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html">    <span class="z-meta z-attribute-with-value z-html"><span class="z-entity z-other z-attribute-name z-html">type</span><span class="z-punctuation z-separator z-key-value z-html">=</span><span class="z-string z-quoted z-double z-html"><span class="z-punctuation z-definition z-string z-begin z-html">&quot;</span>text/css<span class="z-punctuation z-definition z-string z-end z-html">&quot;</span></span></span>
+</span></span></mark><mark><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html">    <span class="z-meta z-attribute-with-value z-html"><span class="z-entity z-other z-attribute-name z-html">href</span><span class="z-punctuation z-separator z-key-value z-html">=</span><span class="z-string z-quoted z-double z-html"><span class="z-punctuation z-definition z-string z-begin z-html">&quot;</span>main.css<span class="z-punctuation z-definition z-string z-end z-html">&quot;</span></span></span>
+</span></span></mark><span class="z-text z-html z-basic"><span class="z-meta z-tag z-inline z-any z-html"><span class="z-punctuation z-definition z-tag z-end z-html">/&gt;</span></span>
+</span></code></pre>
+


### PR DESCRIPTION
The class-based code block formatter has bad interactions with other line-based highlighting effects (`linenos`, `hl_lines`) because the spans it generates cross multiple lines. This patch copies the `scope_to_classes` function from syntect and uses it to make each line independent of one another when using class-based highlighting.

The `SyntaxHighlighter::finalize` method has also been removed in this patch, as it has been rendered unnecessary.

This greatly increases the number of `<span>` tags generated by the formatter, even in code blocks that don't make use of line-based highlighting effects. I would be happy to implement a mechanism to only split the spans when it would otherwise cause problems, and keep the previous nesting behaviour elsewhere.

Fixes #1942