### PR TITLE
Restore trailing slash behaviour in serve command

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -398,7 +398,7 @@ fn create_new_site(
 
     let mut constructed_base_url = construct_url(&base_url, no_port_append, interface_port);
 
-    if !site.config.base_url.ends_with("/") {
+    if !site.config.base_url.ends_with("/") && constructed_base_url != "/" {
         constructed_base_url.truncate(constructed_base_url.len() - 1);
     }
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -396,7 +396,11 @@ fn create_new_site(
         |u| u.to_string(),
     );
 
-    let constructed_base_url = construct_url(&base_url, no_port_append, interface_port);
+    let mut constructed_base_url = construct_url(&base_url, no_port_append, interface_port);
+
+    if !site.config.base_url.ends_with("/") {
+        constructed_base_url.truncate(constructed_base_url.len() - 1);
+    }
 
     site.enable_serve_mode();
     site.set_base_url(constructed_base_url.clone());


### PR DESCRIPTION
This is a follow on to #2311 which restores the switch that will strip the trailing slash from the base url when calling `zola serve` if there is not trailing slash on the base url as defined in the site configuration.

I noticed this discrepancy as I was beginning to prepare tests for #2448. I believe this now aligns with the prior behaviour.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)? (N/A)



