### PR TITLE
Remove remote icon

### DIFF
--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -2,7 +2,6 @@
 
 <component type="console-application">
   <id>org.getzola.zola</id>
-  <icon type="remote">https://github.com/getzola/zola/blob/72461a1fc9a767d4eadb6be48a0c5ba35e974049/docs/static/favicon.ico</icon>
 
   <name>Zola</name>
   <summary>A fast static site generator in a single binary with everything built-in</summary>


### PR DESCRIPTION
Otherwise appstream-compose fails on this:

```
Running: appstreamcli compose --no-partial-urls --prefix=/ --origin=org.getzola.zola --media-baseurl=https://dl.flathub.org/media --media-dir=/srv/buildbot/worker/build-x86_64/build/.flatpak-builder/rofiles/rofiles-6Fx4YU/files/share/app-info/media --result-root=/srv/buildbot/worker/build-x86_64/build/.flatpak-builder/rofiles/rofiles-6Fx4YU/files --data-dir=/srv/buildbot/worker/build-x86_64/build/.flatpak-builder/rofiles/rofiles-6Fx4YU/files/share/app-info/xmls --icons-dir=/srv/buildbot/worker/build-x86_64/build/.flatpak-builder/rofiles/rofiles-6Fx4YU/files/share/app-info/icons/flatpak '--components=org.getzola.zola,org.getzola.zola.desktop' /srv/buildbot/worker/build-x86_64/build/.flatpak-builder/rofiles/rofiles-6Fx4YU/files Only accepting components: org.getzola.zola, org.getzola.zola.desktop Processing directory: /srv/buildbot/worker/build-x86_64/build/.flatpak-builder/rofiles/rofiles-6Fx4YU/files Composing metadata...
Run failed, some data was ignored.
Errors were raised during this compose run:
org.getzola.zola
  E: no-stock-icon
```

And we don't really need an icon since Zola is a CLI app.