### PR TITLE
Added support for multiple feeds (i.e. generating both Atom and RSS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Added support for generating multiple kinds of feeds at once
 - Changed config options named `generate_feed` to `generate_feeds` (both in config.toml and in section front-matter)
 - Changed config option `feed_filename: String` to `feed_filenames: Vec<String>`
-- The config file no longer allows arbitrary fields outside the `[extra]` section (front-matter is unaffected)
+- The config file no longer allows arbitrary fields outside the `[extra]` section
 
 ## 0.18.0 (2023-12-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Add `render = false` capability to pages
 - Handle string dates in YAML front-matter
 - Add support for fuse.js search format
+- Added support for generating multiple kinds of feeds at once
+- Changed config options named `generate_feed` to `generate_feeds` (both in config.toml and in section front-matter)
+- Changed config option `feed_filename: String` to `feed_filenames: Vec<String>`
 
 ## 0.18.0 (2023-12-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added support for generating multiple kinds of feeds at once
 - Changed config options named `generate_feed` to `generate_feeds` (both in config.toml and in section front-matter)
 - Changed config option `feed_filename: String` to `feed_filenames: Vec<String>`
+- The config file no longer allows arbitrary fields outside the `[extra]` section (front-matter is unaffected)
 
 ## 0.18.0 (2023-12-18)
 

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::search;
 use crate::config::taxonomies;
+use crate::config::might_be_single;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
@@ -15,9 +16,11 @@ pub struct LanguageOptions {
     /// Description of the site. Defaults to None
     pub description: Option<String>,
     /// Whether to generate feeds for that language, defaults to `false`
+    #[serde(alias = "generate_feed")]
     pub generate_feeds: bool,
     /// The filenames to use for feeds. Used to find the templates, too.
     /// Defaults to ["atom.xml"], with "rss.xml" also having a template provided out of the box.
+    #[serde(deserialize_with = "might_be_single")]
     pub feed_filenames: Vec<String>,
     pub taxonomies: Vec<taxonomies::TaxonomyConfig>,
     /// Whether to generate search index for that language, defaults to `false`

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -4,9 +4,9 @@ use errors::{bail, Result};
 use libs::unic_langid::LanguageIdentifier;
 use serde::{Deserialize, Serialize};
 
+use crate::config::might_be_single;
 use crate::config::search;
 use crate::config::taxonomies;
-use crate::config::might_be_single;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
@@ -20,7 +20,7 @@ pub struct LanguageOptions {
     pub generate_feeds: bool,
     /// The filenames to use for feeds. Used to find the templates, too.
     /// Defaults to ["atom.xml"], with "rss.xml" also having a template provided out of the box.
-    #[serde(deserialize_with = "might_be_single")]
+    #[serde(alias = "feed_filename", deserialize_with = "might_be_single")]
     pub feed_filenames: Vec<String>,
     pub taxonomies: Vec<taxonomies::TaxonomyConfig>,
     /// Whether to generate search index for that language, defaults to `false`
@@ -69,7 +69,8 @@ impl LanguageOptions {
         merge_field!(self.title, other.title, "title");
         merge_field!(self.description, other.description, "description");
         merge_field!(
-            self.feed_filenames.is_empty(),
+            self.feed_filenames.is_empty()
+                || self.feed_filenames == LanguageOptions::default().feed_filenames,
             self.feed_filenames,
             other.feed_filenames,
             "feed_filename"

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -14,11 +14,11 @@ pub struct LanguageOptions {
     pub title: Option<String>,
     /// Description of the site. Defaults to None
     pub description: Option<String>,
-    /// Whether to generate a feed for that language, defaults to `false`
-    pub generate_feed: bool,
-    /// The filename to use for feeds. Used to find the template, too.
-    /// Defaults to "atom.xml", with "rss.xml" also having a template provided out of the box.
-    pub feed_filename: String,
+    /// Whether to generate feeds for that language, defaults to `false`
+    pub generate_feeds: bool,
+    /// The filenames to use for feeds. Used to find the templates, too.
+    /// Defaults to ["atom.xml"], with "rss.xml" also having a template provided out of the box.
+    pub feed_filenames: Vec<String>,
     pub taxonomies: Vec<taxonomies::TaxonomyConfig>,
     /// Whether to generate search index for that language, defaults to `false`
     pub build_search_index: bool,
@@ -66,9 +66,9 @@ impl LanguageOptions {
         merge_field!(self.title, other.title, "title");
         merge_field!(self.description, other.description, "description");
         merge_field!(
-            self.feed_filename == "atom.xml",
-            self.feed_filename,
-            other.feed_filename,
+            self.feed_filenames.is_empty(),
+            self.feed_filenames,
+            other.feed_filenames,
             "feed_filename"
         );
         merge_field!(self.taxonomies.is_empty(), self.taxonomies, other.taxonomies, "taxonomies");
@@ -79,7 +79,7 @@ impl LanguageOptions {
             "translations"
         );
 
-        self.generate_feed = self.generate_feed || other.generate_feed;
+        self.generate_feeds = self.generate_feeds || other.generate_feeds;
         self.build_search_index = self.build_search_index || other.build_search_index;
 
         if self.search == search::Search::default() {
@@ -101,8 +101,8 @@ impl Default for LanguageOptions {
         LanguageOptions {
             title: None,
             description: None,
-            generate_feed: false,
-            feed_filename: "atom.xml".to_string(),
+            generate_feeds: false,
+            feed_filenames: vec!["atom.xml".to_string()],
             taxonomies: vec![],
             build_search_index: false,
             search: search::Search::default(),
@@ -129,8 +129,8 @@ mod tests {
         let mut base_default_language_options = LanguageOptions {
             title: Some("Site's title".to_string()),
             description: None,
-            generate_feed: true,
-            feed_filename: "atom.xml".to_string(),
+            generate_feeds: true,
+            feed_filenames: vec!["atom.xml".to_string()],
             taxonomies: vec![],
             build_search_index: true,
             search: search::Search::default(),
@@ -140,8 +140,8 @@ mod tests {
         let section_default_language_options = LanguageOptions {
             title: None,
             description: Some("Site's description".to_string()),
-            generate_feed: false,
-            feed_filename: "rss.xml".to_string(),
+            generate_feeds: false,
+            feed_filenames: vec!["rss.xml".to_string()],
             taxonomies: vec![],
             build_search_index: true,
             search: search::Search::default(),
@@ -156,8 +156,8 @@ mod tests {
         let mut base_default_language_options = LanguageOptions {
             title: Some("Site's title".to_string()),
             description: Some("Duplicate site description".to_string()),
-            generate_feed: true,
-            feed_filename: "".to_string(),
+            generate_feeds: true,
+            feed_filenames: vec![],
             taxonomies: vec![],
             build_search_index: true,
             search: search::Search::default(),
@@ -167,8 +167,8 @@ mod tests {
         let section_default_language_options = LanguageOptions {
             title: None,
             description: Some("Site's description".to_string()),
-            generate_feed: false,
-            feed_filename: "Some feed_filename".to_string(),
+            generate_feeds: false,
+            feed_filenames: vec!["Some feed_filename".to_string()],
             taxonomies: vec![],
             build_search_index: true,
             search: search::Search::default(),

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -5,22 +5,19 @@ use libs::unic_langid::LanguageIdentifier;
 use serde::{Deserialize, Serialize};
 
 use crate::config::search;
-use crate::config::single_or_vec;
 use crate::config::taxonomies;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct LanguageOptions {
     /// Title of the site. Defaults to None
     pub title: Option<String>,
     /// Description of the site. Defaults to None
     pub description: Option<String>,
     /// Whether to generate feeds for that language, defaults to `false`
-    #[serde(alias = "generate_feed")]
     pub generate_feeds: bool,
     /// The filenames to use for feeds. Used to find the templates, too.
     /// Defaults to ["atom.xml"], with "rss.xml" also having a template provided out of the box.
-    #[serde(alias = "feed_filename", deserialize_with = "single_or_vec")]
     pub feed_filenames: Vec<String>,
     pub taxonomies: Vec<taxonomies::TaxonomyConfig>,
     /// Whether to generate search index for that language, defaults to `false`

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -4,8 +4,8 @@ use errors::{bail, Result};
 use libs::unic_langid::LanguageIdentifier;
 use serde::{Deserialize, Serialize};
 
-use crate::config::might_be_single;
 use crate::config::search;
+use crate::config::single_or_vec;
 use crate::config::taxonomies;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -20,7 +20,7 @@ pub struct LanguageOptions {
     pub generate_feeds: bool,
     /// The filenames to use for feeds. Used to find the templates, too.
     /// Defaults to ["atom.xml"], with "rss.xml" also having a template provided out of the box.
-    #[serde(alias = "feed_filename", deserialize_with = "might_be_single")]
+    #[serde(alias = "feed_filename", deserialize_with = "single_or_vec")]
     pub feed_filenames: Vec<String>,
     pub taxonomies: Vec<taxonomies::TaxonomyConfig>,
     /// Whether to generate search index for that language, defaults to `false`

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -49,13 +49,13 @@ pub struct Config {
     /// The translations strings for the default language
     translations: HashMap<String, String>,
 
-    /// Whether to generate a feed. Defaults to false.
-    pub generate_feed: bool,
+    /// Whether to generate feeds. Defaults to false.
+    pub generate_feeds: bool,
     /// The number of articles to include in the feed. Defaults to including all items.
     pub feed_limit: Option<usize>,
-    /// The filename to use for feeds. Used to find the template, too.
-    /// Defaults to "atom.xml", with "rss.xml" also having a template provided out of the box.
-    pub feed_filename: String,
+    /// The filenames to use for feeds. Used to find the templates, too.
+    /// Defaults to ["atom.xml"], with "rss.xml" also having a template provided out of the box.
+    pub feed_filenames: Vec<String>,
     /// If set, files from static/ will be hardlinked instead of copied to the output dir.
     pub hard_link_static: bool,
     pub taxonomies: Vec<taxonomies::TaxonomyConfig>,
@@ -109,7 +109,7 @@ pub struct SerializedConfig<'a> {
     languages: HashMap<&'a String, &'a languages::LanguageOptions>,
     default_language: &'a str,
     generate_feed: bool,
-    feed_filename: &'a str,
+    feed_filenames: &'a [String],
     taxonomies: &'a [taxonomies::TaxonomyConfig],
     author: &'a Option<String>,
     build_search_index: bool,
@@ -183,12 +183,14 @@ impl Config {
 
     /// Makes a url, taking into account that the base url might have a trailing slash
     pub fn make_permalink(&self, path: &str) -> String {
-        let trailing_bit =
-            if path.ends_with('/') || path.ends_with(&self.feed_filename) || path.is_empty() {
-                ""
-            } else {
-                "/"
-            };
+        let trailing_bit = if path.ends_with('/')
+            || self.feed_filenames.iter().any(|feed_filename| path.ends_with(feed_filename))
+            || path.is_empty()
+        {
+            ""
+        } else {
+            "/"
+        };
 
         // Index section with a base url that has a trailing slash
         if self.base_url.ends_with('/') && path == "/" {
@@ -212,8 +214,8 @@ impl Config {
         let mut base_language_options = languages::LanguageOptions {
             title: self.title.clone(),
             description: self.description.clone(),
-            generate_feed: self.generate_feed,
-            feed_filename: self.feed_filename.clone(),
+            generate_feeds: self.generate_feeds,
+            feed_filenames: self.feed_filenames.clone(),
             build_search_index: self.build_search_index,
             taxonomies: self.taxonomies.clone(),
             search: self.search.clone(),
@@ -320,8 +322,8 @@ impl Config {
             description: &options.description,
             languages: self.languages.iter().filter(|(k, _)| k.as_str() != lang).collect(),
             default_language: &self.default_language,
-            generate_feed: options.generate_feed,
-            feed_filename: &options.feed_filename,
+            generate_feed: options.generate_feeds,
+            feed_filenames: &options.feed_filenames,
             taxonomies: &options.taxonomies,
             author: &self.author,
             build_search_index: options.build_search_index,
@@ -369,9 +371,9 @@ impl Default for Config {
             theme: None,
             default_language: "en".to_string(),
             languages: HashMap::new(),
-            generate_feed: false,
+            generate_feeds: false,
             feed_limit: None,
-            feed_filename: "atom.xml".to_string(),
+            feed_filenames: vec!["atom.xml".to_string()],
             hard_link_static: false,
             taxonomies: Vec::new(),
             author: None,
@@ -428,8 +430,8 @@ mod tests {
             languages::LanguageOptions {
                 title: None,
                 description: description_lang_section.clone(),
-                generate_feed: true,
-                feed_filename: config.feed_filename.clone(),
+                generate_feeds: true,
+                feed_filenames: config.feed_filenames.clone(),
                 taxonomies: config.taxonomies.clone(),
                 build_search_index: false,
                 search: search::Search::default(),
@@ -456,8 +458,8 @@ mod tests {
             languages::LanguageOptions {
                 title: title_lang_section.clone(),
                 description: None,
-                generate_feed: true,
-                feed_filename: config.feed_filename.clone(),
+                generate_feeds: true,
+                feed_filenames: config.feed_filenames.clone(),
                 taxonomies: config.taxonomies.clone(),
                 build_search_index: false,
                 search: search::Search::default(),

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -2,7 +2,7 @@ mod config;
 pub mod highlighting;
 mod theme;
 
-use std::path::Path;
+use std::{marker::PhantomData, path::Path};
 
 pub use crate::config::{
     languages::LanguageOptions,
@@ -14,9 +14,35 @@ pub use crate::config::{
     Config,
 };
 use errors::Result;
+use serde::Deserialize;
 
 /// Get and parse the config.
 /// If it doesn't succeed, exit
 pub fn get_config(filename: &Path) -> Result<Config> {
     Config::from_file(filename)
+}
+
+/// This is used to print an error message for deprecated fields
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Deprecated<T> {
+    _type: PhantomData<T>,
+}
+
+impl<T> Deprecated<T> {
+    pub fn new() -> Self {
+        Self { _type: PhantomData }
+    }
+}
+
+pub trait DeprecationReason {
+    const REASON: &'static str;
+}
+
+impl<'de, T: DeprecationReason> Deserialize<'de> for Deprecated<T> {
+    fn deserialize<D>(_deserializer: D) -> std::prelude::v1::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Err(serde::de::Error::custom(format!("Failed to parse a deprecated option: {}", T::REASON)))
+    }
 }

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -2,7 +2,7 @@ mod config;
 pub mod highlighting;
 mod theme;
 
-use std::{marker::PhantomData, path::Path};
+use std::path::Path;
 
 pub use crate::config::{
     languages::LanguageOptions,
@@ -14,35 +14,9 @@ pub use crate::config::{
     Config,
 };
 use errors::Result;
-use serde::Deserialize;
 
 /// Get and parse the config.
 /// If it doesn't succeed, exit
 pub fn get_config(filename: &Path) -> Result<Config> {
     Config::from_file(filename)
-}
-
-/// This is used to print an error message for deprecated fields
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct Deprecated<T> {
-    _type: PhantomData<T>,
-}
-
-impl<T> Deprecated<T> {
-    pub fn new() -> Self {
-        Self { _type: PhantomData }
-    }
-}
-
-pub trait DeprecationReason {
-    const REASON: &'static str;
-}
-
-impl<'de, T: DeprecationReason> Deserialize<'de> for Deprecated<T> {
-    fn deserialize<D>(_deserializer: D) -> std::prelude::v1::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        Err(serde::de::Error::custom(format!("Failed to parse a deprecated option: {}", T::REASON)))
-    }
 }

--- a/components/content/src/front_matter/section.rs
+++ b/components/content/src/front_matter/section.rs
@@ -69,7 +69,7 @@ pub struct SectionFrontMatter {
     pub aliases: Vec<String>,
     /// Whether to generate a feed for the current section
     #[serde(skip_serializing)]
-    pub generate_feed: bool,
+    pub generate_feeds: bool,
     /// Any extra parameter present in the front matter
     pub extra: Map<String, Value>,
 }
@@ -113,7 +113,7 @@ impl Default for SectionFrontMatter {
             transparent: false,
             page_template: None,
             aliases: Vec::new(),
-            generate_feed: false,
+            generate_feeds: false,
             extra: Map::new(),
             draft: false,
         }

--- a/components/content/src/front_matter/section.rs
+++ b/components/content/src/front_matter/section.rs
@@ -1,6 +1,7 @@
 use libs::tera::{Map, Value};
 use serde::{Deserialize, Serialize};
 
+use config::{Deprecated, DeprecationReason};
 use errors::Result;
 use utils::de::fix_toml_dates;
 use utils::types::InsertAnchor;
@@ -67,11 +68,21 @@ pub struct SectionFrontMatter {
     /// redirect to this
     #[serde(skip_serializing)]
     pub aliases: Vec<String>,
+    /// Deprecated
+    #[serde(skip_serializing)]
+    pub generate_feed: Deprecated<DeprecatedGenerateFeed>,
     /// Whether to generate a feed for the current section
-    #[serde(skip_serializing, alias = "generate_feed")]
+    #[serde(skip_serializing)]
     pub generate_feeds: bool,
     /// Any extra parameter present in the front matter
     pub extra: Map<String, Value>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct DeprecatedGenerateFeed {}
+
+impl DeprecationReason for DeprecatedGenerateFeed {
+    const REASON: &'static str = "generate_feed is deprecated, please use generate_feeds instead";
 }
 
 impl SectionFrontMatter {
@@ -113,6 +124,7 @@ impl Default for SectionFrontMatter {
             transparent: false,
             page_template: None,
             aliases: Vec::new(),
+            generate_feed: Deprecated::new(),
             generate_feeds: false,
             extra: Map::new(),
             draft: false,

--- a/components/content/src/front_matter/section.rs
+++ b/components/content/src/front_matter/section.rs
@@ -68,7 +68,7 @@ pub struct SectionFrontMatter {
     #[serde(skip_serializing)]
     pub aliases: Vec<String>,
     /// Whether to generate a feed for the current section
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing, alias = "generate_feed")]
     pub generate_feeds: bool,
     /// Any extra parameter present in the front matter
     pub extra: Map<String, Value>,

--- a/components/content/src/front_matter/section.rs
+++ b/components/content/src/front_matter/section.rs
@@ -1,7 +1,6 @@
 use libs::tera::{Map, Value};
 use serde::{Deserialize, Serialize};
 
-use config::{Deprecated, DeprecationReason};
 use errors::Result;
 use utils::de::fix_toml_dates;
 use utils::types::InsertAnchor;
@@ -13,7 +12,7 @@ static DEFAULT_PAGINATE_PATH: &str = "page";
 
 /// The front matter of every section
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct SectionFrontMatter {
     /// <title> of the page
     pub title: Option<String>,
@@ -68,21 +67,11 @@ pub struct SectionFrontMatter {
     /// redirect to this
     #[serde(skip_serializing)]
     pub aliases: Vec<String>,
-    /// Deprecated
-    #[serde(skip_serializing)]
-    pub generate_feed: Deprecated<DeprecatedGenerateFeed>,
     /// Whether to generate a feed for the current section
     #[serde(skip_serializing)]
     pub generate_feeds: bool,
     /// Any extra parameter present in the front matter
     pub extra: Map<String, Value>,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct DeprecatedGenerateFeed {}
-
-impl DeprecationReason for DeprecatedGenerateFeed {
-    const REASON: &'static str = "generate_feed is deprecated, please use generate_feeds instead";
 }
 
 impl SectionFrontMatter {
@@ -124,7 +113,6 @@ impl Default for SectionFrontMatter {
             transparent: false,
             page_template: None,
             aliases: Vec::new(),
-            generate_feed: Deprecated::new(),
             generate_feeds: false,
             extra: Map::new(),
             draft: false,

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -283,7 +283,7 @@ mod tests {
         create_dir_all(path.join(&article_path).join("foo/baz/quux"))
             .expect("create nested temp dir");
         let mut f = File::create(article_path.join("_index.md")).unwrap();
-        f.write_all(b"+++\nslug=\"hey\"\n+++\n").unwrap();
+        f.write_all(b"+++\n+++\n").unwrap();
         File::create(article_path.join("example.js")).unwrap();
         File::create(article_path.join("graph.jpg")).unwrap();
         File::create(article_path.join("fail.png")).unwrap();

--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -160,7 +160,7 @@ pub struct SerializingSection<'a> {
     subsections: Vec<&'a str>,
     translations: Vec<TranslatedContent<'a>>,
     backlinks: Vec<BackLink<'a>>,
-    generate_feed: bool,
+    generate_feeds: bool,
     transparent: bool,
 }
 
@@ -220,7 +220,7 @@ impl<'a> SerializingSection<'a> {
             reading_time: section.reading_time,
             assets: &section.serialized_assets,
             lang: &section.lang,
-            generate_feed: section.meta.generate_feed,
+            generate_feeds: section.meta.generate_feeds,
             transparent: section.meta.transparent,
             pages,
             subsections,

--- a/components/site/benches/site.rs
+++ b/components/site/benches/site.rs
@@ -42,7 +42,7 @@ fn bench_render_feed(b: &mut test::Bencher) {
     let public = &tmp_dir.path().join("public");
     site.set_output_path(&public);
     b.iter(|| {
-        site.render_feed(
+        site.render_feeds(
             site.library.read().unwrap().pages.values().collect(),
             None,
             &site.config.default_language,

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -461,27 +461,34 @@ title = "A title"
     }
 
     #[test]
-    fn can_get_feed_url_with_default_language() {
+    fn can_get_feed_urls_with_default_language() {
         let config = Config::parse(CONFIG_DATA).unwrap();
         let dir = create_temp_dir();
         let static_fn =
             GetUrl::new(dir.path().to_path_buf(), config.clone(), HashMap::new(), PathBuf::new());
-        let mut args = HashMap::new();
-        args.insert("path".to_string(), to_value(config.feed_filenames).unwrap());
-        args.insert("lang".to_string(), to_value("fr").unwrap());
-        assert_eq!(static_fn.call(&args).unwrap(), "https://remplace-par-ton-url.fr/atom.xml");
+        for feed_filename in &config.feed_filenames {
+            let mut args = HashMap::new();
+            args.insert("path".to_string(), to_value(feed_filename).unwrap());
+            args.insert("lang".to_string(), to_value("fr").unwrap());
+            assert_eq!(static_fn.call(&args).unwrap(), "https://remplace-par-ton-url.fr/atom.xml");
+        }
     }
 
     #[test]
-    fn can_get_feed_url_with_other_language() {
+    fn can_get_feed_urls_with_other_language() {
         let config = Config::parse(CONFIG_DATA).unwrap();
         let dir = create_temp_dir();
         let static_fn =
             GetUrl::new(dir.path().to_path_buf(), config.clone(), HashMap::new(), PathBuf::new());
-        let mut args = HashMap::new();
-        args.insert("path".to_string(), to_value(config.feed_filenames).unwrap());
-        args.insert("lang".to_string(), to_value("en").unwrap());
-        assert_eq!(static_fn.call(&args).unwrap(), "https://remplace-par-ton-url.fr/en/atom.xml");
+        for feed_filename in &config.feed_filenames {
+            let mut args = HashMap::new();
+            args.insert("path".to_string(), to_value(feed_filename).unwrap());
+            args.insert("lang".to_string(), to_value("en").unwrap());
+            assert_eq!(
+                static_fn.call(&args).unwrap(),
+                "https://remplace-par-ton-url.fr/en/atom.xml"
+            );
+        }
     }
 
     #[test]

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -467,7 +467,7 @@ title = "A title"
         let static_fn =
             GetUrl::new(dir.path().to_path_buf(), config.clone(), HashMap::new(), PathBuf::new());
         let mut args = HashMap::new();
-        args.insert("path".to_string(), to_value(config.feed_filename).unwrap());
+        args.insert("path".to_string(), to_value(config.feed_filenames).unwrap());
         args.insert("lang".to_string(), to_value("fr").unwrap());
         assert_eq!(static_fn.call(&args).unwrap(), "https://remplace-par-ton-url.fr/atom.xml");
     }
@@ -479,7 +479,7 @@ title = "A title"
         let static_fn =
             GetUrl::new(dir.path().to_path_buf(), config.clone(), HashMap::new(), PathBuf::new());
         let mut args = HashMap::new();
-        args.insert("path".to_string(), to_value(config.feed_filename).unwrap());
+        args.insert("path".to_string(), to_value(config.feed_filenames).unwrap());
         args.insert("lang".to_string(), to_value("en").unwrap());
         assert_eq!(static_fn.call(&args).unwrap(), "https://remplace-par-ton-url.fr/en/atom.xml");
     }

--- a/docs/content/documentation/content/multilingual.md
+++ b/docs/content/documentation/content/multilingual.md
@@ -11,7 +11,7 @@ to your `config.toml`. For example:
 
 ```toml
 [languages.fr]
-generate_feed = true # there will be a feed for French content
+generate_feeds = true # there will be a feed for French content
 build_search_index = true
 taxonomies = [
     {name = "auteurs"},

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -106,11 +106,11 @@ transparent = false
 # current one. This takes an array of paths, not URLs.
 aliases = []
 
-# If set to "true", a feed file will be generated for this section at the
+# If set to "true", feed files will be generated for this section at the
 # section's root path. This is independent of the site-wide variable of the same
 # name. The section feed will only include posts from that respective feed, and
 # not from any other sections, including sub-sections under that section.
-generate_feed = false
+generate_feeds = false
 
 # Your own data.
 [extra]

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -65,12 +65,12 @@ ignored_content = []
 ignored_static = []
 
 # When set to "true", a feed is automatically generated.
-generate_feed = false
+generate_feeds = false
 
-# The filename to use for the feed. Used as the template filename, too.
-# Defaults to "atom.xml", which has a built-in template that renders an Atom 1.0 feed.
+# The filenames to use for the feeds. Used as the template filenames, too.
+# Defaults to ["atom.xml"], which has a built-in template that renders an Atom 1.0 feed.
 # There is also a built-in template "rss.xml" that renders an RSS 2.0 feed.
-feed_filename = "atom.xml"
+feed_filenames = ["atom.xml"]
 
 # The number of articles to include in the feed. All items are included if
 # this limit is not set (the default).
@@ -199,13 +199,13 @@ index_format = "elasticlunr_javascript"
 
 # Additional languages definition
 # You can define language specific config values and translations: 
-# title, description, generate_feed, feed_filename, taxonomies, build_search_index
+# title, description, generate_feeds, feed_filenames, taxonomies, build_search_index
 # as well as its own search configuration and translations (see above for details on those)
 [languages]
 # For example
 # [languages.fr]
 # title = "Mon blog"
-# generate_feed = true
+# generate_feeds = true
 # taxonomies = [
 #    {name = "auteurs"},
 #    {name = "tags"},

--- a/docs/content/documentation/templates/feeds/index.md
+++ b/docs/content/documentation/templates/feeds/index.md
@@ -4,13 +4,13 @@ weight = 50
 aliases = ["/documentation/templates/rss/"]
 +++
 
-If the site `config.toml` file sets `generate_feed = true`, then Zola will
-generate a feed file for the site, named according to the `feed_filename`
+If the site `config.toml` file sets `generate_feeds = true`, then Zola will
+generate feed files for the site, named according to the `feed_filenames`
 setting in `config.toml`, which defaults to `atom.xml`. Given the feed filename
 `atom.xml`, the generated file will live at `base_url/atom.xml`, based upon the
 `atom.xml` file in the `templates` directory, or the built-in Atom template.
 
-`feed_filename` can be set to any value, but built-in templates are provided
+`feed_filenames` can be set to any value, but built-in templates are provided
 for `atom.xml` (in the preferred Atom 1.0 format), and `rss.xml` (in the RSS
 2.0 format). If you choose a different filename (e.g. `feed.xml`), you will
 need to provide a template yourself.
@@ -54,7 +54,7 @@ Feeds for taxonomy terms get two more variables, using types from the
 - `term`: of type `TaxonomyTerm`, but without `term.pages` (use `pages` instead)
 
 You can also enable separate feeds for each section by setting the
-`generate_feed` variable to true in the respective section's front matter.
+`generate_feeds` variable to true in the respective section's front matter.
 Section feeds will use the same template as indicated in the `config.toml` file.
 Section feeds, in addition to the five feed template variables, get the
 `section` variable from the [section

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -107,8 +107,8 @@ lang: String;
 translations: Array<TranslatedContent>;
 // All the pages/sections linking this page: their permalink and a title if there is one
 backlinks: Array<{permalink: String, title: String?}>;
-// Whether this section generates a feed or not. Taken from the front-matter if set
-generate_feed: bool;
+// Whether this section generates feeds or not. Taken from the front-matter if set
+generate_feeds: bool;
 // Whether this section is transparent. Taken from the front-matter if set
 transparent: bool;
 ```

--- a/docs/content/themes/zolarwind/index.md
+++ b/docs/content/themes/zolarwind/index.md
@@ -115,7 +115,7 @@ Here's a breakdown of the configuration settings tailored for this theme:
 - **build_search_index**: If set to `true`, a search index will be built from the pages and section content for the `default_language`.
   In this configuration and for this theme, it's disabled (`false`).
 
-- **generate_feed**: Determines if an Atom feed (file `atom.xml`) is automatically generated.
+- **generate_feeds**: Determines if an Atom feed (file `atom.xml`) is automatically generated.
   It's set to `true`, meaning a feed will be generated.
 
 - **taxonomies**: An array of taxonomies (classification systems) used for the site.

--- a/test_site/config.toml
+++ b/test_site/config.toml
@@ -1,7 +1,7 @@
 title = "My Integration Testing site"
 base_url = "https://replace-this-with-your-url.com"
 compile_sass = true
-generate_feed = true
+generate_feeds = true
 theme = "sample"
 
 taxonomies = [

--- a/test_site/content/posts/_index.md
+++ b/test_site/content/posts/_index.md
@@ -5,5 +5,5 @@ template = "section_paginated.html"
 insert_anchor_links = "left"
 sort_by = "date"
 aliases = ["another-old-url/index.html"]
-generate_feed = true
+generate_feeds = true
 +++

--- a/test_site/content/posts/tutorials/programming/_index.md
+++ b/test_site/content/posts/tutorials/programming/_index.md
@@ -2,7 +2,7 @@
 title = "Programming"
 sort_by = "weight"
 weight = 1
-generate_feed = true
+generate_feeds = true
 
 [extra]
 we_have_extra = "variables"

--- a/test_site_i18n/config.toml
+++ b/test_site_i18n/config.toml
@@ -9,7 +9,7 @@ build_search_index = true
 
 default_language = "en"
 
-generate_feed = true
+generate_feeds = true
 
 taxonomies = [
     {name = "authors", feed = true},
@@ -17,7 +17,7 @@ taxonomies = [
 ]
 
 [languages.fr]
-generate_feed = true
+generate_feeds = true
 taxonomies = [
     {name = "auteurs", feed = true},
     {name = "tags"},

--- a/test_site_i18n/content/blog/_index.fr.md
+++ b/test_site_i18n/content/blog/_index.fr.md
@@ -1,7 +1,7 @@
 +++
 title = "Mon blog"
 sort_by = "date"
-insert_anchors = "right"
+insert_anchor_links = "right"
 +++
 
 [Dernières nouvelles](#news)

--- a/test_site_i18n/content/blog/_index.it.md
+++ b/test_site_i18n/content/blog/_index.it.md
@@ -1,5 +1,5 @@
 +++
 title = "Il mio blog"
 sort_by = "date"
-insert_anchors = "right"
+insert_anchor_links = "right"
 +++

--- a/test_site_i18n/content/blog/_index.md
+++ b/test_site_i18n/content/blog/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "My blog"
 sort_by = "date"
-insert_anchors = "left"
+insert_anchor_links = "left"
 +++


### PR DESCRIPTION
## Introduction
As requested many times before, for example:
- https://zola.discourse.group/t/generate-both-rss-and-atom-feeds/441
- #2083

## Potential improvements
~~I don't know if/how Zola handles deprecating config options, if there's anything I should add to let the user know the feed related options changed please let me know how to do it.~~
Implemented backwards-compatibility as suggested by @selfisekai 

## Formalities
**Sanity check:**

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

**Code changes**
* [x] Are you doing the PR on the `next` branch?

**If the change is a new feature or adding to/changing an existing one:**
* [x] Have you created/updated the relevant documentation page(s)?



