### PR TITLE
Fix YAML date parsing

### DIFF
--- a/components/utils/src/de.rs
+++ b/components/utils/src/de.rs
@@ -23,18 +23,12 @@ pub fn parse_yaml_datetime(date_string: &str) -> Result<time::OffsetDateTime> {
         if let Some(minutes_) = captures.name("minute") { minutes_.as_str() } else { "0" };
     let seconds =
         if let Some(seconds_) = captures.name("second") { seconds_.as_str() } else { "0" };
-    let fractional_seconds_raw =
-        if let Some(fractionals) = captures.name("fraction") { fractionals.as_str() } else { "" };
-    let fractional_seconds_intermediate = fractional_seconds_raw.trim_end_matches("0");
+    let fraction_raw =
+        if let Some(fraction_) = captures.name("fraction") { fraction_.as_str() } else { "" };
+    let fraction_intermediate = fraction_raw.trim_end_matches("0");
     //
     // Prepare for eventual conversion into nanoseconds
-    let fractional_seconds = if fractional_seconds_intermediate.len() > 0
-        && fractional_seconds_intermediate.len() <= 9
-    {
-        fractional_seconds_intermediate
-    } else {
-        "0"
-    };
+    let fraction = if fraction_intermediate.len() > 0 { fraction_intermediate } else { "0" };
     let maybe_timezone_hour = captures.name("offset_hour");
     let maybe_timezone_minute = captures.name("offset_minute");
 
@@ -58,7 +52,7 @@ pub fn parse_yaml_datetime(date_string: &str) -> Result<time::OffsetDateTime> {
         .replace_hour(hours.parse().unwrap())?
         .replace_minute(minutes.parse().unwrap())?
         .replace_second(seconds.parse().unwrap())?
-        .replace_nanosecond(fractional_seconds.parse::<u32>().unwrap() * 100_000_000)?)
+        .replace_nanosecond((fraction.parse::<f64>().unwrap_or(0.0) * 1_000_000_000.0) as u32)?)
 }
 
 /// Used as an attribute when we want to convert from TOML to a string date

--- a/components/utils/src/de.rs
+++ b/components/utils/src/de.rs
@@ -18,11 +18,9 @@ pub fn parse_yaml_datetime(date_string: &str) -> Result<time::OffsetDateTime> {
     let year = captures.name("year").unwrap().as_str();
     let month = captures.name("month").unwrap().as_str();
     let day = captures.name("day").unwrap().as_str();
-    let hours = if let Some(hours_) = captures.name("hour") { hours_.as_str() } else { "0" };
-    let minutes =
-        if let Some(minutes_) = captures.name("minute") { minutes_.as_str() } else { "0" };
-    let seconds =
-        if let Some(seconds_) = captures.name("second") { seconds_.as_str() } else { "0" };
+    let hour = if let Some(hour_) = captures.name("hour") { hour_.as_str() } else { "0" };
+    let minute = if let Some(minute_) = captures.name("minute") { minute_.as_str() } else { "0" };
+    let second = if let Some(second_) = captures.name("second") { second_.as_str() } else { "0" };
     let fraction_raw =
         if let Some(fraction_) = captures.name("fraction") { fraction_.as_str() } else { "" };
     let fraction_intermediate = fraction_raw.trim_end_matches("0");
@@ -49,9 +47,9 @@ pub fn parse_yaml_datetime(date_string: &str) -> Result<time::OffsetDateTime> {
         .replace_year(year.parse().unwrap())?
         .replace_month(time::Month::try_from(month.parse::<u8>().unwrap())?)?
         .replace_day(day.parse().unwrap())?
-        .replace_hour(hours.parse().unwrap())?
-        .replace_minute(minutes.parse().unwrap())?
-        .replace_second(seconds.parse().unwrap())?
+        .replace_hour(hour.parse().unwrap())?
+        .replace_minute(minute.parse().unwrap())?
+        .replace_second(second.parse().unwrap())?
         .replace_nanosecond((fraction.parse::<f64>().unwrap_or(0.0) * 1_000_000_000.0) as u32)?)
 }
 


### PR DESCRIPTION
This PR makes a few changes to how date is parsed in YAML preambles. Fixes #2538.

## Description

### New regex

Initially, I planned to address #2538 by adding the fraction separator (`.`) to the optional group so that it also becomes optional. However, I have made a few more changes:

- **named groups:** instead of indexed access, one can access date components via their name
- Parsing is now a bit **off-spec**
  - when one reads the [timestamp working draft](https://yaml.org/type/timestamp.html), one can see that they use two different parts for dates with and without time and tz
  - the former (just date) _does not_ allow for short months and days (i.e. without leading zero), and is thus compliant with ISO 8601
  - the latter (date, time, and optional offset) allow months, days, and hours without leading zeroes. This is _non-compliant_, but user-friendly
  - I find it weird that both variants are present and have made the choice to allow months and days without leading zeroes in both 'short' and 'long' forms
- as a side effect, there is **no group duplication** any more, and the regex is now shorter
- I also make use of **non-capturing groups** to split the regex more cleanly

You can explore the regex on regex101: [h5wyK4](https://regex101.com/r/h5wyK4/2); and RegExr: [824pi](https://regexr.com/824pi)

### Fixes offset parsing

As far as I can understand from code, the parsing of the offset was done incorrectly:

- to convert to nanosecond, seconds were multiplied by 100 million (instead of 1 billion)
- instead of a floating point number, an integer was multiplied
- the integer was parsed from the decimal part without the dot

I have revised the code and arrived at this solution:

- the regex allows up to 9 decimal points in the fraction part
- the fraction part get parsed as `f64` number. It is between 0 and 1 (exclusive)
- this floating point number represents a fraction of a second
- this floating point number gets multiplied by one billion (nanoseconds in a second) and applied to the offset

### New tests

I have re-organized some tests and have added some more tests. I've taken the new test cases from the [TOML test suite](https://github.com/toml-lang/toml-test), but have only taken those that make sense with the YAML spec

## Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?
