### PR TITLE
(Docs) Fix styling conflict for code tags within li elements

### DIFF
--- a/docs/sass/_base.scss
+++ b/docs/sass/_base.scss
@@ -108,7 +108,7 @@ pre table td:nth-of-type(1) {
   user-select: none;
 }
 
-p code, li code {
+p code, li code:not(pre code) {
   background-color: #f5f5f5;
   white-space: pre-wrap;
   padding: 5px;


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Changes

Fixes a styling conflict where `code` elements within list items (`li`) were being styled identically to inline `code` tags. The problem arose when these `code` tags are already inside a `pre` block for codeblocks.

#### Context
- Original Issue: https://github.com/getzola/themes/issues/82

#### Screenshots
**Before**
![before](https://github.com/getzola/zola/assets/6399341/acf34314-341f-4c03-b6cb-ea65dd0e3e0b)

**After**
![after](https://github.com/getzola/zola/assets/6399341/dc152c02-b342-4026-89d5-18614335234d)