### PR TITLE
fix: set the debian version used to build the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim AS builder
+FROM rust:slim-bookworm AS builder
 
 RUN apt-get update -y && \
   apt-get install -y make g++ libssl-dev && \
@@ -10,6 +10,6 @@ COPY . .
 RUN cargo build --release --target x86_64-unknown-linux-gnu
 
 
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc-debian12
 COPY --from=builder /app/target/x86_64-unknown-linux-gnu/release/zola /bin/zola
 ENTRYPOINT [ "/bin/zola" ]


### PR DESCRIPTION
This avoid conflicting GLibc version between the build step and the distroless cc one.

Resolves #2385 
