### PR TITLE
fix: suppress highlight language warnings when `highlight_code` is false

### DIFF
--- a/components/markdown/src/codeblock/mod.rs
+++ b/components/markdown/src/codeblock/mod.rs
@@ -77,7 +77,7 @@ impl<'config> CodeBlock<'config> {
         path: Option<&'config str>,
     ) -> (Self, String) {
         let syntax_and_theme = resolve_syntax_and_theme(fence.language, config);
-        if syntax_and_theme.source == HighlightSource::NotFound {
+        if syntax_and_theme.source == HighlightSource::NotFound && config.markdown.highlight_code {
             let lang = fence.language.unwrap();
             if let Some(p) = path {
                 eprintln!("Warning: Highlight language {} not found in {}", lang, p);


### PR DESCRIPTION
Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [X] Are you doing the PR on the `next` branch?

---

This PR fixes #2280 by adding conditional logic to suppress warnings about unknown highlight languages when `markdown.highlight_code` is set to `false` in `config.toml`.