### PR TITLE
Add fields to disable sitemap.xml and robots.txt generation

### DIFF
--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -1057,7 +1057,6 @@ generate_robots_txt = false
         assert!(!config.generate_robots_txt);
     }
 
-
     #[test]
     fn default_no_robots_true() {
         let config = r#"

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -98,9 +98,9 @@ pub struct Config {
     pub markdown: markup::Markdown,
     /// All user params set in `[extra]` in the config
     pub extra: HashMap<String, Toml>,
-    /// Disable the generation of Sitemap.xml
+    /// Enables the generation of Sitemap.xml
     pub generate_sitemap: bool,
-    /// Disable the generation of robots.txt
+    /// Enables the generation of robots.txt
     pub generate_robots_txt: bool,
 }
 

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -99,9 +99,9 @@ pub struct Config {
     /// All user params set in `[extra]` in the config
     pub extra: HashMap<String, Toml>,
     /// Disable the generation of Sitemap.xml
-    pub no_sitemap: bool,
+    pub generate_sitemap: bool,
     /// Disable the generation of robots.txt
-    pub no_robots: bool,
+    pub generate_robots_txt: bool,
 }
 
 #[derive(Serialize)]
@@ -121,8 +121,8 @@ pub struct SerializedConfig<'a> {
     extra: &'a HashMap<String, Toml>,
     markdown: &'a markup::Markdown,
     search: search::SerializedSearch<'a>,
-    no_sitemap: bool,
-    no_robots: bool,
+    generate_sitemap: bool,
+    generate_robots_txt: bool,
 }
 
 impl Config {
@@ -338,8 +338,8 @@ impl Config {
             extra: &self.extra,
             markdown: &self.markdown,
             search: self.search.serialize(),
-            no_sitemap: self.no_sitemap,
-            no_robots: self.no_robots,
+            generate_sitemap: self.generate_sitemap,
+            generate_robots_txt: self.generate_robots_txt,
         }
     }
 }
@@ -403,8 +403,8 @@ impl Default for Config {
             search: search::Search::default(),
             markdown: markup::Markdown::default(),
             extra: HashMap::new(),
-            no_sitemap: false,
-            no_robots: false,
+            generate_sitemap: true,
+            generate_robots_txt: true,
         }
     }
 }
@@ -1004,33 +1004,67 @@ feed_filename = "test.xml"
     }
 
     #[test]
-    fn parse_no_sitemap() {
+    fn parse_generate_sitemap_true() {
         let config = r#"
 title = "My Site"
 base_url = "example.com"
-no_sitemap = true
+generate_sitemap = true
 "#;
         let config = Config::parse(config).unwrap();
-        assert!(config.no_sitemap);
+        assert!(config.generate_sitemap);
     }
 
     #[test]
-    fn default_no_sitemap_false() {
+    fn parse_generate_sitemap_false() {
         let config = r#"
 title = "My Site"
 base_url = "example.com"
+generate_sitemap = false
 "#;
         let config = Config::parse(config).unwrap();
-        assert!(!config.no_sitemap);
+        assert!(!config.generate_sitemap);
     }
 
     #[test]
-    fn default_no_robots_false() {
+    fn default_no_sitemap_true() {
         let config = r#"
 title = "My Site"
 base_url = "example.com"
 "#;
         let config = Config::parse(config).unwrap();
-        assert!(!config.no_robots);
+        assert!(config.generate_sitemap);
+    }
+
+    #[test]
+    fn parse_generate_robots_true() {
+        let config = r#"
+title = "My Site"
+base_url = "example.com"
+generate_robots_txt = true
+"#;
+        let config = Config::parse(config).unwrap();
+        assert!(config.generate_robots_txt);
+    }
+
+    #[test]
+    fn parse_generate_robots_false() {
+        let config = r#"
+title = "My Site"
+base_url = "example.com"
+generate_robots_txt = false
+"#;
+        let config = Config::parse(config).unwrap();
+        assert!(!config.generate_robots_txt);
+    }
+
+
+    #[test]
+    fn default_no_robots_true() {
+        let config = r#"
+title = "My Site"
+base_url = "example.com"
+"#;
+        let config = Config::parse(config).unwrap();
+        assert!(config.generate_robots_txt);
     }
 }

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -98,6 +98,10 @@ pub struct Config {
     pub markdown: markup::Markdown,
     /// All user params set in `[extra]` in the config
     pub extra: HashMap<String, Toml>,
+    /// Disable the generation of Sitemap.xml
+    pub no_sitemap: bool,
+    /// Disable the generation of robots.txt
+    pub no_robots: bool,
 }
 
 #[derive(Serialize)]
@@ -117,6 +121,8 @@ pub struct SerializedConfig<'a> {
     extra: &'a HashMap<String, Toml>,
     markdown: &'a markup::Markdown,
     search: search::SerializedSearch<'a>,
+    no_sitemap: bool,
+    no_robots: bool,
 }
 
 impl Config {
@@ -332,6 +338,8 @@ impl Config {
             extra: &self.extra,
             markdown: &self.markdown,
             search: self.search.serialize(),
+            no_sitemap: self.no_sitemap,
+            no_robots: self.no_robots,
         }
     }
 }
