### PR TITLE
Issue 2359 get section by lang

### DIFF
--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -80,7 +80,11 @@ pub fn register_tera_global_fns(site: &mut Site) {
     );
     site.tera.register_function(
         "get_section",
-        global_fns::GetSection::new(site.base_path.clone(), &site.config.default_language, site.library.clone()),
+        global_fns::GetSection::new(
+            site.base_path.clone(),
+            &site.config.default_language,
+            site.library.clone(),
+        ),
     );
     site.tera.register_function(
         "get_taxonomy",

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -80,7 +80,7 @@ pub fn register_tera_global_fns(site: &mut Site) {
     );
     site.tera.register_function(
         "get_section",
-        global_fns::GetSection::new(site.base_path.clone(), site.library.clone()),
+        global_fns::GetSection::new(site.base_path.clone(), &site.config.default_language, site.library.clone()),
     );
     site.tera.register_function(
         "get_taxonomy",

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -1,5 +1,6 @@
 use crate::Site;
 use libs::tera::Result as TeraResult;
+use std::sync::Arc;
 use templates::{filters, global_fns};
 
 /// Adds global fns that are to be available to shortcodes while rendering markdown
@@ -74,15 +75,23 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
 
 /// Functions filled once we have parsed all the pages/sections only, so not available in shortcodes
 pub fn register_tera_global_fns(site: &mut Site) {
+    let language_list: Arc<Vec<String>> =
+        Arc::new(site.config.languages.keys().map(|s| s.to_string()).collect());
     site.tera.register_function(
         "get_page",
-        global_fns::GetPage::new(site.base_path.clone(), site.library.clone()),
+        global_fns::GetPage::new(
+            site.base_path.clone(),
+            &site.config.default_language,
+            Arc::clone(&language_list),
+            site.library.clone(),
+        ),
     );
     site.tera.register_function(
         "get_section",
         global_fns::GetSection::new(
             site.base_path.clone(),
             &site.config.default_language,
+            Arc::clone(&language_list),
             site.library.clone(),
         ),
     );

--- a/components/templates/src/global_fns/content.rs
+++ b/components/templates/src/global_fns/content.rs
@@ -143,34 +143,36 @@ impl TeraFn for GetSection {
         let lang =
             optional_arg!(String, args.get("lang"), "`get_section`: `lang` must be a string");
 
-        lang.as_ref().map_or_else(
-            || Ok(Cow::Borrowed(&path)),
-            |lang_code| match self.default_lang.as_str() == lang_code {
-                true => Ok(Cow::Borrowed(&path)),
-                false => Self::add_lang_to_path(&path, lang_code),
-            },
-        ).and_then(|calculated_path| {
-            let full_path = self.base_path.join(calculated_path.as_ref());
-            let library = self.library.read().unwrap();
-
-            match library.sections.get(&full_path) {
-                Some(s) => {
-                    if metadata_only {
-                        Ok(to_value(s.serialize_basic(&library)).unwrap())
-                    } else {
-                        Ok(to_value(s.serialize(&library)).unwrap())
-                    }
-                }
-                None => match lang {
-                    Some(lang_code) => Err(format!(
-                        "Section `{}` not found for language `{}`.",
-                        path, lang_code
-                    )
-                    .into()),
-                    None => Err(format!("Section `{}` not found.", path).into()),
+        lang.as_ref()
+            .map_or_else(
+                || Ok(Cow::Borrowed(&path)),
+                |lang_code| match self.default_lang.as_str() == lang_code {
+                    true => Ok(Cow::Borrowed(&path)),
+                    false => Self::add_lang_to_path(&path, lang_code),
                 },
-            }
-        })
+            )
+            .and_then(|calculated_path| {
+                let full_path = self.base_path.join(calculated_path.as_ref());
+                let library = self.library.read().unwrap();
+
+                match library.sections.get(&full_path) {
+                    Some(s) => {
+                        if metadata_only {
+                            Ok(to_value(s.serialize_basic(&library)).unwrap())
+                        } else {
+                            Ok(to_value(s.serialize(&library)).unwrap())
+                        }
+                    }
+                    None => match lang {
+                        Some(lang_code) => Err(format!(
+                            "Section `{}` not found for language `{}`.",
+                            path, lang_code
+                        )
+                        .into()),
+                        None => Err(format!("Section `{}` not found.", path).into()),
+                    },
+                }
+            })
     }
 }
 

--- a/components/templates/src/global_fns/content.rs
+++ b/components/templates/src/global_fns/content.rs
@@ -106,7 +106,11 @@ pub struct GetSection {
 }
 impl GetSection {
     pub fn new(base_path: PathBuf, default_lang: &str, library: Arc<RwLock<Library>>) -> Self {
-        Self { base_path: base_path.join("content"), default_lang: default_lang.to_string(), library }
+        Self {
+            base_path: base_path.join("content"),
+            default_lang: default_lang.to_string(),
+            library,
+        }
     }
 
     fn add_lang_to_path<'a>(path: &str, lang: &str) -> Result<Cow<'a, String>> {
@@ -160,14 +164,15 @@ impl TeraFn for GetSection {
                         }
                     }
                     None => match lang {
-                        Some(lang_code) => {
-                            Err(format!("Section `{}` not found for language `{}`.", path, lang_code)
-                                .into())
-                        }
+                        Some(lang_code) => Err(format!(
+                            "Section `{}` not found for language `{}`.",
+                            path, lang_code
+                        )
+                        .into()),
                         None => Err(format!("Section `{}` not found.", path).into()),
                     },
                 }
-            },
+            }
             Err(e) => Err(e),
         }
     }
