### PR TITLE
Allow IPv6 serve, default `base_url` to listen interface instead of 127.0.0.1

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,8 +71,8 @@ pub enum Command {
         force: bool,
 
         /// Changes the base_url
-        #[clap(short = 'u', long, default_value = "127.0.0.1")]
-        base_url: String,
+        #[clap(short = 'u', long)]
+        base_url: Option<String>,
 
         /// Include drafts when loading the site
         #[clap(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use std::net::IpAddr;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
@@ -54,7 +55,7 @@ pub enum Command {
     Serve {
         /// Interface to bind on
         #[clap(short = 'i', long, default_value = "127.0.0.1")]
-        interface: String,
+        interface: IpAddr,
 
         /// Which port to use
         #[clap(short = 'p', long, default_value_t = 1111)]

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -325,16 +325,25 @@ fn create_new_site(
     interface_port: u16,
     output_dir: Option<&Path>,
     force: bool,
-    base_url: &str,
+    base_url: Option<&str>,
     config_file: &Path,
     include_drafts: bool,
-    no_port_append: bool,
+    mut no_port_append: bool,
     ws_port: Option<u16>,
 ) -> Result<(Site, SocketAddr)> {
     SITE_CONTENT.write().unwrap().clear();
 
     let mut site = Site::new(root_dir, config_file)?;
     let address = SocketAddr::new(interface, interface_port);
+
+    // if no base URL provided, use socket address
+    let base_url = base_url.map_or_else(
+        || {
+            no_port_append = true;
+            address.to_string()
+        },
+        |u| u.to_string(),
+    );
 
     let base_url = if base_url == "/" {
         String::from("/")
@@ -385,7 +394,7 @@ pub fn serve(
     interface_port: u16,
     output_dir: Option<&Path>,
     force: bool,
-    base_url: &str,
+    base_url: Option<&str>,
     config_file: &Path,
     open: bool,
     include_drafts: bool,

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -24,7 +24,7 @@
 use std::cell::Cell;
 use std::fs::read_dir;
 use std::future::IntoFuture;
-use std::net::{SocketAddrV4, TcpListener};
+use std::net::{IpAddr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::sync::mpsc::channel;
 use std::sync::Mutex;
@@ -321,7 +321,7 @@ fn rebuild_done_handling(broadcaster: &Sender, res: Result<()>, reload_path: &st
 #[allow(clippy::too_many_arguments)]
 fn create_new_site(
     root_dir: &Path,
-    interface: &str,
+    interface: IpAddr,
     interface_port: u16,
     output_dir: Option<&Path>,
     force: bool,
@@ -330,11 +330,11 @@ fn create_new_site(
     include_drafts: bool,
     no_port_append: bool,
     ws_port: Option<u16>,
-) -> Result<(Site, String)> {
+) -> Result<(Site, SocketAddr)> {
     SITE_CONTENT.write().unwrap().clear();
 
     let mut site = Site::new(root_dir, config_file)?;
-    let address = format!("{}:{}", interface, interface_port);
+    let address = SocketAddr::new(interface, interface_port);
 
     let base_url = if base_url == "/" {
         String::from("/")
@@ -381,7 +381,7 @@ fn create_new_site(
 #[allow(clippy::too_many_arguments)]
 pub fn serve(
     root_dir: &Path,
-    interface: &str,
+    interface: IpAddr,
     interface_port: u16,
     output_dir: Option<&Path>,
     force: bool,
@@ -394,7 +394,7 @@ pub fn serve(
     utc_offset: UtcOffset,
 ) -> Result<()> {
     let start = Instant::now();
-    let (mut site, address) = create_new_site(
+    let (mut site, bind_address) = create_new_site(
         root_dir,
         interface,
         interface_port,
@@ -409,12 +409,8 @@ pub fn serve(
     messages::report_elapsed_time(start);
 
     // Stop right there if we can't bind to the address
-    let bind_address: SocketAddrV4 = match address.parse() {
-        Ok(a) => a,
-        Err(_) => return Err(anyhow!("Invalid address: {}.", address)),
-    };
     if (TcpListener::bind(bind_address)).is_err() {
-        return Err(anyhow!("Cannot start server on address {}.", address));
+        return Err(anyhow!("Cannot start server on address {}.", bind_address));
     }
 
     let config_path = PathBuf::from(config_file);
@@ -466,8 +462,6 @@ pub fn serve(
     let static_root = output_path.clone();
     let broadcaster = {
         thread::spawn(move || {
-            let addr = address.parse().unwrap();
-
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -484,11 +478,11 @@ pub fn serve(
                     }
                 });
 
-                let server = Server::bind(&addr).serve(make_service);
+                let server = Server::bind(&bind_address).serve(make_service);
 
-                println!("Web server is available at http://{}\n", &address);
+                println!("Web server is available at http://{}\n", bind_address);
                 if open {
-                    if let Err(err) = open::that(format!("http://{}", &address)) {
+                    if let Err(err) = open::that(format!("http://{}", bind_address)) {
                         eprintln!("Failed to open URL in your browser: {}", err);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
             console::info("Building site...");
             if let Err(e) = cmd::serve(
                 &root_dir,
-                &interface,
+                interface,
                 port,
                 output_dir.as_deref(),
                 force,

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn main() {
                 port,
                 output_dir.as_deref(),
                 force,
-                &base_url,
+                base_url.as_deref(),
                 &config_file,
                 open,
                 drafts,


### PR DESCRIPTION
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?

This *could* work fine if you just replaced `SocketAddrV4` with `SocketAddr`, but I decided to tidy things up a bit more while I was looking at it. The main changes:

1. Instead of defaulting to 127.0.0.1, `zola serve` will make the `base_url` equal to the interface it's listening on by default (prevents you from doing `zola serve -i (thing) -u (same thing)`)
2. Parses `interface` explicitly as an IP address instead of just parsing `(interface):port` as a socket address. This means that you should provide IPv6 addresses without the brackets and that `base_url` will automatically add the brackets as needed.