### PR TITLE
fix(docs): Use CSS-style comments in syntax highlight CSS suggestion snippet

### DIFF
--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -316,27 +316,27 @@ highlight(code);
 Depending on the annotations used, some codeblocks will be hard to read without any CSS. We recommend using the following
 snippet in your sites:
 
-```scss
+```css
 pre {
   padding: 1rem;
   overflow: auto;
 }
-// The line numbers already provide some kind of left/right padding
+/* The line numbers already provide some kind of left/right padding */
 pre[data-linenos] {
   padding: 1rem 0;
 }
 pre table td {
   padding: 0;
 }
-// The line number cells
+/* The line number cells */
 pre table td:nth-of-type(1) {
   text-align: center;
   user-select: none;
 }
 pre mark {
-  // If you want your highlights to take the full width.
+  /* If you want your highlights to take the full width */
   display: block;
-  // The default background colour of a mark is bright yellow
+  /* The default background colour of a mark is bright yellow */
   background-color: rgba(254, 252, 232, 0.9);
 }
 pre table {
@@ -353,7 +353,7 @@ snippet above.
 
 ```scss, linenos, linenostart=10, hl_lines=3-4 8-9, hide_lines=2 7
 pre mark {
-  // If you want your highlights to take the full width.
+  // If you want your highlights to take the full width
   display: block;
   color: currentcolor;
 }


### PR DESCRIPTION

The suggested SCSS snippet to properly style syntax-highlighted code blocks is valid CSS, except that it uses C++ style comments (`// foo`). This updates the snippet to use C style comments (`/* foo */`) making the snippet valid for both CSS and SCSS.

Ran into this because I was building a very simple zola page without scss.

I am a total webdev beginner, so please shoot me down if this makes no sense :)

Thanks for the great project!

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

