### PR TITLE
Fix theme images loading

### DIFF
--- a/docs/sass/_themes.scss
+++ b/docs/sass/_themes.scss
@@ -31,6 +31,7 @@
 
     img {
       width: 100%;
+      aspect-ratio: 16 / 9;
       height: 90%;
       object-fit: cover;
     }

--- a/docs/sass/_themes.scss
+++ b/docs/sass/_themes.scss
@@ -1,4 +1,3 @@
-
 .themes-container {
   padding: 3rem;
   width: 80%;
@@ -9,7 +8,7 @@
   }
 }
 
-@media only screen and (max-width: 1000px)  {
+@media only screen and (max-width: 1000px) {
   .themes-container {
     width: 100%;
     margin: 0 1rem;
@@ -54,21 +53,21 @@
     margin-right: 2rem;
   }
 
-  h1, p {
+  h1,
+  p {
     margin: 0;
   }
 
   padding: 1rem;
 }
 
-
-@media only screen and (max-width: 1000px)  {
+@media only screen and (max-width: 1000px) {
   .themes .theme {
     width: 100%;
   }
 }
 
-@media only screen and (max-width: 1000px)  {
+@media only screen and (max-width: 1000px) {
   .theme-info {
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

---

The theme images currently have heights equal to one of the images with the other fitting via `object-fit: cover`. This causes a lot of layout shift and inconsistent heights.

To fix this, I just added an `aspect-ratio: 16 / 9` as a progressive enhancement.

## Before

Testing with a slower connection to show layouts before the images load:

![image](https://github.com/getzola/zola/assets/109556932/c0fad0fd-f71b-43a2-ae67-4f83cfdd41f2)

## After

Testing with a slower connection to show layouts before the images load:

![image](https://github.com/getzola/zola/assets/109556932/34450093-524c-4b38-9f10-ad3ff2187e6e)

## Additional Info

This project's docs site should probably try and find a formatter, as lots of the styles were inconsistent and formatting was most of the diff here. If the maintainer wishes to reduce the diff for this pull request, they may revert/drop the `chore: format themes file` commit.