### PR TITLE
Add MIME type to `get_image_metadata`

### DIFF
--- a/components/imageproc/src/meta.rs
+++ b/components/imageproc/src/meta.rs
@@ -37,11 +37,12 @@ pub struct ImageMetaResponse {
     pub width: u32,
     pub height: u32,
     pub format: Option<&'static str>,
+    pub mime: Option<&'static str>,
 }
 
 impl ImageMetaResponse {
     pub fn new_svg(width: u32, height: u32) -> Self {
-        Self { width, height, format: Some("svg") }
+        Self { width, height, format: Some("svg"), mime: Some("text/svg+xml") }
     }
 }
 
@@ -51,6 +52,7 @@ impl From<ImageMeta> for ImageMetaResponse {
             width: im.size.0,
             height: im.size.1,
             format: im.format.and_then(|f| f.extensions_str().first()).copied(),
+            mime: im.format.map(|f| f.to_mime_type()),
         }
     }
 }

--- a/components/imageproc/tests/resize_image.rs
+++ b/components/imageproc/tests/resize_image.rs
@@ -136,7 +136,12 @@ fn resize_image_webp_jpg() {
 fn read_image_metadata_jpg() {
     assert_eq!(
         image_meta_test("jpg.jpg"),
-        ImageMetaResponse { width: 300, height: 380, format: Some("jpg") }
+        ImageMetaResponse {
+            width: 300,
+            height: 380,
+            format: Some("jpg"),
+            mime: Some("image/jpeg")
+        }
     );
 }
 
@@ -144,7 +149,7 @@ fn read_image_metadata_jpg() {
 fn read_image_metadata_png() {
     assert_eq!(
         image_meta_test("png.png"),
-        ImageMetaResponse { width: 300, height: 380, format: Some("png") }
+        ImageMetaResponse { width: 300, height: 380, format: Some("png"), mime: Some("image/png") }
     );
 }
 
@@ -152,7 +157,12 @@ fn read_image_metadata_png() {
 fn read_image_metadata_svg() {
     assert_eq!(
         image_meta_test("svg.svg"),
-        ImageMetaResponse { width: 300, height: 300, format: Some("svg") }
+        ImageMetaResponse {
+            width: 300,
+            height: 300,
+            format: Some("svg"),
+            mime: Some("text/svg+xml")
+        }
     );
 }
 
@@ -160,7 +170,12 @@ fn read_image_metadata_svg() {
 fn read_image_metadata_webp() {
     assert_eq!(
         image_meta_test("webp.webp"),
-        ImageMetaResponse { width: 300, height: 380, format: Some("webp") }
+        ImageMetaResponse {
+            width: 300,
+            height: 380,
+            format: Some("webp"),
+            mime: Some("image/webp")
+        }
     );
 }
 

--- a/components/templates/src/global_fns/images.rs
+++ b/components/templates/src/global_fns/images.rs
@@ -269,6 +269,8 @@ mod tests {
         let data = static_fn.call(&args).unwrap().as_object().unwrap().clone();
         assert_eq!(data["height"], to_value(380).unwrap());
         assert_eq!(data["width"], to_value(300).unwrap());
+        assert_eq!(data["format"], to_value("jpg").unwrap());
+        assert_eq!(data["mime"], to_value("image/jpeg").unwrap());
 
         // 2. a call to something in `static` with an absolute path is handled currently the same as the above
         let mut args = HashMap::new();
@@ -276,6 +278,8 @@ mod tests {
         let data = static_fn.call(&args).unwrap().as_object().unwrap().clone();
         assert_eq!(data["height"], to_value(380).unwrap());
         assert_eq!(data["width"], to_value(300).unwrap());
+        assert_eq!(data["format"], to_value("jpg").unwrap());
+        assert_eq!(data["mime"], to_value("image/jpeg").unwrap());
 
         // 3. a call to something in `content` with a relative path
         let mut args = HashMap::new();
@@ -283,6 +287,8 @@ mod tests {
         let data = static_fn.call(&args).unwrap().as_object().unwrap().clone();
         assert_eq!(data["height"], to_value(380).unwrap());
         assert_eq!(data["width"], to_value(300).unwrap());
+        assert_eq!(data["format"], to_value("jpg").unwrap());
+        assert_eq!(data["mime"], to_value("image/jpeg").unwrap());
 
         // 4. a call to something in `content` with a @/ path corresponds to
         let mut args = HashMap::new();
@@ -290,5 +296,7 @@ mod tests {
         let data = static_fn.call(&args).unwrap().as_object().unwrap().clone();
         assert_eq!(data["height"], to_value(380).unwrap());
         assert_eq!(data["width"], to_value(300).unwrap());
+        assert_eq!(data["format"], to_value("jpg").unwrap());
+        assert_eq!(data["mime"], to_value("image/jpeg").unwrap());
     }
 }

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -305,7 +305,7 @@ It can take the following arguments:
 - `path`: mandatory, see [File Searching Logic](@/documentation/templates/overview.md#file-searching-logic) for details
 - `allow_missing`: optional, `true` or `false`, defaults to `false`. Whether a missing file should raise an error or not.
 
-The method returns a map containing `width`, `height` and `format` (the lowercased value as string).
+The method returns a map containing `width`, `height`, `format`, and `mime`. The `format` returned is the most common file extension for the file format, which may not match the one used for the image.
 
 ```jinja2
   {% set meta = get_image_metadata(path="...") %}


### PR DESCRIPTION
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?
* [x] Have you created/updated the relevant documentation page(s)?

This is required for OpenGraph under the `og:image:type` field, and probably other cases.

Also updated the documentation to clarify that `get_image_metadata` doesn't return the extension of the image, but the most common one for its format, so for example `image.jpeg` will show its format as `jpg`.