### PR TITLE
Add mention of `authors` template page variable to docs

### DIFF
--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -22,6 +22,7 @@ date: String?;
 updated: String?;
 slug: String;
 path: String;
+authors: Array<String>;
 draft: Bool;
 // the path, split on '/'
 components: Array<String>;


### PR DESCRIPTION
The `authors` variable so far has only been documented as something you can define in the front matter for use of feeds primarily, but it also works in templates to define the authors of a page. (For practical use see: https://github.com/bevyengine/bevy-website/pull/1073/commits/6c293fa1a446036a8b6becf307b0112830c63d41#diff-672b08946ef5cbc8db5c086bf50651b69b29e9d7be0708a1de7ded170b440e99)

This PR adds it to the documentation so that folks don't have to dig in commit histories to figure out it also works in templates.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
