### PR TITLE
Add attributes to base_url link in atom template

### DIFF
--- a/components/templates/src/builtins/atom.xml
+++ b/components/templates/src/builtins/atom.xml
@@ -8,8 +8,8 @@
     {%- if config.description %}
     <subtitle>{{ config.description }}</subtitle>
     {%- endif %}
-    <link href="{{ feed_url | safe }}" rel="self" type="application/atom+xml"/>
-    <link href="
+    <link rel="self" type="application/atom+xml" href="{{ feed_url | safe }}"/>
+    <link rel="alternate" type="text/html" href="
       {%- if section -%}
         {{ section.permalink | escape_xml | safe }}
       {%- else -%}
@@ -35,7 +35,7 @@
             {%- endif -%}
           </name>
         </author>
-        <link rel="alternate" href="{{ page.permalink | safe }}" type="text/html"/>
+        <link rel="alternate" type="text/html" href="{{ page.permalink | safe }}"/>
         <id>{{ page.permalink | safe }}</id>
         {% if page.summary %}
         <summary type="html">{{ page.summary }}</summary>


### PR DESCRIPTION
The `rel` and `type` HTML attributes are needed in the `base_url` (or `section.permalink`) link so feed aggregators know that's the HTML page that corresponds to the atom feed.

Note: The RSS template doesn't have this issue.

----

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



