### PR TITLE
Document author

### DIFF
--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -77,6 +77,9 @@ feed_filename = "atom.xml"
 # files are always copied, regardless of this setting.
 hard_link_static = false
 
+# The default author for pages
+author = 
+
 # The taxonomies to be rendered for the site and their configuration of the default languages
 # Example:
 #     taxonomies = [

--- a/docs/content/documentation/templates/feeds/index.md
+++ b/docs/content/documentation/templates/feeds/index.md
@@ -17,6 +17,20 @@ need to provide a template yourself.
 
 **Only pages with a date will be available.**
 
+The author in the feed is set as
+- The first author in `authors` set in the 
+  [front matter](@/documentation/content/page.md#front-matter)
+- If that is not present it falls back to the `author` in the 
+  [Configuration](@/documentation/getting-started/configuration.md)
+- If that is also not preset it is set to `Unknown`.
+
+Note that `atom.xml` and `rss.xml` require different formats for specifying the
+author. According to [RFC 4287][atom_rfc] `atom.xml` requires the author's
+name, for example `"John Doe"`. While according to the 
+[RSS 2.0 Specification][rss_spec] the email address is required, and the name
+optionally included, for example `"lawyer@boyer.net"` or 
+`"lawyer@boyer.net (Lawyer Boyer)"`.
+
 The feed template gets five variables:
 
 - `config`: the site config
@@ -63,3 +77,6 @@ In order to enable the tag feeds as well, you can overload the `block rss` using
 {% endblock rss %}
 ```
 Each tag page will refer to it's dedicated feed.
+
+[atom_rfc]: https://www.rfc-editor.org/rfc/rfc4287
+[rss_spec]: https://www.rssboard.org/rss-specification#ltauthorgtSubelementOfLtitemgt


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

> The place to discuss new features is the forum: <https://zola.discourse.group/>
> If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

This adds author to the page that shows what fields are available in the configuration.

It also explains how the `author` from the configuration and `authors` from the front matter are used for feeds.

I'm on the fence about how to add author to the configuration as it is blank and not set to "Unknown" that happens in the feed template. However, the way I've done it causes the config not to work if you just copy and paste it, without editing it. I think that's probably bad but I patterned on the front matter documentation where the date and update are done the same way. I considered commenting out the line but then it's easier to miss. Not sure what is the best way to treat this.