### PR TITLE
Fix hot reloading for `config.toml` in `zola serve` on Linux

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -46,7 +46,6 @@ use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, notify::Watche
 use ws::{Message, Sender, WebSocket};
 
 use errors::{anyhow, Context, Error, Result};
-use pathdiff::diff_paths;
 use site::sass::compile_sass;
 use site::{Site, SITE_CONTENT};
 use utils::fs::{clean_site_output_folder, copy_file};
@@ -458,18 +457,21 @@ pub fn serve(
     }
 
     let config_path = PathBuf::from(config_file);
-    let config_path_rel = diff_paths(&config_path, root_dir).unwrap_or_else(|| config_path.clone());
+    let root_dir_str = root_dir.to_str().expect("Project root dir is not valid UTF-8.");
 
-    // An array of (path, WatchMode) where the path should be watched for changes,
-    // and the WatchMode value indicates whether this file/folder must exist for
-    // zola serve to operate
+    // An array of (path, WatchMode, RecursiveMode) where the path is watched for changes,
+    // the WatchMode value indicates whether this path must exist for zola serve to operate,
+    // and the RecursiveMode value indicates whether to watch nested directories.
     let watch_this = vec![
-        (config_path_rel.to_str().unwrap_or("config.toml"), WatchMode::Required),
-        ("content", WatchMode::Required),
-        ("sass", WatchMode::Condition(site.config.compile_sass)),
-        ("static", WatchMode::Optional),
-        ("templates", WatchMode::Optional),
-        ("themes", WatchMode::Condition(site.config.theme.is_some())),
+        // The first entry is ultimtely to watch config.toml in a more robust manner on Linux when
+        // the file changes by way of a caching strategy used by editors such as vim.
+        // https://github.com/getzola/zola/issues/2266
+        (root_dir_str, WatchMode::Required, RecursiveMode::NonRecursive),
+        ("content", WatchMode::Required, RecursiveMode::Recursive),
+        ("sass", WatchMode::Condition(site.config.compile_sass), RecursiveMode::Recursive),
+        ("static", WatchMode::Optional, RecursiveMode::Recursive),
+        ("templates", WatchMode::Optional, RecursiveMode::Recursive),
+        ("themes", WatchMode::Condition(site.config.theme.is_some()), RecursiveMode::Recursive),
     ];
 
     // Setup watchers
@@ -482,16 +484,16 @@ pub fn serve(
     //   - the path exists but has incorrect permissions
     // watchers will contain the paths we're actually watching
     let mut watchers = Vec::new();
-    for (entry, mode) in watch_this {
+    for (entry, watch_mode, recursive_mode) in watch_this {
         let watch_path = root_dir.join(entry);
-        let should_watch = match mode {
+        let should_watch = match watch_mode {
             WatchMode::Required => true,
             WatchMode::Optional => watch_path.exists(),
             WatchMode::Condition(b) => b && watch_path.exists(),
         };
         if should_watch {
             debouncer.watcher()
-                .watch(&root_dir.join(entry), RecursiveMode::Recursive)
+                .watch(&root_dir.join(entry), recursive_mode)
                 .with_context(|| format!("Can't watch `{}` for changes in folder `{}`. Does it exist, and do you have correct permissions?", entry, root_dir.display()))?;
             watchers.push(entry.to_string());
         }
@@ -575,12 +577,17 @@ pub fn serve(
         broadcaster
     };
 
-    println!(
-        "Listening for changes in {}{}{{{}}}",
-        root_dir.display(),
-        MAIN_SEPARATOR,
-        watchers.join(",")
-    );
+    // We watch for changes in the config by monitoring its parent directory, but we ignore all
+    // ordinary peer files. Map the parent directory back to the config file name to not confuse
+    // the end user.
+    let config_name =
+        config_path.file_name().unwrap().to_str().expect("Config name is not valid UTF-8.");
+    let watch_list = watchers
+        .iter()
+        .map(|w| if w == root_dir_str { config_name } else { w })
+        .collect::<Vec<&str>>()
+        .join(",");
+    println!("Listening for changes in {}{}{{{}}}", root_dir.display(), MAIN_SEPARATOR, watch_list);
 
     let preserve_dotfiles_in_output = site.config.preserve_dotfiles_in_output;
 

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -96,6 +96,12 @@ pub fn filter_events(
             continue;
         }
 
+        // Ignore ordinary files peer to config.toml. This assumes all other files we care
+        // about are nested more deeply than config.toml or are directories peer to config.toml.
+        if path != config_path && path.is_file() && path.parent() == config_path.parent() {
+            continue;
+        }
+
         let (change_k, partial_p) = detect_change_kind(root_dir, &path, config_path);
         meaningful_events.insert(path, (partial_p, simple_kind.unwrap(), change_k));
     }


### PR DESCRIPTION
# Introduction

Fixes #2266 , alternative to #2269 which appears to be stalled and has a large diff against `next`. In particular, this fixes hot reloading for changes made to `config.toml` via the caching strategy used by editors such as vim on Linux. At the time of this writing, changes written to `config.toml` via at least vim and neovim on Linux are not noticed at all by `zola serve`.

## Code changes

1. Watch `config.toml`'s containing folder--not `config.toml` directly--for changes. See Details for why.
2. Each item to watch tracks whether to watch it recursively.
3. Ignore changes to files peer to `config.toml`, assuming that all other files we care about are nested more deeply than the config file. This is the case at the time of this writing, and the Zola docs suggest that `config.toml` is the only top-level file we watch in a zola project.
4. When announcing the files we're watching, replace the config file parent directory with the config file name to not confuse the end user, since we ignore all ordinary files peer to `config.toml`.

## Details

Editors such as vi, vim, and neovim cache changes to swap files. When a user wants to write to the original file, such editors may delete the original file and replace it with the swap file. This changes the inode of the "original" file. The file-watching strategy on Linux is inotify which watches for changes via inodes, not file names. So when an editor like vim deletes the file we're watching, we lose event information on that file after the final delete event. If we instead watch the owning directory, we can observe events on all file changes and with some filtering pretend like we're watching the same `config.toml` file all along.

The reason this bug is not observed on macOS is because macOS uses FSEvents to watch for file system changes. FSEvents monitors on the directory level. The change here makes behavior on Linux approximate that of FSEvents.

zola uses Notify v4, and `notify::watcher` returns a `RecommendedWatcher`. The recommended watcher on macOS [is `FsEventWatcher`](https://docs.rs/notify/4.0.17/x86_64-apple-darwin/notify/type.RecommendedWatcher.html) whereas it [is `INotifyWatcher`](https://docs.rs/notify/4.0.17/x86_64-unknown-linux-gnu/notify/type.RecommendedWatcher.html) on Linux.

## Testing

Due to where the ignore logic is done in `serve.rs:serve`, we can't really extend the tests in the same module to check this feature.

I have manually checked `zola serve` on Linux and macOS by editing `config.toml` and theme files and observing hot reloading. I also edited `theme.toml` at the top-level of a zola project, and such changes were correctly ignored.

I don't have a Windows platform to test on.

## UI

Due to the watch list remapping, `zola serve` still announces the following to the end user (note `config.toml` even though we watch the parent directory).

```
Listening for changes in /foo/bar/{config.toml,content,static,templates}
Press Ctrl+C to stop
```