@@ -316,10 +321,7 @@ mod tests {
     use std::sync::{Arc, RwLock};
 
     fn create_section(title: &str, file_path: &str, lang: &str) -> Section {
-        let mut section = Section{
-            lang: lang.to_owned(),
-            ..Section::default()
-        };
+        let mut section = Section { lang: lang.to_owned(), ..Section::default() };
         section.file = FileInfo::new_section(
             Path::new(format!("/test/base/path/{}", file_path).as_str()),
             &PathBuf::new(),

--- a/components/templates/src/global_fns/content.rs
+++ b/components/templates/src/global_fns/content.rs
@@ -72,14 +72,60 @@ impl TeraFn for GetTaxonomyUrl {
     }
 }
 
+fn add_lang_to_path<'a>(path: &str, lang: &str) -> Result<Cow<'a, String>> {
+    match path.rfind('.') {
+        Some(period_offset) => {
+            let prefix = path.get(0..period_offset);
+            let suffix = path.get(period_offset..);
+            if prefix.is_none() || suffix.is_none() {
+                Err(format!("Error adding language code to {}", path).into())
+            } else {
+                Ok(Cow::Owned(format!("{}.{}{}", prefix.unwrap(), lang, suffix.unwrap())))
+            }
+        }
+        None => Ok(Cow::Owned(format!("{}.{}", path, lang))),
+    }
+}
+
+fn calculate_path<'a>(
+    path: &'a String,
+    lang: &Option<String>,
+    default_lang: &str,
+    supported_languages: &[String],
+) -> Result<Cow<'a, String>> {
+    if supported_languages.contains(&default_lang.to_string()) {
+        lang.as_ref().map_or_else(
+            || Ok(Cow::Borrowed(path)),
+            |lang_code| match default_lang == lang_code {
+                true => Ok(Cow::Borrowed(path)),
+                false => add_lang_to_path(path, lang_code),
+            },
+        )
+    } else {
+        Err(format!("Unsupported language {}", default_lang).into())
+    }
+}
+
 #[derive(Debug)]
 pub struct GetPage {
     base_path: PathBuf,
+    default_lang: String,
+    supported_languages: Arc<Vec<String>>,
     library: Arc<RwLock<Library>>,
 }
 impl GetPage {
-    pub fn new(base_path: PathBuf, library: Arc<RwLock<Library>>) -> Self {
-        Self { base_path: base_path.join("content"), library }
+    pub fn new(
+        base_path: PathBuf,
+        default_lang: &str,
+        supported_languages: Arc<Vec<String>>,
+        library: Arc<RwLock<Library>>,
+    ) -> Self {
+        Self {
+            base_path: base_path.join("content"),
+            default_lang: default_lang.to_string(),
+            supported_languages,
+            library,
+        }
     }
 }
 impl TeraFn for GetPage {
@@ -89,12 +135,27 @@ impl TeraFn for GetPage {
             args.get("path"),
             "`get_page` requires a `path` argument with a string value"
         );
-        let full_path = self.base_path.join(&path);
-        let library = self.library.read().unwrap();
-        match library.pages.get(&full_path) {
-            Some(p) => Ok(to_value(p.serialize(&library)).unwrap()),
-            None => Err(format!("Page `{}` not found.", path).into()),
-        }
+
+        let lang =
+            optional_arg!(String, args.get("lang"), "`get_section`: `lang` must be a string");
+
+        calculate_path(&path, &lang, &self.default_lang, &self.supported_languages).and_then(
+            |calculated_path| {
+                let full_path = self.base_path.join(calculated_path.as_ref());
+                let library = self.library.read().unwrap();
+
+                match library.pages.get(&full_path) {
+                    Some(p) => Ok(to_value(p.serialize(&library)).unwrap()),
+                    None => match lang {
+                        Some(lang_code) => {
+                            Err(format!("Page `{}` not found for language `{}`.", path, lang_code)
+                                .into())
+                        }
+                        None => Err(format!("Page `{}` not found.", path).into()),
+                    },
+                }
+            },
+        )
     }
 }
 
