### PR TITLE
Docs: Fix long words breaking the site on small screens

### DIFF
--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -59,7 +59,7 @@ This will create a shortcode `books` with the argument `path` pointing to a `.to
 titles and descriptions. They will flow with the rest of the document in which `books` is called.
 
 Shortcodes are rendered before the page's Markdown is parsed so they don't have access to the page's table of contents.
-Because of that, you also cannot use the [`get_page`](@/documentation/templates/overview.md#get-page)/[`get_section`](@/documentation/templates/overview.md#get-section)/[`get_taxonomy`](@/documentation/templates/overview.md#get-taxonomy)/[`get_taxonomy_term`](@/documentation/templates/overview.md#get-taxonomy-term) global functions. It might work while
+Because of that, you also cannot use the [`get_page`](@/documentation/templates/overview.md#get-page) / [`get_section`](@/documentation/templates/overview.md#get-section) / [`get_taxonomy`](@/documentation/templates/overview.md#get-taxonomy) / [`get_taxonomy_term`](@/documentation/templates/overview.md#get-taxonomy-term) global functions. It might work while
 running `zola serve` because it has been loaded but it will fail during `zola build`.
 
 ## Using shortcodes

--- a/docs/sass/_base.scss
+++ b/docs/sass/_base.scss
@@ -18,6 +18,9 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+
+  // Stop long words from breaking mobile
+  overflow-wrap: break-word;
 }
 
 img {


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

Fixes overflowing words that caused the mobile website to have a horizontal scroll

## Before

Long text could go off screen and break stuff.

![image](https://github.com/getzola/zola/assets/109556932/912751c6-c42c-4a9e-a5d0-4c98e7b208f8)

![image](https://github.com/getzola/zola/assets/109556932/51f24fcb-1630-43e7-a643-d9eff75adc79)

## After

Long text will always get wrapped before destroying the page (this case is also manually for this pull request)

![image](https://github.com/getzola/zola/assets/109556932/1516233e-a26b-4b21-abde-aaca72e24b7c)

(and a manual fix on top of this)
![image](https://github.com/getzola/zola/assets/109556932/0b280774-2789-45a7-a3e9-0527ba72cae1)

