### PR TITLE
Change to updated version of checkout action

### DIFF
--- a/docs/content/documentation/deployment/github-pages.md
+++ b/docs/content/documentation/deployment/github-pages.md
@@ -47,7 +47,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
       - name: build_and_deploy
         uses: shalzz/zola-deploy-action@v0.17.2
         env:
@@ -78,7 +78,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     steps:
       - name: 'checkout'
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
       - name: 'build'
         uses: shalzz/zola-deploy-action@v0.17.2
         env:
@@ -91,7 +91,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: 'checkout'
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
       - name: 'build and deploy'
         uses: shalzz/zola-deploy-action@v0.17.2
         env:


### PR DESCRIPTION
I think we should update to the new version of checkout in the example. The current example is pinned to a very old version of checkout. I also just pinned it to version 4 instead of 4.0.0 so the documentation doesn't require updates as often to be up to date. That's also how they show it in the example in [their readme](https://github.com/actions/checkout#usage).

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

Small change, was easier to do than to explain what I wanted to do. Less time investment than creating an issue (to ensure in include all required context).


The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?