### PR TITLE
Docs: slugify.paths replaces whitespace with - not _

### DIFF
--- a/docs/content/documentation/content/linking.md
+++ b/docs/content/documentation/content/linking.md
@@ -6,7 +6,7 @@ weight = 50
 ## Heading id and anchor insertion
 While rendering the Markdown content, a unique id will automatically be assigned to each heading. 
 This id is created by converting the heading text to a [slug](https://en.wikipedia.org/wiki/Semantic_URL#Slug) if `slugify.anchors` is set to `"on"` (the default).
-If `slugify.paths` is set to `"safe"`, whitespaces are replaced by `_` and the following characters are stripped: `#`, `%`, `<`, `>`, `[`, `]`, `(`, `)`, \`, `^`, `{`, `|`, `}`.
+If `slugify.paths` is set to `"safe"`, whitespaces are replaced by `-` and the following characters are stripped: `#`, `%`, `<`, `>`, `[`, `]`, `(`, `)`, \`, `^`, `{`, `|`, `}`.
 If `slugify.paths` is set to `"off"`, no modifications are made, and you may be left with nominally illegal ids.
 A number is appended at the end if the slug already exists for that article.
 For example:


### PR DESCRIPTION
Minor documentation fix: when `slugify.paths` is set to `"safe"`, whitespaces are replaced with a hyphen, not an underscore.

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



