### PR TITLE
Fix section.transparent serialization

### DIFF
--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -161,6 +161,7 @@ pub struct SerializingSection<'a> {
     translations: Vec<TranslatedContent<'a>>,
     backlinks: Vec<BackLink<'a>>,
     generate_feed: bool,
+    transparent: bool,
 }
 
 #[derive(Debug)]
@@ -220,6 +221,7 @@ impl<'a> SerializingSection<'a> {
             assets: &section.serialized_assets,
             lang: &section.lang,
             generate_feed: section.meta.generate_feed,
+            transparent: section.meta.transparent,
             pages,
             subsections,
             translations,

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -109,6 +109,8 @@ translations: Array<TranslatedContent>;
 backlinks: Array<{permalink: String, title: String?}>;
 // Whether this section generates a feed or not. Taken from the front-matter if set
 generate_feed: bool;
+// Whether this section is transparent. Taken from the front-matter if set
+transparent: bool;
 ```
 
 ## Table of contents


### PR DESCRIPTION
Fixes passing `section.transparent` for https://github.com/getzola/zola/commit/e8b04bb11a9464d515b47bd76bd732d7e83d6965 and https://github.com/getzola/zola/issues/1840

I cobbled a test together from the examples, but suspect it only checks for a section having `transparent` set internally, and not a template having access to `{{ section.transparent }}`... Since both rely on `meta.transparent` anyway, it's perhaps best to leave it at this.

If you have any remarks, let me know.

```
#[test]
fn check_transparancy() {
    let (mut site, _tmp_dir, _public) = build_site("test_site");
    site.load().unwrap();

    let mut path = env::current_dir().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
    path.push("test_site");
    let posts_path = path.join("content").join("posts");
    let transparent_section_path = posts_path.join("2018");

    let library = site.library.read().unwrap();
    let section = library.sections.get(&transparent_section_path.join("_index.md")).unwrap();   
    assert_eq!(section.meta.transparent, true);
}
```