### PR TITLE
Fix inconsistency in the documentation

### DIFF
--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -149,8 +149,9 @@ Here is a full list of supported languages and their short names:
 
 Note: due to some issues with the JavaScript syntax, the TypeScript syntax will be used instead.
 
-If you want to highlight a language not on this list, please open an issue or a pull request on the [Zola repo](https://github.com/getzola/zola).
-Alternatively, the `extra_syntaxes_and_themes` configuration option can be used to add additional syntax (and theme) files.
+If the language you want to highlight is not on this list, please follow our [contribution guidelines](https://github.com/getzola/zola/blob/master/CONTRIBUTING.md)
+to add support for a new language.
+Alternatively, the `extra_syntaxes_and_themes` configuration option can be used to add additional syntax and theme files.
 
 If your site source is laid out as follows:
 


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.
-->

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

* [ ] Are you doing the PR on the `next` branch?

From `CONTRIBUTING.md`:
> As the documentation site is automatically built on commits to master, all development happens on the next branch, **unless it is fixing the current documentation**.
> However, if you notice an error or typo in the documentation, feel free to directly submit a PR without opening an issue.

## Context

The documented way to add new features is inconsistent between the **Syntax Highlighting** page in the site and the **Contribution guidelines** in the repo.

![2023-12-09-NHrNDH](https://github.com/getzola/zola/assets/68171111/55e52a1a-8e8f-4ded-a966-54735722c777)

![2023-12-09-zJkEcw](https://github.com/getzola/zola/assets/68171111/38af8d60-048b-475c-804f-23e33d46b2a6)
