### PR TITLE
docs: show that `base_url` should contain protocol

### DIFF
--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -26,7 +26,7 @@ used by Zola as well as their default values are listed below:
 
 ```toml
 # The base URL of the site; the only required configuration variable.
-base_url = "mywebsite.com"
+base_url = "https://mywebsite.com"
 
 # The site title and description; used in feeds by default.
 title = ""


### PR DESCRIPTION
I was confused, like https://github.com/getzola/zola/issues/1524, by the example in the documentation for `base_url`. I also got double links on my website; just like in the issue. Showing the example with the protocol/scheme should probably make it a little bit more clear.


