### PR TITLE
Update pulldown_cmark dep to v0.10, and add pulldown_cmark_escape dep.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.19.0 (unreleased)
 
+- Updates the pulldown-cmark dependency to v0.10.0. This improves footnote handling, and may also introduce some minor behavior changes such as reducing the amount of unnecessary HTML-escaping of text content.
 
 ## 0.18.0 (2023-12-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,8 @@ dependencies = [
  "num-format",
  "once_cell",
  "percent-encoding",
- "pulldown-cmark",
+ "pulldown-cmark 0.10.0",
+ "pulldown-cmark-escape",
  "quickxml_to_serde",
  "rayon",
  "regex",
@@ -2776,6 +2777,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce76ce678ffc8e5675b22aa1405de0b7037e2fdf8913fea40d1926c6fe1e6e7"
+dependencies = [
+ "bitflags 2.4.1",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
+
+[[package]]
 name = "pure-rust-locales"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,7 +3360,7 @@ dependencies = [
  "cargo_metadata",
  "error-chain",
  "glob",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.3",
  "tempfile",
  "walkdir",
 ]

--- a/components/libs/Cargo.toml
+++ b/components/libs/Cargo.toml
@@ -21,7 +21,8 @@ nom-bibtex = "0.5"
 num-format = "0.4"
 once_cell = "1"
 percent-encoding = "2"
-pulldown-cmark = { version = "0.9", default-features = false, features = ["simd"]  }
+pulldown-cmark = { version = "0.10", default-features = false, features = ["html", "simd"] }
+pulldown-cmark-escape = { version = "0.10", default-features = false }
 quickxml_to_serde = "0.5"
 rayon = "1"
 regex = "1"

--- a/components/libs/src/lib.rs
+++ b/components/libs/src/lib.rs
@@ -23,6 +23,7 @@ pub use num_format;
 pub use once_cell;
 pub use percent_encoding;
 pub use pulldown_cmark;
+pub use pulldown_cmark_escape;
 pub use quickxml_to_serde;
 pub use rayon;
 pub use regex;

--- a/components/markdown/tests/snapshots/markdown__all_markdown_features_integration.snap
+++ b/components/markdown/tests/snapshots/markdown__all_markdown_features_integration.snap
@@ -1,8 +1,6 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 358
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <!-- Adapted from https://markdown-it.github.io/ -->
 <h1 id="h1-heading">h1 Heading</h1>
@@ -83,7 +81,7 @@ line 1 of code
 line 2 of code
 line 3 of code
 </code></pre>
-<p>Block code &quot;fences&quot;</p>
+<p>Block code "fences"</p>
 <pre><code>Sample text here...
 </code></pre>
 <p>Syntax highlighting</p>

--- a/components/markdown/tests/snapshots/markdown__can_handle_heading_ids-2.snap
+++ b/components/markdown/tests/snapshots/markdown__can_handle_heading_ids-2.snap
@@ -1,12 +1,10 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 84
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <h1 id="Hello">Hello</h1>
 <h1 id="Hello-1">Hello</h1>
-<h1 id="L'écologie_et_vous">L'écologie et vous</h1>
+<h1 id="L&#39;écologie_et_vous">L'écologie et vous</h1>
 <h1 id="hello">Hello</h1>
 <h1 id="hello">Hello</h1>
 <h1 id="Something_else">Hello</h1>
@@ -22,6 +20,6 @@ expression: body
 <h1 id="text__there">text <sup class="footnote-reference"><a href="#1">1</a></sup> there</h1>
 <div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup>
 <p>footnote</p>
-<h1 id="classes" class="bold another">Classes</h1>
 </div>
+<h1 id="classes" class="bold another">Classes</h1>
 

--- a/components/markdown/tests/snapshots/markdown__can_handle_heading_ids.snap
+++ b/components/markdown/tests/snapshots/markdown__can_handle_heading_ids.snap
@@ -1,8 +1,6 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 79
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <h1 id="hello-1">Hello</h1>
 <h1 id="hello-2">Hello</h1>
@@ -22,6 +20,6 @@ expression: body
 <h1 id="text-there">text <sup class="footnote-reference"><a href="#1">1</a></sup> there</h1>
 <div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup>
 <p>footnote</p>
-<h1 id="classes" class="bold another">Classes</h1>
 </div>
+<h1 id="classes" class="bold another">Classes</h1>
 

--- a/components/markdown/tests/snapshots/shortcodes__doesnt_render_ignored_shortcodes.snap
+++ b/components/markdown/tests/snapshots/shortcodes__doesnt_render_ignored_shortcodes.snap
@@ -1,8 +1,6 @@
 ---
-source: components/rendering/tests/shortcodes.rs
-assertion_line: 104
+source: components/markdown/tests/shortcodes.rs
 expression: body
-
 ---
-<p>{{ youtube(id=&quot;w7Ft2ymGmfc&quot;) }}</p>
+<p>{{ youtube(id="w7Ft2ymGmfc") }}</p>
 


### PR DESCRIPTION
The pulldown_cmark escaping functionality is now shipped in a separate
pulldown_cmark_escape crate
(https://crates.io/crates/pulldown-cmark-escape), starting with v0.10.0.

The markdown.rs module has to be adapted to a few API changes in
pulldown_cmark, and we have to introduce explicit handling of <img> alt
text to ensure it continues to be properly escaped.

There are also a few other behavior changes that are caught by the
tests, but these actually seem to be desired, so I've updated the insta
snapshot files for those tests to incorporate those changes.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
Yes, but see the related https://github.com/getzola/zola/pull/2326#issuecomment-1929315804.

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
   --> N/A



