### PR TITLE
fix: fix docs CI workflow; build in MRs; build and deploy on master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,35 @@
 name: Build and deploy GH Pages
+
 on:
   push:
+    branches:
+      - master
+  pull_request:
     branches:
       - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
     steps:
       - name: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
+      - name: build
+        uses: shalzz/zola-deploy-action@v0.18.0
+        env:
+          BUILD_DIR: docs/
+          BUILD_ONLY: true
+          
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
       - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.17.2
+        uses: shalzz/zola-deploy-action@v0.18.0
         env:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: docs/
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -17,6 +17,8 @@ highlight_theme = "kronuz"
 #  { theme = "base16-ocean-light", filename = "syntax-theme-light.css" },
 #]
 
+[link_checker]
+internal_level = "warn"
 
 [extra]
 author = "Vincent Prouillet"


### PR DESCRIPTION
# Introduction

The `Build and deploy GH Pages` GitHub Actions workflow defined in `docs.yml` is designed to run on pushes to master. However, we don't check that the docs build correctly before allowing MRs that change the docs to land. This sometimes results in [failures](https://github.com/getzola/zola/actions/runs/8513228432/job/23316472052#step:4:92) in the workflow on master.

The change here introduces another job in the workflow, one that runs only in merge requests and performs a docs build. The previous job is adapted to only run on pushes to `master`, but it still performs a build and deployment.

The change here essentially adapts the [usage of a newer version of the Action](https://github.com/shalzz/zola-deploy-action?tab=readme-ov-file#usage) to the zola repository.

# Testing

Without this change, on `master`, run

```
cd docs
zola build
```

You can reproduce the CI failure. With this change, `zola build` succeeds locally and in CI.
