### PR TITLE
Fix typo in Fedora installation instructions

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -49,7 +49,7 @@ $ sudo dpkg -i zola_<version>_amd64_debian_<debian_version>.deb
 
 ### Fedora
 
-On Fedora, Zola is avialable via [COPR](https://fedoraproject.org/wiki/Category:Copr).
+On Fedora, Zola is available via [COPR](https://fedoraproject.org/wiki/Category:Copr).
 
 ```sh
 $ sudo dnf copr enable fz0x1/zola


### PR DESCRIPTION
Just a minor typo in the Fedora installation instructions that bothered me.

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

