### PR TITLE
0.19.1 Metainfo fixes

### DIFF
--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -52,7 +52,7 @@
 
   <releases>
     <release version="0.19.1" date="2024-06-24">
-      <url>https://github.com/getzola/zola/releases/tag/v0.19.0</url>
+      <url>https://github.com/getzola/zola/releases/tag/v0.19.1</url>
     </release>
     <release version="0.19.0" date="2024-06-20">
       <url>https://github.com/getzola/zola/releases/tag/v0.19.0</url>

--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -54,7 +54,7 @@
     <release version="0.19.1" date="2024-06-24">
       <url>https://github.com/getzola/zola/releases/tag/v0.19.0</url>
     </release>
-    <release version="0.19.0" date="2024-06-24">
+    <release version="0.19.0" date="2024-06-20">
       <url>https://github.com/getzola/zola/releases/tag/v0.19.0</url>
     </release>
     <release version="0.18.0" date="2023-12-18">

--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -51,6 +51,9 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.19.1" date="2024-06-24">
+      <url>https://github.com/getzola/zola/releases/tag/v0.19.0</url>
+    </release>
     <release version="0.19.0" date="2024-06-24">
       <url>https://github.com/getzola/zola/releases/tag/v0.19.0</url>
     </release>


### PR DESCRIPTION
Usual post-release MR, plus a small fix for the previous one.