### PR TITLE
Fix CloudFront Cache Invalidation Path in GitHub Actions Deployment Example

### DIFF
--- a/docs/content/documentation/deployment/aws-s3.md
+++ b/docs/content/documentation/deployment/aws-s3.md
@@ -89,7 +89,7 @@ jobs:
           bucket-region: us-east-1
           # Use the next two only if you have created a CloudFront distribution
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          invalidation: /
+          invalidation: /*
 ```
 
 Note, that you may need to change the branch name in the above snippet if you desire a different behavior.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

### Description
This pull request addresses an issue in the GitHub Actions workflow example for deploying a website to an AWS S3 bucket with CloudFront distribution. Previously, the workflow was configured to invalidate the CloudFront cache using the path "invalidation: /", which does not effectively clear the cached content across the entire distribution.

### Problem
The original cache invalidation directive "invalidation: /" in the GitHub Actions configuration file does not correctly specify the path pattern for CloudFront to invalidate. According to AWS CloudFront documentation, to invalidate all files, the path pattern must be specified as "/*". The incorrect path specification led to situations where updated content was not properly served due to the old cached versions persisting in CloudFront.

### Solution
This pull request corrects the cache invalidation path by changing the directive from "invalidation: /" to "invalidation: /*" within the GitHub Actions workflow file. This ensures that all files are correctly invalidated in the CloudFront distribution, allowing for updated content to be served immediately after deployment.