### PR TITLE
[docs] Add drafts to serve command in tutorial

### DIFF
--- a/docs/content/documentation/getting-started/overview.md
+++ b/docs/content/documentation/getting-started/overview.md
@@ -70,7 +70,7 @@ Let's start the Zola development server within the newly created `myblog` direct
 
 ```bash
 $ cd myblog
-$ zola serve
+$ zola serve --draft
 Building site...
 Checking all internal links with anchors.
 > Successfully checked 0 internal link(s) with anchors.


### PR DESCRIPTION

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
  * Did a quick search for "draft"; didn't find any

If following the [tutorial](https://www.getzola.org/documentation/getting-started/overview/) as is won't work because Zola defaults to *NOT* render draft blog posts. 

This change just enables draft serving. Another solution would be to mark the posts as `draft = false`

It might also be a good idea to mention the draft concept in the guide