### PR TITLE
Update the GitLab Pages documentation

### DIFF
--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -82,7 +82,7 @@ After you push this file to the default branch of your repository
 (e.g. "master" or "main"), your site will be ready. The GitLab CI/CD pipelines
 will ensure your site is published and updated automatically.
 
-On the left sidebar, navigate to **Deploy > Pages**`** to find the URL of your
+On the left sidebar of GitLab, navigate to **Deploy > Pages**`** to find the URL of your
 website inside the **Access pages** section.
 
 More information on how to host your site on GitLab Pages is available

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -15,6 +15,10 @@ It is recommended to create a repository on GitLab that contains solely your
 Zola project. The [Zola's directory structure](https://www.getzola.org/documentation/getting-started/directory-structure/)
 should be located in the root directory of your repository.
 
+For information on how to create and manage a repository on GitLab, refer to:
+
+<https://docs.gitlab.com/ee/user/project/repository/>
+
 ## Ensuring that the runner can access your theme
 
 Depending on how you added your theme, your repository may not contain it.

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -49,7 +49,7 @@ stages:
   - deploy
 
 default:
-  image: alpine:latest
+  image: debian:stable-slim
   tags:
     - docker
 
@@ -58,11 +58,38 @@ variables:
   # set to "recursive".
   GIT_SUBMODULE_STRATEGY: "recursive"
 
+  # If you don't set a version here, your site will be built with the latest
+  # version of Zola available in GitHub releases.
+  # Use the semver (x.y.z) format to specify a version. For example: "0.17.2" or "0.18.0".
+  ZOLA_VERSION:
+    description: "The version of Zola used to build the site."
+    value: ""
+
 pages:
   stage: deploy
   script:
-    - apk add zola
-    - zola build
+    - |
+      apt-get update --assume-yes && apt-get install --assume-yes --no-install-recommends wget ca-certificates
+      if [ $ZOLA_VERSION ]; then
+        zola_url="https://github.com/getzola/zola/releases/download/v$ZOLA_VERSION/zola-v$ZOLA_VERSION-x86_64-unknown-linux-gnu.tar.gz"
+        if wget --quiet --spider $zola_url; then
+          wget $zola_url
+        else
+          echo "A Zola release with the specified version could not be found.";
+          exit 1;
+        fi
+      else
+        github_api_url="https://api.github.com/repos/getzola/zola/releases/latest"
+        zola_url=$(
+          wget --output-document - $github_api_url |
+          grep "browser_download_url.*linux-gnu.tar.gz" |
+          cut --delimiter : --fields 2,3 |
+          tr --delete "\" "
+        )
+        wget $zola_url
+      fi
+      tar -xzf *.tar.gz
+      ./zola build
 
   artifacts:
     paths:

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -80,7 +80,7 @@ Feel free to adjust the file to your workflow and specific requirements.
 
 After you push this file to the default branch of your repository
 (e.g. "master" or "main"), your site will be ready. The GitLab CI/CD pipelines
-will ensure your site is published with those changes automatically.
+will ensure your site is published and updated automatically.
 
 On the left sidebar, navigate to **Deploy > Pages**`** to find the URL of your
 website inside the **Access pages** section.

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -82,7 +82,7 @@ After you push this file to the default branch of your repository
 (e.g. "master" or "main"), your site will be ready. The GitLab CI/CD pipelines
 will ensure your site is published and updated automatically.
 
-On the left sidebar of GitLab, navigate to **Deploy > Pages**`** to find the URL of your
+On the left sidebar of GitLab, navigate to **Deploy > Pages** to find the URL of your
 website inside the **Access pages** section.
 
 More information on how to host your site on GitLab Pages is available

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -72,9 +72,7 @@ pages:
       apt-get update --assume-yes && apt-get install --assume-yes --no-install-recommends wget ca-certificates
       if [ $ZOLA_VERSION ]; then
         zola_url="https://github.com/getzola/zola/releases/download/v$ZOLA_VERSION/zola-v$ZOLA_VERSION-x86_64-unknown-linux-gnu.tar.gz"
-        if wget --quiet --spider $zola_url; then
-          wget $zola_url
-        else
+        if ! wget --quiet --spider $zola_url; then
           echo "A Zola release with the specified version could not be found.";
           exit 1;
         fi
@@ -86,8 +84,8 @@ pages:
           cut --delimiter : --fields 2,3 |
           tr --delete "\" "
         )
-        wget $zola_url
       fi
+      wget $zola_url
       tar -xzf *.tar.gz
       ./zola build
 


### PR DESCRIPTION
<!--
  **IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**
  
  The place to discuss new features is the forum: <https://zola.discourse.group/>
  If you want to add a new feature, please open a thread there first in the feature requests section.
-->
Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Rationale

1. What's stated in the section **Repository setup** seems to be outdated. As per the current documentation on GitLab, GitLab Pages does not seem to work the way described there.
2. In the GitLab CI template, the `only` keyword is no longer supported by GitLab. Its replacement is `rules`.
3. The GitLab CI template can be changed to allow using specific versions of Zola.
4. Rewritten some parts as per my personal writing style.
5. Some other changes were proposed by my Markdown linter, such as [removing the dollar signs from the fenced code blocks](https://github.com/DavidAnson/markdownlint/blob/main/doc/md014.md).
6. Removed comments that described _what_ a command does, instead of the _why_.