### PR TITLE
Atom template authors

### DIFF
--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -680,6 +680,11 @@ fn can_build_feeds() {
     assert!(file_contains!(public, "posts/tutorials/programming/atom.xml", "Rust"));
     // It doesn't contain articles from other sections
     assert!(!file_contains!(public, "posts/tutorials/programming/atom.xml", "Extra Syntax"));
+
+    // Test Atom feed entry with 3 authors
+    assert!(file_contains!(public, "posts/tutorials/programming/atom.xml", "Foo Doe"));
+    assert!(file_contains!(public, "posts/tutorials/programming/atom.xml", "Bar Doe"));
+    assert!(file_contains!(public, "posts/tutorials/programming/atom.xml", "Baz Doe"));
 }
 
 #[test]

--- a/components/templates/src/builtins/atom.xml
+++ b/components/templates/src/builtins/atom.xml
@@ -24,17 +24,23 @@
         <title>{{ page.title }}</title>
         <published>{{ page.date | date(format="%+") }}</published>
         <updated>{{ page.updated | default(value=page.date) | date(format="%+") }}</updated>
+        {% for author in page.authors %}
         <author>
           <name>
-            {%- if page.authors -%}
-              {{ page.authors[0] }}
-            {%- elif config.author -%}
+            {{ author }}
+          </name>
+        </author>
+        {% else %}
+        <author>
+          <name>
+            {%- if config.author -%}
               {{ config.author }}
             {%- else -%}
               Unknown
             {%- endif -%}
           </name>
         </author>
+        {% endfor %}
         <link rel="alternate" href="{{ page.permalink | safe }}" type="text/html"/>
         <id>{{ page.permalink | safe }}</id>
         {% if page.summary %}

--- a/test_site/content/posts/tutorials/programming/rust.md
+++ b/test_site/content/posts/tutorials/programming/rust.md
@@ -2,6 +2,7 @@
 title = "Rust"
 weight = 2
 date = 2017-01-01
+authors = ["Foo Doe", "Bar Doe", "Baz Doe"]
 +++
 
 A simple page


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?

---

Atom 1.0 [0] support multiple `<author>` entries in the feed. This commit modified the template to generate as many `<author>` as the page's metadata contains.

Forum post: https://zola.discourse.group/t/why-the-default-feed-templates-only-use-the-first-author/1738

[0] https://validator.w3.org/feed/docs/atom.html#recommendedEntryElements


