### PR TITLE
Fix the link to the author's site

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -99,7 +99,7 @@
             {% endblock content %}
         </div>
         <footer>
-            ©2017-{{ now() | date(format="%Y") }} — <a class="white" href="https://vincentprouillet.com">Vincent Prouillet</a> and <a class="white" href="https://github.com/getzola/zola/graphs/contributors">contributors</a>
+            ©2017-{{ now() | date(format="%Y") }} — <a class="white" href="https://www.vincentprouillet.com">Vincent Prouillet</a> and <a class="white" href="https://github.com/getzola/zola/graphs/contributors">contributors</a>
         </footer>
 
         <script type="text/javascript" src="{{ get_url(path="elasticlunr.min.js") }}"></script>


### PR DESCRIPTION
Hello! I recently found out about Zola and it seems like a great project to me! 
I was just browsing the main site and saw that the link to the author's site is broken. Its missing a `www` after `https://`. 

I'm not sure if I've updated the link at the right place but I could find no other occurrence of this address in the code.

Really sorry if I have done something wrong here. This is my first PR to a project and I'm not fully clear about the process yet :sweat_smile:.

Thank you!

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?




