### PR TITLE
Refactor: create_directory responsibly

### DIFF
--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -177,7 +177,7 @@ impl Processor {
     /// Run the enqueued image operations
     pub fn do_process(&mut self) -> Result<()> {
         if !self.img_ops.is_empty() {
-            ufs::ensure_directory_exists(&self.output_dir)?;
+            ufs::create_directory(&self.output_dir)?;
         }
 
         self.img_ops
@@ -197,7 +197,7 @@ impl Processor {
             return Ok(());
         }
 
-        ufs::ensure_directory_exists(&self.output_dir)?;
+        ufs::create_directory(&self.output_dir)?;
         let output_paths: HashSet<_> = self
             .img_ops
             .iter()

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -638,7 +638,6 @@ impl Site {
         create_dirs: bool,
     ) -> Result<PathBuf> {
         let write_dirs = self.build_mode == BuildMode::Disk || create_dirs;
-        create_directory(&self.output_path)?;
 
         let mut site_path = RelativePathBuf::new();
         let mut current_path = self.output_path.to_path_buf();
@@ -646,10 +645,6 @@ impl Site {
         for component in components {
             current_path.push(component);
             site_path.push(component);
-
-            if !current_path.exists() && write_dirs {
-                create_directory(&current_path)?;
-            }
         }
 
         if write_dirs {
@@ -787,9 +782,13 @@ impl Site {
     }
 
     pub fn render_themes_css(&self) -> Result<()> {
-        create_directory(&self.static_path)?;
+        let themes = &self.config.markdown.highlight_themes_css;
 
-        for t in &self.config.markdown.highlight_themes_css {
+        if !themes.is_empty() {
+            create_directory(&self.static_path)?;
+        }
+
+        for t in themes {
             let p = self.static_path.join(&t.filename);
             if !p.exists() {
                 let content = &self.config.markdown.export_theme_css(&t.theme)?;
@@ -856,7 +855,6 @@ impl Site {
     /// Renders all the aliases for each page/section: a magic HTML template that redirects to
     /// the canonical one
     pub fn render_aliases(&self) -> Result<()> {
-        create_directory(&self.output_path)?;
         let library = self.library.read().unwrap();
         for (_, page) in &library.pages {
             for alias in &page.meta.aliases {
@@ -873,7 +871,6 @@ impl Site {
 
     /// Renders 404.html
     pub fn render_404(&self) -> Result<()> {
-        create_directory(&self.output_path)?;
         let mut context = Context::new();
         context.insert("config", &self.config.serialize(&self.config.default_language));
         context.insert("lang", &self.config.default_language);
@@ -885,7 +882,6 @@ impl Site {
 
     /// Renders robots.txt
     pub fn render_robots(&self) -> Result<()> {
-        create_directory(&self.output_path)?;
         let mut context = Context::new();
         context.insert("config", &self.config.serialize(&self.config.default_language));
         let content = render_template("robots.txt", &self.tera, context, &self.config.theme)?;
@@ -909,8 +905,6 @@ impl Site {
         if taxonomy.items.is_empty() {
             return Ok(());
         }
-
-        create_directory(&self.output_path)?;
 
         let mut components = Vec::new();
         if taxonomy.lang != self.config.default_language {
@@ -976,8 +970,6 @@ impl Site {
 
     /// What it says on the tin
     pub fn render_sitemap(&self) -> Result<()> {
-        create_directory(&self.output_path)?;
-
         let library = self.library.read().unwrap();
         let all_sitemap_entries =
             { sitemap::find_entries(&library, &self.taxonomies[..], &self.config) };
@@ -1031,8 +1023,6 @@ impl Site {
         lang: &str,
         additional_context_fn: impl Fn(Context) -> Context,
     ) -> Result<()> {
-        create_directory(&self.output_path)?;
-
         let feed = match feed::render_feed(self, all_pages, lang, base_path, additional_context_fn)?
         {
             Some(v) => v,
@@ -1059,7 +1049,6 @@ impl Site {
 
     /// Renders a single section
     pub fn render_section(&self, section: &Section, render_pages: bool) -> Result<()> {
-        create_directory(&self.output_path)?;
         let mut output_path = self.output_path.clone();
         let mut components: Vec<&str> = Vec::new();
         let create_directories = self.build_mode == BuildMode::Disk || !section.assets.is_empty();
@@ -1067,19 +1056,15 @@ impl Site {
         if section.lang != self.config.default_language {
             components.push(&section.lang);
             output_path.push(&section.lang);
-
-            if !output_path.exists() && create_directories {
-                create_directory(&output_path)?;
-            }
         }
 
         for component in &section.file.components {
             components.push(component);
             output_path.push(component);
+        }
 
-            if !output_path.exists() && create_directories {
-                create_directory(&output_path)?;
-            }
+        if create_directories {
+            create_directory(&output_path)?;
         }
 
         if section.meta.generate_feed {
@@ -1165,7 +1150,6 @@ impl Site {
 
     /// Renders all pages that do not belong to any sections
     pub fn render_orphan_pages(&self) -> Result<()> {
-        create_directory(&self.output_path)?;
         let library = self.library.read().unwrap();
         for page in library.get_all_orphan_pages() {
             self.render_page(page)?;
@@ -1180,8 +1164,6 @@ impl Site {
         components: Vec<&'a str>,
         paginator: &'a Paginator,
     ) -> Result<()> {
-        create_directory(&self.output_path)?;
-
         let index_components = components.clone();
 
         paginator

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -23,7 +23,6 @@ use std::time::Instant;
 use templates::{load_tera, render_redirect_template};
 use utils::fs::{
     clean_site_output_folder, copy_directory, copy_file_if_needed, create_directory, create_file,
-    ensure_directory_exists,
 };
 use utils::net::{get_available_port, is_external_link};
 use utils::templates::{render_template, ShortcodeDefinition};
@@ -639,7 +638,7 @@ impl Site {
         create_dirs: bool,
     ) -> Result<PathBuf> {
         let write_dirs = self.build_mode == BuildMode::Disk || create_dirs;
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
 
         let mut site_path = RelativePathBuf::new();
         let mut current_path = self.output_path.to_path_buf();
@@ -788,7 +787,7 @@ impl Site {
     }
 
     pub fn render_themes_css(&self) -> Result<()> {
-        ensure_directory_exists(&self.static_path)?;
+        create_directory(&self.static_path)?;
 
         for t in &self.config.markdown.highlight_themes_css {
             let p = self.static_path.join(&t.filename);
@@ -818,7 +817,7 @@ impl Site {
     }
 
     pub fn build_search_index(&self) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
         // TODO: add those to the SITE_CONTENT map
 
         // index first
@@ -857,7 +856,7 @@ impl Site {
     /// Renders all the aliases for each page/section: a magic HTML template that redirects to
     /// the canonical one
     pub fn render_aliases(&self) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
         let library = self.library.read().unwrap();
         for (_, page) in &library.pages {
             for alias in &page.meta.aliases {
@@ -874,7 +873,7 @@ impl Site {
 
     /// Renders 404.html
     pub fn render_404(&self) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
         let mut context = Context::new();
         context.insert("config", &self.config.serialize(&self.config.default_language));
         context.insert("lang", &self.config.default_language);
@@ -886,7 +885,7 @@ impl Site {
 
     /// Renders robots.txt
     pub fn render_robots(&self) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
         let mut context = Context::new();
         context.insert("config", &self.config.serialize(&self.config.default_language));
         let content = render_template("robots.txt", &self.tera, context, &self.config.theme)?;
@@ -911,7 +910,7 @@ impl Site {
             return Ok(());
         }
 
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
 
         let mut components = Vec::new();
         if taxonomy.lang != self.config.default_language {
@@ -977,7 +976,7 @@ impl Site {
 
     /// What it says on the tin
     pub fn render_sitemap(&self) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
 
         let library = self.library.read().unwrap();
         let all_sitemap_entries =
@@ -1032,7 +1031,7 @@ impl Site {
         lang: &str,
         additional_context_fn: impl Fn(Context) -> Context,
     ) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
 
         let feed = match feed::render_feed(self, all_pages, lang, base_path, additional_context_fn)?
         {
@@ -1060,7 +1059,7 @@ impl Site {
 
     /// Renders a single section
     pub fn render_section(&self, section: &Section, render_pages: bool) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
         let mut output_path = self.output_path.clone();
         let mut components: Vec<&str> = Vec::new();
         let create_directories = self.build_mode == BuildMode::Disk || !section.assets.is_empty();
@@ -1166,7 +1165,7 @@ impl Site {
 
     /// Renders all pages that do not belong to any sections
     pub fn render_orphan_pages(&self) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
         let library = self.library.read().unwrap();
         for page in library.get_all_orphan_pages() {
             self.render_page(page)?;
@@ -1181,7 +1180,7 @@ impl Site {
         components: Vec<&'a str>,
         paginator: &'a Paginator,
     ) -> Result<()> {
-        ensure_directory_exists(&self.output_path)?;
+        create_directory(&self.output_path)?;
 
         let index_components = components.clone();
 

--- a/components/site/src/sass.rs
+++ b/components/site/src/sass.rs
@@ -7,10 +7,10 @@ use libs::walkdir::{DirEntry, WalkDir};
 
 use crate::anyhow;
 use errors::{bail, Result};
-use utils::fs::{create_file, ensure_directory_exists};
+use utils::fs::{create_directory, create_file};
 
 pub fn compile_sass(base_path: &Path, output_path: &Path) -> Result<()> {
-    ensure_directory_exists(output_path)?;
+    create_directory(output_path)?;
 
     let sass_path = {
         let mut sass_path = PathBuf::from(base_path);

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -27,14 +27,6 @@ pub fn create_file(path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
-/// Create a directory at the given path if it doesn't exist already
-pub fn ensure_directory_exists(path: &Path) -> Result<()> {
-    if !path.exists() {
-        create_directory(path)?;
-    }
-    Ok(())
-}
-
 /// Very similar to `create_dir` from the std except it checks if the folder
 /// exists before creating it
 pub fn create_directory(path: &Path) -> Result<()> {


### PR DESCRIPTION
These are the first two commits of #2388 separated into their own PR. Specifically:

* At some point, `ensure_directory_exists` was made identical to `create_directory`. I removed the former and replaced all instances with the latter.
* A lot of methods were running `create_directory` iteratively on every component despite it using `create_dir_all` internally. I decided to update these to have fewer `create_directory` calls so they could be better tracked.