### PR TITLE
Fix resizing for images with EXIF orientation

### DIFF
--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -38,7 +38,8 @@ impl ImageOp {
             return Ok(());
         }
 
-        let mut img = image::open(&self.input_path)?;
+        let img = image::open(&self.input_path)?;
+        let mut img = fix_orientation(&img, &self.input_path).unwrap_or(img);
 
         let img = match self.instr.crop_instruction {
             Some((x, y, w, h)) => img.crop(x, y, w, h),
@@ -48,8 +49,6 @@ impl ImageOp {
             Some((w, h)) => img.resize_exact(w, h, FilterType::Lanczos3),
             None => img,
         };
-
-        let img = fix_orientation(&img, &self.input_path).unwrap_or(img);
 
         let f = File::create(&self.output_path)?;
         let mut buffered_f = BufWriter::new(f);

--- a/components/imageproc/tests/resize_image.rs
+++ b/components/imageproc/tests/resize_image.rs
@@ -248,3 +248,25 @@ fn check_img(img: DynamicImage) -> bool {
     // bottom right is white
         && img.get_pixel(15, 15).channels() == [255, 255, 255, 255]
 }
+
+#[test]
+fn asymmetric_resize_with_exif_orientations() {
+    // No exif metadata
+    image_op_test("exif_0.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    // 1: Horizontal (normal)
+    image_op_test("exif_1.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    // 2: Mirror horizontal
+    image_op_test("exif_2.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    // 3: Rotate 180
+    image_op_test("exif_3.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    // 4: Mirror vertical
+    image_op_test("exif_4.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    // 5: Mirror horizontal and rotate 270 CW
+    image_op_test("exif_5.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    // 6: Rotate 90 CW
+    image_op_test("exif_6.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    // 7: Mirror horizontal and rotate 90 CW
+    image_op_test("exif_7.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    // 8: Rotate 270 CW
+    image_op_test("exif_8.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+}


### PR DESCRIPTION
Fixes https://github.com/getzola/zola/issues/2445


### Previous Behavior
```bash
$ identify test.png
test.png PNG 300x380 300x380+0+0 8-bit sRGB 123430B 0.000u 0:00.000

$ identify -format '%[orientation]' static/photos/testExif.jpeg
RightTop

# resize_image(..., width=300, height=100)

$ identify test.2b662a94d62c950e.png
test.2b662a94d62c950e.png PNG 100x300 100x300+0+0 8-bit sRGB 65706B 0.000u 0:00.000

$ identify -format '%[orientation]' test.2b662a94d62c950e.png
Undefined
```


### New Behavior
```bash
$ identify test.png
test.png PNG 300x380 300x380+0+0 8-bit sRGB 123430B 0.000u 0:00.000

$ identify -format '%[orientation]' static/photos/testExif.jpeg
RightTop

# resize_image(..., width=300, height=100)

$ identify test.2b662a94d62c950e.png
test.2b662a94d62c950e.png PNG 300x100 300x100+0+0 8-bit sRGB 65706B 0.000u 0:00.000

$ identify -format '%[orientation]' test.2b662a94d62c950e.png
Undefined
```


Let me know if you have any remarks.