### PR TITLE
docs(deploy-gh-pages): add workflow permissions

### DIFF
--- a/docs/content/documentation/deployment/github-pages.md
+++ b/docs/content/documentation/deployment/github-pages.md
@@ -35,6 +35,7 @@ Let's start with the token. Remember, if you are publishing the site on the same
 For creating the token either click on [here](https://github.com/settings/tokens/new?scopes=public_repo) or go to Settings > Developer Settings > Personal access tokens. Under the *Select Scopes* section, give it *public_repo* permissions and click *Generate token*. Then copy the token, navigate to your repository and add in the Settings tab the *Secret* `TOKEN` and paste your token in it.
 
 Next we need to create the *Github Action*. Here we can make use of the [zola-deploy-action](https://github.com/shalzz/zola-deploy-action). Go to the *Actions* tab of your repository, click on *set up a workflow yourself* to get a blank workflow file. Copy the following script into it and commit it afterwards; note that you may need to change the `github.ref` branch from `main` to `master` or similar, as the action will only run for the branch you choose.
+If you get a permissions denied error, you may need to change the workflow permissions to read and write in Settings > Actions > Workflow permissions.
 
 ```yaml
 # On every push this script is executed


### PR DESCRIPTION
Adds a reminder to change the workflow permissions to read and write for deployment to GitHub pages. This should fix bugs like https://github.com/shalzz/zola-deploy-action/issues/77.
While this is already documented in https://github.com/shalzz/zola-deploy-action/pull/59, I think it is worth adding as it can easily be overlooked or the user may not have visited the deploy action repo when following the documentation.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

