### PR TITLE
fix: do not check the same url more than once

### DIFF
--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -179,17 +179,11 @@ pub fn check_external_links(site: &Site) -> Vec<String> {
     for link in checked_links.iter() {
         if dedup_links_by_domain.contains_key(link.domain.as_str()) {
             let deduped_links = dedup_links_by_domain.get_mut(link.domain.as_str()).unwrap();
-
-            if deduped_links.contains_key(link.external_link.as_str()) {
-                deduped_links.get_mut(link.external_link.as_str()).unwrap().push(link);
-            } else {
-                deduped_links.insert(&link.external_link, vec![link]);
-            }
+            deduped_links.entry(&link.external_link).or_insert_with(Vec::default).push(link);
         } else {
-            dedup_links_by_domain.insert(
-                link.domain.as_str(),
-                HashMap::from([(link.external_link.as_str(), vec![link])]),
-            );
+            dedup_links_by_domain
+                .entry(&link.domain)
+                .or_insert_with(|| HashMap::from([(link.external_link.as_str(), vec![link])]));
         }
     }
 


### PR DESCRIPTION
This is a fix for https://github.com/getzola/zola/issues/2298

Before:

![DeepinScreenshot_select-area_20230912162708](https://github.com/getzola/zola/assets/7164437/7ae418c9-2299-4910-ab5e-cce909db246d)

After:

![DeepinScreenshot_select-area_20230912162728](https://github.com/getzola/zola/assets/7164437/be7cc7e0-8833-437d-9cd0-ce092f637d57)

I've used the https://github.com/organicmaps/organicmaps.github.io/ repo for the before and after tests.


**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



