### PR TITLE
Add multi-stage dockerfile build example

### DIFF
--- a/docs/content/documentation/deployment/docker-image.md
+++ b/docs/content/documentation/deployment/docker-image.md
@@ -1,0 +1,36 @@
++++
+title = "Docker image"
+weight = 90
++++
+
+If you have to distribute a Zola based web site through Docker, it's easy to do with a multi-stage build.
+
+Here is an example that builds the current folder, and put the result in a docker image that will be served by
+[static-web-server](https://static-web-server.net/), a minimalist web server written in rust.
+
+Of course, you may want to replace the second stage with another static web server like Nginx or Apache.
+
+```Dockerfile
+FROM ghcr.io/getzola/zola:v0.17.1 as zola
+
+COPY . /project
+WORKDIR /project
+RUN ["zola", "build"]
+
+FROM ghcr.io/static-web-server/static-web-server:2
+WORKDIR /
+COPY --from=zola /project/public /public
+```
+
+To build your website as a docker image, you then run:
+```shell
+docker build -t my_website:latest .
+```
+
+To test your site, just run the docker image and browse [http://localhost:8000](http://localhost:8000)
+
+```
+docker run --rm -p 8000:80 my_website:latest
+```
+
+Note that, if you want to be able to use your docker image from multiple locations, you'll have to set `base_url` to `/`.

--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -180,7 +180,8 @@ You can now browse http://localhost:8080.
 
 #### Multi-stage build
 
-Build current folder content and create a lightweight web server image using static-web-server:
+Since there is no shell in the Zola docker image, if you want to use it from inside a Dockerfile, you have to use the
+exec form of `RUN`, like:
 
 ```Dockerfile
 FROM ghcr.io/getzola/zola:v0.17.1 as zola
@@ -188,10 +189,6 @@ FROM ghcr.io/getzola/zola:v0.17.1 as zola
 COPY . /project
 WORKDIR /project
 RUN ["zola", "build"]
-
-FROM ghcr.io/static-web-server/static-web-server:2
-WORKDIR /
-COPY --from=zola /project/public /public
 ```
 
 

--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -178,6 +178,22 @@ You can now browse http://localhost:8080.
 > port between 1024 and 9000 for live reload. The new docker command would be
 > `$ docker run -u "$(id -u):$(id -g)" -v $PWD:/app --workdir /app -p 8080:8080 -p 1024:1024 ghcr.io/getzola/zola:v0.17.1 serve --interface 0.0.0.0 --port 8080 --base-url localhost`
 
+#### Multi-stage build
+
+Build current folder content and create a lightweight web server image using static-web-server:
+
+```Dockerfile
+FROM ghcr.io/getzola/zola:v0.17.1 as zola
+
+COPY . /project
+WORKDIR /project
+RUN ["zola", "build"]
+
+FROM ghcr.io/static-web-server/static-web-server:2
+WORKDIR /
+COPY --from=zola /project/public /public
+```
+
 
 ## Windows
 


### PR DESCRIPTION
Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

This is a simple documentation improvement proposal to add an example how to use the zola docker image in a multi stage build. 

This should answers questions like #1319 and avoid workaround like creating derived docker images.

