### PR TITLE
Avoid unnecessary checking for already checked links

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
               rustup_toolchain: stable
             linux-pinned:
               imageName: 'ubuntu-20.04'
-              rustup_toolchain: 1.64.0
+              rustup_toolchain: 1.71.1
         pool:
           vmImage: $(imageName)
         steps:

--- a/components/content/src/library.rs
+++ b/components/content/src/library.rs
@@ -188,7 +188,7 @@ impl Library {
             if !self.sections[&path].meta.transparent {
                 // Fill siblings
                 for (i, page_path) in sorted.iter().enumerate() {
-                    let mut p = self.pages.get_mut(page_path).unwrap();
+                    let p = self.pages.get_mut(page_path).unwrap();
                     if i > 0 {
                         // lighter / later / title_prev
                         p.lower = Some(sorted[i - 1].clone());

--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -52,7 +52,7 @@ pub fn check_internal_links_with_anchors(site: &Site) -> Vec<String> {
             full_path.push(part);
         }
         // NOTE: This will also match _index.foobar.md where foobar is not a language
-        // as well as any other sring containing "_index." which is now referenced as
+        // as well as any other string containing "_index." which is now referenced as
         // unsupported page path in the docs.
         if md_path.contains("_index.") {
             let section = library.sections.get(&full_path).unwrap_or_else(|| {


### PR DESCRIPTION
Fixes #2298

For localized [Organic Maps zola site](https://github.com/organicmaps/organicmaps.github.io/) the time for `zola check` link checking has reduced from 3 minutes to less than 1 minute.

I'm new to Rust, so any ideas on how to write better code are welcome!