### PR TITLE
Clarify shortcode usage

### DIFF
--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -35,8 +35,8 @@ following:
 ```
 
 This template is very straightforward: an iframe pointing to the YouTube embed URL wrapped in a `<div>`.
-In terms of input, this shortcode expects at least one variable: `id`. Because the other variables
-are in an `if` statement, they are optional.
+In terms of input, this shortcode expects at least one variable: `id` ([example here](#shortcodes-without-body)).
+Because the other variables are in an `if` statement, they are optional.
 
 That's it. Zola will now recognise this template as a shortcode named `youtube` (the filename minus the `.html` extension).
 


### PR DESCRIPTION
I was reading the [Writing a shortcode](https://www.getzola.org/documentation/content/shortcodes/#writing-a-shortcode) section and got confused about how exactly to use it. There is a nice example a few paragraphs below, but it's hard to find upon a first read.

I've looked into moving some paragraphs around, but I didn't see a better order. So instead this PR suggests to add a link to the example.

![image](https://github.com/user-attachments/assets/77e86538-3503-47a5-83c4-094b0881ceaa)



