### PR TITLE
fix: treat any data change as a modification

### DIFF
--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -38,8 +38,7 @@ fn get_relevant_event_kind(event_kind: &EventKind) -> Option<SimpleFileSystemEve
         EventKind::Create(CreateKind::File) | EventKind::Create(CreateKind::Folder) => {
             Some(SimpleFileSystemEventKind::Create)
         }
-        EventKind::Modify(ModifyKind::Data(DataChange::Size))
-        | EventKind::Modify(ModifyKind::Data(DataChange::Content))
+        EventKind::Modify(ModifyKind::Data(_))
         // Intellij modifies file metadata on edit.
         // https://github.com/passcod/notify/issues/150#issuecomment-494912080
         | EventKind::Modify(ModifyKind::Metadata(MetadataKind::WriteTime))
@@ -182,6 +181,14 @@ mod tests {
                 Some(SimpleFileSystemEventKind::Modify),
             ),
             (
+                EventKind::Modify(ModifyKind::Data(DataChange::Any)),
+                Some(SimpleFileSystemEventKind::Modify),
+            ),
+            (
+                EventKind::Modify(ModifyKind::Data(DataChange::Other)),
+                Some(SimpleFileSystemEventKind::Modify),
+            ),
+            (
                 EventKind::Modify(ModifyKind::Metadata(MetadataKind::WriteTime)),
                 Some(SimpleFileSystemEventKind::Modify),
             ),
@@ -202,7 +209,7 @@ mod tests {
         ];
         for (case, expected) in cases.iter() {
             let ek = get_relevant_event_kind(&case);
-            assert_eq!(ek, *expected);
+            assert_eq!(ek, *expected, "case: {:?}", case);
         }
     }
 


### PR DESCRIPTION
fix: treat any data change as a modification

For unknown reasons, it seems some environments emit a `DataChange::Any` event,
rather than specifying content or size, when a file is edited. As an example:

    [src/fs_utils.rs:72:9] &event = DebouncedEvent {
        event: Event {
            kind: Modify(
                Data(
                    Any,
                ),
            ),
            paths: [
                "/home/redacted/content/blog/2024-06-23_example.md",
            ],
            attr:tracker: None,
            attr:flag: None,
            attr:info: None,
            attr:source: None,
        },
        time: Instant {
            tv_sec: 78544,
            tv_nsec: 936740729,
        },
    }

Consequently, because this isn't treated by Zola as a modification, the
site is not rebuilt, which regresses on previous behavior.

This patch fixes this particular case by treating any data modification
events as a modification.

Closes: https://github.com/getzola/zola/issues/2536

---

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
