### PR TITLE
fix: handle another fs event to fix change monitoring on Windows 10

### DIFF
--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -39,6 +39,8 @@ fn get_relevant_event_kind(event_kind: &EventKind) -> Option<SimpleFileSystemEve
             Some(SimpleFileSystemEventKind::Create)
         }
         EventKind::Modify(ModifyKind::Data(_))
+        // Windows 10 only reports modify events at the `Any` granularity.
+        | EventKind::Modify(ModifyKind::Any)
         // Intellij modifies file metadata on edit.
         // https://github.com/passcod/notify/issues/150#issuecomment-494912080
         | EventKind::Modify(ModifyKind::Metadata(MetadataKind::WriteTime))
@@ -178,6 +180,7 @@ mod tests {
         let cases = vec![
             (EventKind::Create(CreateKind::File), Some(SimpleFileSystemEventKind::Create)),
             (EventKind::Create(CreateKind::Folder), Some(SimpleFileSystemEventKind::Create)),
+            (EventKind::Modify(ModifyKind::Any), Some(SimpleFileSystemEventKind::Modify)),
             (
                 EventKind::Modify(ModifyKind::Data(DataChange::Size)),
                 Some(SimpleFileSystemEventKind::Modify),


### PR DESCRIPTION
# Introduction

Toward #2551 . We needed to expand my narrower filtering in #2498 to handle some platforms I could not test for. The fix here is similar to that in #2542 .

## Code changes

1. Bin [`notify::event::ModifyKind::Any`](https://docs.rs/notify/6.1.1/notify/event/enum.ModifyKind.html) as a modification event. Previously we filtered it out.
2. Add test coverage for this event kind.

`ModifyKind::Any` is not a catch-all event kind but rather a "no detailed context" one. This seems to be the only granularity we are exposed to on Windows 10.

## Testing

I performed manual testing on Windows 10. I modified the config file and files in content, sass, static, templates, and themes and confirmed that site reload is fixed, at least on my runtime. I also tested modifications with editors like vim and simple Notepad. They raise a different set of events, but both contain the modify kind in this change, so this change covers both cases.

It would help to have someone else confirm this change if possible.