@@ -395,6 +403,8 @@ impl Default for Config {
             search: search::Search::default(),
             markdown: markup::Markdown::default(),
             extra: HashMap::new(),
+            no_sitemap: false,
+            no_robots: false,
         }
     }
 }
@@ -991,5 +1001,36 @@ feed_filename = "test.xml"
         "#;
 
         Config::parse(config).unwrap();
+    }
+
+    #[test]
+    fn parse_no_sitemap() {
+        let config = r#"
+title = "My Site"
+base_url = "example.com"
+no_sitemap = true
+"#;
+        let config = Config::parse(config).unwrap();
+        assert!(config.no_sitemap);
+    }
+
+    #[test]
+    fn default_no_sitemap_false() {
+        let config = r#"
+title = "My Site"
+base_url = "example.com"
+"#;
+        let config = Config::parse(config).unwrap();
+        assert!(!config.no_sitemap);
+    }
+
+    #[test]
+    fn default_no_robots_false() {
+        let config = r#"
+title = "My Site"
+base_url = "example.com"
+"#;
+        let config = Config::parse(config).unwrap();
+        assert!(!config.no_robots);
     }
 }

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -742,7 +742,7 @@ impl Site {
         start = log_time(start, "Rendered sections");
         self.render_orphan_pages()?;
         start = log_time(start, "Rendered orphan pages");
-        if self.config.generate_sitemap{
+        if self.config.generate_sitemap {
             self.render_sitemap()?;
             start = log_time(start, "Rendered sitemap");
         }

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -742,8 +742,10 @@ impl Site {
         start = log_time(start, "Rendered sections");
         self.render_orphan_pages()?;
         start = log_time(start, "Rendered orphan pages");
-        self.render_sitemap()?;
-        start = log_time(start, "Rendered sitemap");
+        if !self.config.no_sitemap {
+            self.render_sitemap()?;
+            start = log_time(start, "Rendered sitemap");
+        }
 
         let library = self.library.read().unwrap();
         if self.config.generate_feeds {
@@ -769,8 +771,10 @@ impl Site {
         start = log_time(start, "Rendered themes css");
         self.render_404()?;
         start = log_time(start, "Rendered 404");
-        self.render_robots()?;
-        start = log_time(start, "Rendered robots.txt");
+        if !self.config.no_robots {
+            self.render_robots()?;
+            start = log_time(start, "Rendered robots.txt");
+        }
         self.render_taxonomies()?;
         start = log_time(start, "Rendered taxonomies");
         // We process images at the end as we might have picked up images to process from markdown

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -742,7 +742,7 @@ impl Site {
         start = log_time(start, "Rendered sections");
         self.render_orphan_pages()?;
         start = log_time(start, "Rendered orphan pages");
-        if !self.config.no_sitemap {
+        if self.config.generate_sitemap{
             self.render_sitemap()?;
             start = log_time(start, "Rendered sitemap");
         }
@@ -771,7 +771,7 @@ impl Site {
         start = log_time(start, "Rendered themes css");
         self.render_404()?;
         start = log_time(start, "Rendered 404");
-        if !self.config.no_robots {
+        if self.config.generate_robots_txt {
             self.render_robots()?;
             start = log_time(start, "Rendered robots.txt");
         }

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -100,6 +100,12 @@ taxonomies = []
 # content for `default_language`.
 build_search_index = false
 
+# When set to "true", Sitemap.xml is not generated (default: false)
+no_sitemap = false
+
+# When set to "true", robots.txt is not generated (default: false)
+no_robots = false
+
 # Configuration of the Markdown rendering
 [markdown]
 # When set to "true", all code blocks are highlighted.

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -100,11 +100,11 @@ taxonomies = []
 # content for `default_language`.
 build_search_index = false
 
-# When set to "true", Sitemap.xml is not generated (default: false)
-no_sitemap = false
+# When set to "false", Sitemap.xml is not generated (default: true)
+generate_sitemap = false
 
-# When set to "true", robots.txt is not generated (default: false)
-no_robots = false
+# When set to "false", robots.txt is not generated (default: true)
+generate_robots_txt = false
 
 # Configuration of the Markdown rendering
 [markdown]

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -100,11 +100,11 @@ taxonomies = []
 # content for `default_language`.
 build_search_index = false
 
-# When set to "false", Sitemap.xml is not generated (default: true)
-generate_sitemap = false
+# When set to "false", Sitemap.xml is not generated
+generate_sitemap = true
 
-# When set to "false", robots.txt is not generated (default: true)
-generate_robots_txt = false
+# When set to "false", robots.txt is not generated
+generate_robots_txt = true
 
 # Configuration of the Markdown rendering
 [markdown]


### PR DESCRIPTION
Addresses feature request #2248

this simply adds two fields in `config.toml`, one field `no_sitemap`, which disable the generation of `sitemap.xml` if set, and one field `no_robots`, which disable the generation of `no_robots.txt` if set.


**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

This feature is discussed in #2248 "We could make it a config.toml option." (Keats, July 2023) -> This is exactly what this PR implements

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?