@@ -102,29 +163,21 @@ impl TeraFn for GetPage {
 pub struct GetSection {
     base_path: PathBuf,
     default_lang: String,
+    supported_languages: Arc<Vec<String>>,
     library: Arc<RwLock<Library>>,
 }
 impl GetSection {
-    pub fn new(base_path: PathBuf, default_lang: &str, library: Arc<RwLock<Library>>) -> Self {
+    pub fn new(
+        base_path: PathBuf,
+        default_lang: &str,
+        supported_languages: Arc<Vec<String>>,
+        library: Arc<RwLock<Library>>,
+    ) -> Self {
         Self {
             base_path: base_path.join("content"),
             default_lang: default_lang.to_string(),
+            supported_languages,
             library,
-        }
-    }
-
-    fn add_lang_to_path<'a>(path: &str, lang: &str) -> Result<Cow<'a, String>> {
-        match path.rfind('.') {
-            Some(period_offset) => {
-                let prefix = path.get(0..period_offset);
-                let suffix = path.get(period_offset..);
-                if prefix.is_none() || suffix.is_none() {
-                    Err(format!("Error adding language code to {}", path).into())
-                } else {
-                    Ok(Cow::Owned(format!("{}.{}{}", prefix.unwrap(), lang, suffix.unwrap())))
-                }
-            }
-            None => Ok(Cow::Owned(format!("{}.{}", path, lang))),
         }
     }
 }
@@ -143,14 +196,7 @@ impl TeraFn for GetSection {
         let lang =
             optional_arg!(String, args.get("lang"), "`get_section`: `lang` must be a string");
 
-        lang.as_ref()
-            .map_or_else(
-                || Ok(Cow::Borrowed(&path)),
-                |lang_code| match self.default_lang.as_str() == lang_code {
-                    true => Ok(Cow::Borrowed(&path)),
-                    false => Self::add_lang_to_path(&path, lang_code),
-                },
-            )
+        calculate_path(&path, &lang, self.default_lang.as_str(), &self.supported_languages)
             .and_then(|calculated_path| {
                 let full_path = self.base_path.join(calculated_path.as_ref());
                 let library = self.library.read().unwrap();
@@ -314,9 +360,77 @@ impl TeraFn for GetTaxonomyTerm {
 mod tests {
     use super::*;
     use config::{Config, TaxonomyConfig};
-    use content::{FileInfo, Library, Section, SortBy, TaxonomyTerm};
+    use content::{FileInfo, Library, Page, Section, SortBy, TaxonomyTerm};
     use std::path::Path;
     use std::sync::{Arc, RwLock};
+
+    fn create_page(title: &str, file_path: &str, lang: &str) -> Page {
+        let mut page = Page { lang: lang.to_owned(), ..Page::default() };
+        page.file = FileInfo::new_page(
+            Path::new(format!("/test/base/path/{}", file_path).as_str()),
+            &PathBuf::new(),
+        );
+        page.meta.title = Some(title.to_string());
+        page.meta.weight = Some(1);
+        page.file.find_language("en", &["fr"]).unwrap();
+        page
+    }
+
+    #[test]
+    fn can_get_page() {
+        let mut library = Library::default();
+        let pages = vec![
+            ("Homepage", "content/homepage.md", "en"),
+            ("Page D'Accueil", "content/homepage.fr.md", "fr"),
+            ("Blog", "content/blog.md", "en"),
+            ("Wiki", "content/wiki.md", "en"),
+            ("Wiki", "content/wiki.fr.md", "fr"),
+            ("Recipes", "content/wiki/recipes.md", "en"),
+            ("Recettes", "content/wiki/recipes.fr.md", "fr"),
+            ("Programming", "content/wiki/programming.md", "en"),
+            ("La Programmation", "content/wiki/programming.fr.md", "fr"),
+            ("Novels", "content/novels.md", "en"),
+            ("Des Romans", "content/novels.fr.md", "fr"),
+        ];
+        for (t, f, l) in pages.clone() {
+            library.insert_page(create_page(t, f, l));
+        }
+        let base_path = "/test/base/path".into();
+        let lang_list = vec!["en".to_string(), "fr".to_string()];
+
+        let static_fn =
+            GetPage::new(base_path, "en", Arc::new(lang_list), Arc::new(RwLock::new(library)));
+
+        // Find with lang argument
+        let mut args = HashMap::new();
+        args.insert("path".to_string(), to_value("wiki/recipes.md").unwrap());
+        args.insert("lang".to_string(), to_value("fr").unwrap());
+        let res = static_fn.call(&args).unwrap();
+        let res_obj = res.as_object().unwrap();
+        assert_eq!(res_obj["title"], to_value("Recettes").unwrap());
+
+        // Find with lang in path for legacy support
+        args = HashMap::new();
+        args.insert("path".to_string(), to_value("wiki/recipes.fr.md").unwrap());
+        let res = static_fn.call(&args).unwrap();
+        let res_obj = res.as_object().unwrap();
+        assert_eq!(res_obj["title"], to_value("Recettes").unwrap());
+
+        // Find with default lang
+        args = HashMap::new();
+        args.insert("path".to_string(), to_value("wiki/recipes.md").unwrap());
+        let res = static_fn.call(&args).unwrap();
+        let res_obj = res.as_object().unwrap();
+        assert_eq!(res_obj["title"], to_value("Recipes").unwrap());
+
+        // Find with default lang when default lang passed
+        args = HashMap::new();
+        args.insert("path".to_string(), to_value("wiki/recipes.md").unwrap());
+        args.insert("lang".to_string(), to_value("en").unwrap());
+        let res = static_fn.call(&args).unwrap();
+        let res_obj = res.as_object().unwrap();
+        assert_eq!(res_obj["title"], to_value("Recipes").unwrap());
+    }
 
     fn create_section(title: &str, file_path: &str, lang: &str) -> Section {
         let mut section = Section { lang: lang.to_owned(), ..Section::default() };
@@ -353,8 +467,10 @@ mod tests {
             library.insert_section(create_section(t, f, l));
         }
         let base_path = "/test/base/path".into();
+        let lang_list = vec!["en".to_string(), "fr".to_string()];
 
-        let static_fn = GetSection::new(base_path, "en", Arc::new(RwLock::new(library)));
+        let static_fn =
+            GetSection::new(base_path, "en", Arc::new(lang_list), Arc::new(RwLock::new(library)));
 
         // Find with lang argument
         let mut args = HashMap::new();

--- a/components/templates/src/global_fns/content.rs
+++ b/components/templates/src/global_fns/content.rs
@@ -87,7 +87,7 @@ fn add_lang_to_path<'a>(path: &str, lang: &str) -> Result<Cow<'a, String>> {
     }
 }
 
-fn calculate_path<'a>(
+fn get_path_with_lang<'a>(
     path: &'a String,
     lang: &Option<String>,
     default_lang: &str,
@@ -139,9 +139,9 @@ impl TeraFn for GetPage {
         let lang =
             optional_arg!(String, args.get("lang"), "`get_section`: `lang` must be a string");
 
-        calculate_path(&path, &lang, &self.default_lang, &self.supported_languages).and_then(
-            |calculated_path| {
-                let full_path = self.base_path.join(calculated_path.as_ref());
+        get_path_with_lang(&path, &lang, &self.default_lang, &self.supported_languages).and_then(
+            |path_with_lang| {
+                let full_path = self.base_path.join(path_with_lang.as_ref());
                 let library = self.library.read().unwrap();
 
                 match library.pages.get(&full_path) {
@@ -196,9 +196,9 @@ impl TeraFn for GetSection {
         let lang =
             optional_arg!(String, args.get("lang"), "`get_section`: `lang` must be a string");
 
-        calculate_path(&path, &lang, self.default_lang.as_str(), &self.supported_languages)
-            .and_then(|calculated_path| {
-                let full_path = self.base_path.join(calculated_path.as_ref());
+        get_path_with_lang(&path, &lang, self.default_lang.as_str(), &self.supported_languages)
+            .and_then(|path_with_lang| {
+                let full_path = self.base_path.join(path_with_lang.as_ref());
                 let library = self.library.read().unwrap();
 
                 match library.sections.get(&full_path) {

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -154,6 +154,12 @@ If you only need the metadata of the section, you can pass `metadata_only=true` 
 {% set section = get_section(path="blog/_index.md", metadata_only=true) %}
 ```
 
+If selecting a specific language for the section, you can pass `lang` with the language code to the function:
+
+```jinja2
+{% set section = get_section(path="blog/_index.md", lang="fr") %}
+```
+
 ### `get_taxonomy_url`
 Gets the permalink for the taxonomy item found.
 

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -145,6 +145,12 @@ If selecting a specific language for the page, you can pass `lang` with the lang
 
 ```jinja2
 {% set page = get_page(path="blog/page2.md", lang="fr") %}
+
+{# If "fr" is the default language, this is equivalent to #}
+{% set page = get_page(path="blog/page2.md") %}
+
+{# If "fr" is not the default language, this is equivalent to #}
+{% set page = get_page(path="blog/page2.fr.md") %}
 ```
 
 ### `get_section`
@@ -164,6 +170,12 @@ If selecting a specific language for the section, you can pass `lang` with the l
 
 ```jinja2
 {% set section = get_section(path="blog/_index.md", lang="fr") %}
+
+{# If "fr" is the default language, this is equivalent to #}
+{% set section = get_section(path="blog/_index.md") %}
+
+{# If "fr" is not the default language, this is equivalent to #}
+{% set section = get_section(path="blog/_index.fr.md") %}
 ```
 
 ### `get_taxonomy_url`

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -141,6 +141,12 @@ Takes a path to an `.md` file and returns the associated page. The base path is 
 {% set page = get_page(path="blog/page2.md") %}
 ```
 
+If selecting a specific language for the page, you can pass `lang` with the language code to the function:
+
+```jinja2
+{% set page = get_page(path="blog/page2.md", lang="fr") %}
+```
+
 ### `get_section`
 Takes a path to an `_index.md` file and returns the associated section. The base path is the `content` directory.
 


### PR DESCRIPTION
Adding optional `lang` argument for `get_section` global function.  Language code will be added to the filename if it is not the default language.  Related issue [here](https://github.com/getzola/zola/issues/2359).

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



