### PR TITLE
Refactor: add BuildMode::Skip

### DIFF
--- a/components/site/src/sitemap.rs
+++ b/components/site/src/sitemap.rs
@@ -73,11 +73,13 @@ pub fn find_entries<'a>(
     }
 
     for s in library.sections.values() {
-        if s.meta.render {
-            let mut entry = SitemapEntry::new(Cow::Borrowed(&s.permalink), &None);
-            entry.add_extra(&s.meta.extra);
-            entries.insert(entry);
+        if !s.meta.render {
+            continue;
         }
+
+        let mut entry = SitemapEntry::new(Cow::Borrowed(&s.permalink), &None);
+        entry.add_extra(&s.meta.extra);
+        entries.insert(entry);
 
         if let Some(paginate_by) = s.paginate_by() {
             let number_pagers = (s.pages.len() as f64 / paginate_by as f64).ceil() as isize;


### PR DESCRIPTION
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?

**Note: this is rebased on top of #2418, and that should be merged first.**

This is an attempt at incorporating the refactoring done in #2388 without changing behaviour. It helps pave a path toward `render = false` for pages while making things a bit more consistent for the existing `render = false` for sections and taxonomies.

Effectively, `render = false` will still add things to the library, but their pages and aliases won't be rendered. We could potentially convert having `aliases` for something `render = false` to a hard error, but at least for now, it makes no sense to create links to something that isn't actually rendered.