### PR TITLE
Fix link check report inconsistency

### DIFF
--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -178,9 +178,12 @@ pub fn check_external_links(site: &Site) -> Vec<String> {
         }
     }
 
+    // Get unique links count from Vec by creating a temporary HashSet.
     let unique_links_count = HashSet::<&str>::from_iter(
         checked_links.iter().map(|link_def| link_def.external_link.as_str()),
-    ).len();
+    )
+    .len();
+
     println!(
         "Checking {} external link(s). Skipping {} external link(s).{}",
         unique_links_count,

--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -178,13 +178,12 @@ pub fn check_external_links(site: &Site) -> Vec<String> {
         }
     }
 
+    let unique_links_count = HashSet::<&str>::from_iter(
+        checked_links.iter().map(|link_def| link_def.external_link.as_str()),
+    ).len();
     println!(
         "Checking {} external link(s). Skipping {} external link(s).{}",
-        // Get unique links count from Vec by creating a temporary HashSet.
-        HashSet::<&str>::from_iter(
-            checked_links.iter().map(|link_def| link_def.external_link.as_str())
-        )
-        .len(),
+        unique_links_count,
         skipped_link_count,
         if invalid_url_links == 0 {
             "".to_string()
@@ -272,7 +271,7 @@ pub fn check_external_links(site: &Site) -> Vec<String> {
 
             println!(
                 "> Checked {} external link(s): {} error(s) found.",
-                checked_links.len(),
+                unique_links_count,
                 errors.len()
             );
 


### PR DESCRIPTION
Fixes: https://github.com/getzola/zola/issues/2412

## Root Cause
In the first log we are removing duplicate links by using HashSet but in the second log we were counting all links

## Tests
Skipped tests cause this is a logging issue and does not affects the functionality