### PR TITLE
fix: taxonomies missing lang in sitemap

### DIFF
--- a/components/content/src/pagination.rs
+++ b/components/content/src/pagination.rs
@@ -107,12 +107,8 @@ impl<'a> Paginator<'a> {
             paginate_reversed: false,
             root: PaginationRoot::Taxonomy(taxonomy, item),
             permalink: item.permalink.clone(),
-            path: format!("/{}/{}/", taxonomy.slug, item.slug),
-            paginate_path: taxonomy
-                .kind
-                .paginate_path
-                .clone()
-                .unwrap_or_else(|| "page".to_string()),
+            path: item.path.clone(),
+            paginate_path: taxonomy.kind.paginate_path().to_owned(),
             is_index: false,
             template: template.to_string(),
         };

--- a/components/site/src/sitemap.rs
+++ b/components/site/src/sitemap.rs
@@ -92,14 +92,10 @@ pub fn find_entries<'a>(
         if !taxonomy.kind.render {
             continue;
         }
-        let name = &taxonomy.kind.name;
-        entries.insert(SitemapEntry::new(Cow::Owned(config.make_permalink(name)), &None));
+        entries.insert(SitemapEntry::new(Cow::Borrowed(&taxonomy.permalink), &None));
 
         for item in &taxonomy.items {
-            entries.insert(SitemapEntry::new(
-                Cow::Owned(config.make_permalink(&format!("{}/{}", name, item.slug))),
-                &None,
-            ));
+            entries.insert(SitemapEntry::new(Cow::Borrowed(&item.permalink), &None));
 
             if taxonomy.kind.is_paginated() {
                 let number_pagers = (item.pages.len() as f64
@@ -107,9 +103,8 @@ pub fn find_entries<'a>(
                     .ceil() as isize;
                 for i in 1..=number_pagers {
                     let permalink = config.make_permalink(&format!(
-                        "{}/{}/{}/{}",
-                        name,
-                        item.slug,
+                        "{}{}/{}/",
+                        item.path,
                         taxonomy.kind.paginate_path(),
                         i
                     ));

--- a/components/site/tests/site_i18n.rs
+++ b/components/site/tests/site_i18n.rs
@@ -169,6 +169,14 @@ fn can_build_multilingual_site() {
     assert!(file_contains!(public, "fr/tags/index.html", "bonjour"));
     assert!(!file_contains!(public, "fr/tags/index.html", "hello"));
 
+    // sitemap contains per-language taxonomies
+    assert!(file_contains!(public, "sitemap.xml", "https://example.com/tags/"));
+    assert!(file_contains!(public, "sitemap.xml", "https://example.com/tags/hello/"));
+    assert!(file_contains!(public, "sitemap.xml", "https://example.com/fr/tags/"));
+    assert!(file_contains!(public, "sitemap.xml", "https://example.com/fr/tags/bonjour/"));
+
+    assert!(!file_contains!(public, "sitemap.xml", "https://example.com/tags/bonjour"));
+
     // one lang index per language
     assert!(file_exists!(public, "search_index.en.js"));
     assert!(file_exists!(public, "search_index.it.js"));


### PR DESCRIPTION
This PR fixes `sitemap.xml` having incorrect i18n taxonomy URLs.

---

## Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
* [X] Are you doing the PR on the `next` branch?

