### PR TITLE
Fix: zola serve no longer includes output directory content because of path canonicalization mismatch

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -461,9 +461,9 @@ pub fn serve(
     let ws_address = format!("{}:{}", interface, ws_port.unwrap());
     let output_path = site.output_path.clone();
 
-    // output path is going to need to be moved later on, so clone it for the
-    // http closure to avoid contention.
-    let static_root = output_path.clone();
+    // static_root needs to be canonicalized because we do the same for the http server.
+    let static_root = std::fs::canonicalize(&output_path).unwrap();
+
     let broadcaster = {
         thread::spawn(move || {
             let addr = address.parse().unwrap();


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/getzola/zola/pull/2258

The issue arose when `output_path` was relative. The request being served would be canonicalized and this would be a string. So, for example, if you were serving content from `public` the code [right after](https://github.com/getzola/zola/blob/38199c125501e9ff0e700e96adaca72cc3f25d2b/src/cmd/serve.rs#L144-L147) the canonicalization checking if
`root.starts_with(original_root)` would always return `false` since an absolute path, `/some/path/to/content` would never start with a string like `public`.

---

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
