### PR TITLE
feat: move from notify v4 to notify-debouncer-full v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,20 +1233,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fsevent"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
-dependencies = [
- "bitflags 1.3.2",
- "fsevent-sys",
-]
-
-[[package]]
 name = "fsevent-sys"
-version = "2.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
@@ -1754,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.7.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
@@ -1915,6 +1923,26 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2449,6 +2477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -2610,20 +2639,35 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
-version = "4.0.17"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
+ "crossbeam-channel",
  "filetime",
- "fsevent",
  "fsevent-sys",
  "inotify",
+ "kqueue",
  "libc",
- "mio 0.6.23",
- "mio-extras",
+ "log",
+ "mio 0.8.11",
  "walkdir",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
 ]
 
 [[package]]
@@ -5076,7 +5120,7 @@ dependencies = [
  "libs",
  "mime",
  "mime_guess",
- "notify",
+ "notify-debouncer-full",
  "open",
  "pathdiff",
  "same-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clap_complete = "4"
 hyper = { version = "0.14.1", default-features = false, features = ["runtime", "server", "http2", "http1"] }
 tokio = { version = "1.0.1", default-features = false, features = ["rt", "fs", "time"] }
 time = { version = "0.3", features = ["formatting", "macros", "local-offset"] }
-notify = "4"
+notify-debouncer-full = "0.3"
 ws = "0.9"
 ctrlc = "3"
 open = "5"

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -52,7 +52,9 @@ pub struct Site {
     pub live_reload: Option<u16>,
     pub output_path: PathBuf,
     content_path: PathBuf,
+    pub sass_path: PathBuf,
     pub static_path: PathBuf,
+    pub templates_path: PathBuf,
     pub taxonomies: Vec<Taxonomy>,
     /// A map of all .md files (section and pages) and their permalink
     /// We need that if there are relative links in the content that need to be resolved
@@ -82,7 +84,9 @@ impl Site {
         let shortcode_definitions = utils::templates::get_shortcodes(&tera);
 
         let content_path = path.join("content");
+        let sass_path = path.join("sass");
         let static_path = path.join("static");
+        let templates_path = path.join("templates");
         let imageproc = imageproc::Processor::new(path.to_path_buf(), &config);
         let output_path = path.join(config.output_dir.clone());
 
@@ -94,7 +98,9 @@ impl Site {
             live_reload: None,
             output_path,
             content_path,
+            sass_path,
             static_path,
+            templates_path,
             taxonomies: Vec::new(),
             permalinks: HashMap::new(),
             include_drafts: false,

--- a/src/fs_event_utils.rs
+++ b/src/fs_event_utils.rs
@@ -1,0 +1,80 @@
+//! Utilities to simplify working with events raised by the `notify*` family of file system
+//! event-watching libraries.
+
+use notify_debouncer_full::notify::event::*;
+
+/// This enum abstracts over the fine-grained group of enums in `notify`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SimpleFSEventKind {
+    Create,
+    Modify,
+    Remove,
+}
+
+/// Filter `notify_debouncer_full` events. For events that we care about,
+/// return our internal simplified representation. For events we don't care about,
+/// return `None`.
+pub fn get_relevant_event_kind(event_kind: &EventKind) -> Option<SimpleFSEventKind> {
+    match event_kind {
+        EventKind::Create(CreateKind::File) | EventKind::Create(CreateKind::Folder) => {
+            Some(SimpleFSEventKind::Create)
+        }
+        EventKind::Modify(ModifyKind::Data(DataChange::Size))
+        | EventKind::Modify(ModifyKind::Data(DataChange::Content))
+        // Intellij modifies file metadata on edit.
+        // https://github.com/passcod/notify/issues/150#issuecomment-494912080
+        | EventKind::Modify(ModifyKind::Metadata(MetadataKind::WriteTime))
+        | EventKind::Modify(ModifyKind::Metadata(MetadataKind::Permissions))
+        | EventKind::Modify(ModifyKind::Metadata(MetadataKind::Ownership))
+        | EventKind::Modify(ModifyKind::Name(RenameMode::To)) => Some(SimpleFSEventKind::Modify),
+        EventKind::Remove(RemoveKind::File) | EventKind::Remove(RemoveKind::Folder) => {
+            Some(SimpleFSEventKind::Remove)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use notify_debouncer_full::notify::event::*;
+
+    use super::{get_relevant_event_kind, SimpleFSEventKind};
+
+    // This test makes sure we at least have code coverage on the `notify` event kinds we care
+    // about when watching the file system for site changes. This is to make sure changes to the
+    // event mapping and filtering don't cause us to accidentally ignore things we care about.
+    #[test]
+    fn test_get_relative_event_kind() {
+        let cases = vec![
+            (EventKind::Create(CreateKind::File), Some(SimpleFSEventKind::Create)),
+            (EventKind::Create(CreateKind::Folder), Some(SimpleFSEventKind::Create)),
+            (
+                EventKind::Modify(ModifyKind::Data(DataChange::Size)),
+                Some(SimpleFSEventKind::Modify),
+            ),
+            (
+                EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+                Some(SimpleFSEventKind::Modify),
+            ),
+            (
+                EventKind::Modify(ModifyKind::Metadata(MetadataKind::WriteTime)),
+                Some(SimpleFSEventKind::Modify),
+            ),
+            (
+                EventKind::Modify(ModifyKind::Metadata(MetadataKind::Permissions)),
+                Some(SimpleFSEventKind::Modify),
+            ),
+            (
+                EventKind::Modify(ModifyKind::Metadata(MetadataKind::Ownership)),
+                Some(SimpleFSEventKind::Modify),
+            ),
+            (EventKind::Modify(ModifyKind::Name(RenameMode::To)), Some(SimpleFSEventKind::Modify)),
+            (EventKind::Remove(RemoveKind::File), Some(SimpleFSEventKind::Remove)),
+            (EventKind::Remove(RemoveKind::Folder), Some(SimpleFSEventKind::Remove)),
+        ];
+        for (case, expected) in cases.iter() {
+            let ek = get_relevant_event_kind(&case);
+            assert_eq!(ek, *expected);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use time::UtcOffset;
 
 mod cli;
 mod cmd;
+mod fs_event_utils;
 mod messages;
 mod prompt;
 


### PR DESCRIPTION
# Introduction

Closes #2077 , unblocks #2498 .

This updates our `notify` dependency from v4 to `notify-debouncer-full` v0.3. The newer `notify` libraries behave significantly differently from the version zola currently uses, so we need to introduce more logic to generally preserve the current end-user experience behind the scenes. The most significant difference is that `serve` now needs to react to a [`Vec<DebouncedEvent>`](https://docs.rs/notify-debouncer-full/latest/notify_debouncer_full/type.DebounceEventResult.html) instead of a [single `DebouncedEvent`](https://docs.rs/notify/4.0.17/notify/fn.watcher.html).

# Code Changes

1. Use `notify-debouncer-full`, which adds debouncing functionality peripheral to the newer `notify` v6. This functionality was built directly into v4.
2. Map fine-grained `notify` file system event kinds into our own local abstraction for ease of use.
3. Introduce `get_relevant_event_kind` to map the vector of `notify` file system events to our abstraction and filter out events we aren't interested in. This moves previously inlined filtering logic into its own function. The new function lives in a new library, `components/fs_event_utils`.
4. Sort the incoming events by timestamp, descending. Add the events into a hash map where the key is the event path. This way we keep only the latest event for each unique path. This helps in cases where editors like Vim raise multiple events (which don't seem to be debounced) on a single path.
5. Munge the collection in (4) into a new map that bins changes by change type.
6. Iterate over the change map from (5) to process the group of events. This means we can make multiple changes to the site in rapid succession if the user changes a lot of files within the debounce period.
7. `reload_sass` and `reload_templates` now pass an absolute path to the `sass` and `templates` directories, respectively, to `rebuild_done_handling` to participate in livereload. To support this, the `Site` struct now stores the sass and template directories as fields.

# Testing

## Unit Tests

This MR introduces a new unit test to test the new internal support function listed above. Run with `cargo test --package fs_event_utils`.

## Integration Testing

I created the following script to rapidly modify `test_site`.

<details>
<summary>Expand for script.</summary>

```
# Config
echo " " >> test_site/config.toml
echo " " >> test_site/config.toml

# Content
echo " " >> test_site/content/root-page-1.md
echo " " >> test_site/content/posts/fixed-slug.md

# Templates
echo " " >> test_site/templates/index.html
echo " " >> test_site/templates/page.html

# Static files
echo " " >> test_site/static/site.css
echo " " >> test_site/static/scripts/hello.js

# SASS
echo " " >> test_site/sass/blog.scss
echo " " >> test_site/sass/scss.scss

# Themes
echo " " >> test_site/themes/sample/theme.toml
echo " " >> test_site/themes/sample/sass/sample.scss
```

</details>

Here is the result of running the test on `zola` built on `next`.

<details>
<summary>Expand for results on next.</summary>

```
Change detected @ 2024-05-19 20:15:53
-> Config changed. The browser needs to be refreshed to make the changes visible.
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
Done in 87ms.

Change detected @ 2024-05-19 20:15:54
-> Content changed /Users/orphen/code/zola/test_site/content/root-page-1.md
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
Done in 46ms.

Change detected @ 2024-05-19 20:15:54
-> Content changed /Users/orphen/code/zola/test_site/content/posts/fixed-slug.md
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
Done in 45ms.

Change detected @ 2024-05-19 20:15:54
-> Template changed /Users/orphen/code/zola/test_site/templates/index.html
Reloading only template
Done in 20ms.

Change detected @ 2024-05-19 20:15:54
-> Template changed /Users/orphen/code/zola/test_site/templates/page.html
Reloading only template
Done in 20ms.

Change detected @ 2024-05-19 20:15:54
-> Static file changed /Users/orphen/code/zola/test_site/static/site.css
Done in 0ms.

Change detected @ 2024-05-19 20:15:54
-> Static file changed /Users/orphen/code/zola/test_site/static/scripts/hello.js
Done in 0ms.

Change detected @ 2024-05-19 20:15:54
-> Sass file changed /Users/orphen/code/zola/test_site/sass/blog.scss
Done in 0ms.

Change detected @ 2024-05-19 20:15:54
-> Sass file changed /Users/orphen/code/zola/test_site/sass/scss.scss
Done in 0ms.

Change detected @ 2024-05-19 20:15:54
-> Themes changed.
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
Done in 44ms.

Change detected @ 2024-05-19 20:15:54
-> Themes changed.
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
Done in 45ms.
```

</details>

The config changes are rolled into a single update, and the content, template, static, sass, and theme changes are all processed individually (2 changes each).

Cumulative time to update is ~310 ms.

Here is the result of running the test on this feature branch.

<details>
<summary>Expand for test result on this branch.</summary>

```
Change detected @ 2024-05-20 09:10:48
-> Template file(s) changed /Users/orphen/code/zola/test_site/templates/index.html, /Users/orphen/code/zola/test_site/templates/page.html
Reloading only template
Done in 49ms.

Change detected @ 2024-05-20 09:10:48
-> Static file changed /Users/orphen/code/zola/test_site/static/scripts/hello.js
-> Static file changed /Users/orphen/code/zola/test_site/static/site.css
Done in 0ms.

Change detected @ 2024-05-20 09:10:48
-> Themes changed.
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
Done in 54ms.

Change detected @ 2024-05-20 09:10:48
-> Sass file(s) changed /Users/orphen/code/zola/test_site/sass/blog.scss, /Users/orphen/code/zola/test_site/sass/scss.scss
Done in 1ms.

Change detected @ 2024-05-20 09:10:48
-> Config changed. The browser needs to be refreshed to make the changes visible.
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
Done in 43ms.

Change detected @ 2024-05-20 09:10:48
-> Content changed /Users/orphen/code/zola/test_site/content/posts/fixed-slug.md
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
-> Content changed /Users/orphen/code/zola/test_site/content/root-page-1.md
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 35 pages (1 orphan) and 12 sections
Done in 87ms.
```

</details>

(The order of events is different, subject mostly to OS event scheduling and whatever the backing `notify` library is at the mercy of.) Template changes are batched into a single update, sass changes are batched into a single update, themes changes are batched into a single update, the config changes are still rolled into 1, and the static files and content are processed individually (looped over).

Cumulative time to update is ~235 ms. This single test is by no means a reliable profiling, but the results are not surprising, since we perform fewer operations overall relative to current behavior on `next`.

## Manual Tests

I modified my own personal site using zola built from this branch; in particular, I edited files with Vim. This is what revealed the need for `debounce_events`.

# Alternatives

It is possible we perform multiple site rebuilds in one debounce period, for example by modifying the config and modifying the theme. I investigated adding an optimization that would skip all remaining event processing in a debounce period if some change requires a site rebuild. While doable, this handling greatly complicates the logic in my opinion.

First, we can no longer simply `match` on `ChangeKind` because we would need to prioritize handling of particular events. This is mostly done by a branch-order-matters `if` that first checks for config changes, then template changes, then etc. In the case that we don't do a site rebuild in a debounce period, we have to make sure we correctly apply all required updates to account for each change.

If we do a site rebuild, we also need a clean way to end event processing early. We can do this with labeled `match` cases and `break` to those labels, but we'd also need to account for printing the time taken to apply site changes. Time-tracking and breaking at various points during the event handling makes understanding control flow more difficult.

To keep the user-facing experience similar with what's on `master`, we would also need to let the end-user know which files we observed changing, and the reporting of such becomes non-trivial (ex: if config changed, print usual config-changed message and then list all other files; but if templates changed, print usual templates-changed message and then list all other files; but if you don't rebuild the site and only do partial updates , then...).

I don't know whether end users are often applying many site changes in a single debounce window. I personally do not. I don't think pursuing this optimization is worth it from an ROI-to-end-user and maintainability perspective.