### PR TITLE
fix broken link to Tera

### DIFF
--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -7,7 +7,7 @@ Zola uses the [Tera](https://tera.netlify.com) template engine, which is very si
 to Jinja2, Liquid and Twig.
 
 As this documentation will only talk about how templates work in Zola, please read
-the [Tera template documentation](https://tera.netlify.com/docs#templates) if you want
+the [Tera template documentation](https://keats.github.io/tera/docs/#templates) if you want
 to learn more about it first.
 
 All templates live in the `templates` directory.  If you are not sure what variables are available in a template,


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Details
The existing link to Tera in the documentation page is broken: update it to a working one. I'm not sure if this is the correct URL for the fix. I haven't created an issue for this since the fix is very minor, hopefully this is alright!



