### PR TITLE
Sorted subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.19.0 (unreleased)
+
+
 ## 0.18.0 (2023-12-18)
 
 - Fix LFI in `zola serve`

--- a/components/content/src/library.rs
+++ b/components/content/src/library.rs
@@ -208,6 +208,45 @@ impl Library {
         }
     }
 
+    /// Sort all subsections according to sorting method given
+    pub fn sort_section_subsections(&mut self) {
+        let mut updates = AHashMap::new();
+        for (path, section) in &self.sections {
+            let subsections: Vec<_> =
+                section.subsections.iter().map(|p| &self.sections[p]).collect();
+            let (sorted_subsections, cannot_be_sorted_subsections) = match section.meta.sort_by {
+                SortBy::None => continue,
+                _ => sort_pages(&subsections, section.meta.sort_by),
+            };
+
+            updates.insert(
+                path.clone(),
+                (sorted_subsections, cannot_be_sorted_subsections, section.meta.sort_by),
+            );
+        }
+
+        for (path, (sorted, unsortable, _)) in updates {
+            // Fill siblings
+            for (i, subsection_path) in sorted.iter().enumerate() {
+                let p = self.sections.get_mut(subsection_path).unwrap();
+                if i > 0 {
+                    // lighter / later / title_prev
+                    p.lower = Some(sorted[i - 1].clone());
+                }
+
+                if i < sorted.len() - 1 {
+                    // heavier / earlier / title_next
+                    p.higher = Some(sorted[i + 1].clone());
+                }
+            }
+
+            if let Some(s) = self.sections.get_mut(&path) {
+                s.subsections = sorted;
+                s.ignored_subsections = unsortable;
+            }
+        }
+    }
+
     /// Find out the direct subsections of each subsection if there are some
     /// as well as the pages for each section
     pub fn populate_sections(&mut self, config: &Config, content_path: &Path) {
@@ -331,6 +370,7 @@ impl Library {
 
         // And once we have all the pages assigned to their section, we sort them
         self.sort_section_pages();
+        self.sort_section_subsections();
     }
 
     /// Find all the orphan pages: pages that are in a folder without an `_index.md`
@@ -778,5 +818,108 @@ mod tests {
             set! {PathBuf::from("page1.md"), PathBuf::from("_index.md")}
         );
         assert_eq!(library.backlinks["_index.md"], set! {PathBuf::from("page2.md")});
+    }
+
+    #[test]
+    fn can_sort_sections_by_weight() {
+        let config = Config::default_for_test();
+        let mut library = Library::default();
+        let sections = vec![
+            ("content/_index.md", "en", 0, false, SortBy::Weight),
+            ("content/blog/_index.md", "en", 0, false, SortBy::Weight),
+            ("content/novels/_index.md", "en", 3, false, SortBy::Weight),
+            ("content/novels/first/_index.md", "en", 2, false, SortBy::Weight),
+            ("content/novels/second/_index.md", "en", 1, false, SortBy::Weight),
+            // Transparency does not apply to sections as of now!
+            ("content/wiki/_index.md", "en", 4, true, SortBy::Weight),
+            ("content/wiki/recipes/_index.md", "en", 1, false, SortBy::Weight),
+            ("content/wiki/programming/_index.md", "en", 2, false, SortBy::Weight),
+        ];
+        for (p, l, w, t, s) in sections.clone() {
+            library.insert_section(create_section(p, l, w, t, s));
+        }
+
+        library.populate_sections(&config, Path::new("content"));
+        assert_eq!(library.sections.len(), sections.len());
+        let root_section = &library.sections[&PathBuf::from("content/_index.md")];
+        assert_eq!(root_section.lower, None);
+        assert_eq!(root_section.higher, None);
+
+        let blog_section = &library.sections[&PathBuf::from("content/blog/_index.md")];
+        assert_eq!(blog_section.lower, None);
+        assert_eq!(blog_section.higher, Some(PathBuf::from("content/novels/_index.md")));
+
+        let novels_section = &library.sections[&PathBuf::from("content/novels/_index.md")];
+        assert_eq!(novels_section.lower, Some(PathBuf::from("content/blog/_index.md")));
+        assert_eq!(novels_section.higher, Some(PathBuf::from("content/wiki/_index.md")));
+        assert_eq!(
+            novels_section.subsections,
+            vec![
+                PathBuf::from("content/novels/second/_index.md"),
+                PathBuf::from("content/novels/first/_index.md"),
+            ]
+        );
+
+        let first_novel_section =
+            &library.sections[&PathBuf::from("content/novels/first/_index.md")];
+        assert_eq!(
+            first_novel_section.lower,
+            Some(PathBuf::from("content/novels/second/_index.md"))
+        );
+        assert_eq!(first_novel_section.higher, None);
+
+        let second_novel_section =
+            &library.sections[&PathBuf::from("content/novels/second/_index.md")];
+        assert_eq!(second_novel_section.lower, None);
+        assert_eq!(
+            second_novel_section.higher,
+            Some(PathBuf::from("content/novels/first/_index.md"))
+        );
+    }
+
+    #[test]
+    fn can_sort_sections_by_title() {
+        fn create_section(file_path: &str, title: &str, weight: usize, sort_by: SortBy) -> Section {
+            let mut section = Section::default();
+            section.lang = "en".to_owned();
+            section.file = FileInfo::new_section(Path::new(file_path), &PathBuf::new());
+            section.meta.title = Some(title.to_owned());
+            section.meta.weight = weight;
+            section.meta.transparent = false;
+            section.meta.sort_by = sort_by;
+            section.meta.page_template = Some("new_page.html".to_owned());
+            section
+        }
+
+        let config = Config::default_for_test();
+        let mut library = Library::default();
+        let sections = vec![
+            ("content/_index.md", "root", 0, SortBy::Title),
+            ("content/a_first/_index.md", "1", 1, SortBy::Title),
+            ("content/b_third/_index.md", "3", 2, SortBy::Title),
+            ("content/c_second/_index.md", "2", 2, SortBy::Title),
+        ];
+        for (p, l, w, s) in sections.clone() {
+            library.insert_section(create_section(p, l, w, s));
+        }
+
+        library.populate_sections(&config, Path::new("content"));
+        assert_eq!(library.sections.len(), sections.len());
+
+        let root_section = &library.sections[&PathBuf::from("content/_index.md")];
+        assert_eq!(root_section.lower, None);
+        assert_eq!(root_section.higher, None);
+
+        let first = &library.sections[&PathBuf::from("content/a_first/_index.md")];
+        assert_eq!(first.lower, None);
+        assert_eq!(first.higher, Some(PathBuf::from("content/c_second/_index.md")));
+
+        let second = &library.sections[&PathBuf::from("content/c_second/_index.md")];
+        assert_eq!(second.lower, Some(PathBuf::from("content/a_first/_index.md")));
+        assert_eq!(second.higher, Some(PathBuf::from("content/b_third/_index.md")));
+
+        let third = &library.sections[&PathBuf::from("content/b_third/_index.md")];
+        assert_eq!(third.lower, Some(PathBuf::from("content/c_second/_index.md")));
+        assert_eq!(third.higher, None);
     }
 }

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -43,7 +43,7 @@ fn can_parse_site() {
     assert!(index_section.ancestors.is_empty());
 
     let posts_section = library.sections.get(&posts_path.join("_index.md")).unwrap();
-    assert_eq!(posts_section.subsections.len(), 2);
+    assert_eq!(posts_section.ignored_subsections.len(), 2);
     assert_eq!(posts_section.pages.len(), 10); // 11 with 1 draft == 10
     assert_eq!(posts_section.ancestors, vec![index_section.file.relative.clone()]);
 

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -208,16 +208,13 @@ to newest (at the bottom).
 If the section is paginated the `paginate_reversed=true` in the front matter of the relevant section should be set instead of using the filter.
 
 ## Sorting subsections
-Sorting sections is a bit less flexible: sections can only be sorted by `weight`,
-and do not have variables that point to the heavier/lighter sections.
+Sorting sections is a bit less flexible: sections can only be sorted by `weight`
+and `title`. Similarly to pages, section have `section.lower` and `section.higher`
+variables, pointing to the heavier/lighter sections.
 
 By default, the lightest (lowest `weight`) subsections will be at
 the top of the list and the heaviest (highest `weight`) will be at the bottom;
 the `reverse` filter reverses this order.
 
-**Note**: Unlike pages, permalinks will **not** be used to break ties between
-equally weighted sections. Thus, if the `weight` variable for your section is not set (or if it
-is set in a way that produces ties), then your sections will be sorted in
-**random** order. Moreover, that order is determined at build time and will
-change with each site rebuild.  Thus, if there is any chance that you will
-iterate over your sections, you should always assign them distinct weights.
+**Note**: A section's "transparency" doesn't apply to subsections, so subsections
+will not be visible as direct children of the parent section.


### PR DESCRIPTION
This PR adds subsection sorting and introduces `lower` and `higher` fields to make sections more consistent with pages. As pointed [here](https://zola.discourse.group/t/next-previous-section-based-on-weight/528/2), these fields are supposed to be there.

An open question remains: how should we treat subsections of a transparent section? I raised this question [here](https://zola.discourse.group/t/should-transparant-sections-pass-their-subsections/1965), but so far there is no definite conclusion, so I'm leaving it out of the scope of this PR.

---

## Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
* [X] Are you doing the PR on the `next` branch?
* [X] Have you created/updated the relevant documentation page(s)?

