### PR TITLE
Metainfo: Add 0.19.0

### DIFF
--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -52,6 +52,9 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.19.0" date="2024-06-24">
+      <url>https://github.com/getzola/zola/releases/tag/v0.19.0</url>
+    </release>
     <release version="0.18.0" date="2023-12-18">
       <url>https://github.com/getzola/zola/releases/tag/v0.18.0</url>
     </release>


### PR DESCRIPTION
Usual post-release metainfo fixup.


