### PR TITLE
fix: shortcode in inline elements

### DIFF
--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -679,7 +679,7 @@ pub fn markdown_to_html(
                         event
                     });
                 }
-                Event::Html(text) => {
+                Event::Html(text) | Event::InlineHtml(text) => {
                     if !has_summary && MORE_DIVIDER_RE.is_match(&text) {
                         has_summary = true;
                         events.push(Event::Html(CONTINUE_READING.into()));

--- a/components/markdown/tests/shortcodes.rs
+++ b/components/markdown/tests/shortcodes.rs
@@ -311,3 +311,12 @@ fn can_use_shortcodes_in_quotes() {
     .body;
     insta::assert_snapshot!(body);
 }
+
+// https://github.com/getzola/zola/issues/2565
+#[test]
+fn can_use_shortcodes_in_inline_elements() {
+    let body = common::render(
+        r#"<a href="{{ out_put_id(id="top") }}">top</a>"#
+    ).unwrap().body;
+    insta::assert_snapshot!(body);
+}

--- a/components/markdown/tests/shortcodes.rs
+++ b/components/markdown/tests/shortcodes.rs
@@ -315,8 +315,6 @@ fn can_use_shortcodes_in_quotes() {
 // https://github.com/getzola/zola/issues/2565
 #[test]
 fn can_use_shortcodes_in_inline_elements() {
-    let body = common::render(
-        r#"<a href="{{ out_put_id(id="top") }}">top</a>"#
-    ).unwrap().body;
+    let body = common::render(r#"<a href="{{ out_put_id(id="top") }}">top</a>"#).unwrap().body;
     insta::assert_snapshot!(body);
 }

--- a/components/markdown/tests/snapshots/shortcodes__can_use_shortcodes_in_inline_elements.snap
+++ b/components/markdown/tests/snapshots/shortcodes__can_use_shortcodes_in_inline_elements.snap
@@ -1,0 +1,6 @@
+---
+source: components/markdown/tests/shortcodes.rs
+assertion_line: 321
+expression: body
+---
+<p><a href="top">top</a></p>


### PR DESCRIPTION
### Fixes Issue: https://github.com/getzola/zola/issues/2565

### BTS
Step 1: Minimum reproducible example (to break shortcodes)
```markdown
<a href="{{ basic() }}">{{ basic() }}</a>
```

Step 2: Investigating code which references `@@ZOLA_SC_PLACEHOLDER@@`
- markdown.rs (renders markdown, point of interest)
- mod.rs
- parser.rs

Step 3: Investigating `shortcode.render` call in `markdown.rs`
- for samples which are rendered correctly the `shortcode.render` was invoked for each shortcode
- for samples which render `@@ZOLA_SC_PLACEHOLDER@@`, `shortcode.render` was **NOT** invoked
- source of shortcodes: `html_shortcodes` list (which had the shortcode references even if they were not rendered)

Step 4: Investigating missing shortcodes
- `!$range.contains(&shortcode.span.start)` skips shortcodes which are not in the range
- Understanding `range` and `shortcode.span`
- Understanding parsed content (cmark markdown parser)
  - `iterator(event, range)` where range -> range in the markdown source

Step 5: Investigating ranges
```plaintext
content: <pre>•  <a href="@@ZOLA_SC_PLACEHOLDER@@">@@ZOLA_SC_PLACEHOLDER@@</a>•</pre>••<a href="@@ZOLA_SC_PLACEHOLDER@@">@@ZOLA_SC_PLACEHOLDER@@</a>
note: • represents newline (replaced for easy offset calculation)
parse_tree:
  Start(HtmlBlock) 0..77
  Html(Borrowed(<pre>•)) 0..6
    Html(Borrowed(  <a href="@@ZOLA_SC_PLACEHOLDER@@">@@ZOLA_SC_PLACEHOLDER@@</a>•)) 6..70
  Html(Borrowed(</pre>•)) 70..77
  End(HtmlBlock) 0..77
  Start(Paragraph) 78..140
    InlineHtml(Borrowed(<a href="@@ZOLA_SC_PLACEHOLDER@@">)) 78..112
    Text(Borrowed(@@ZOLA_SC_PLACEHOLDER@@)) 112..135
    InlineHtml(Borrowed(</a>)) 135..139
  End(Paragraph) 78..140
shortcodes:
  17..40
  42..65
  87..110
  112..135
logs:
  Start(HtmlBlock) 0..77
  Html(Borrowed(<pre>•)) 0..6
  Html(Borrowed(  <a href="@@ZOLA_SC_PLACEHOLDER@@">@@ZOLA_SC_PLACEHOLDER@@</a>•)) 6..70
    html_render_shortcodes: Borrowed(  <a href="@@ZOLA_SC_PLACEHOLDER@@">@@ZOLA_SC_PLACEHOLDER@@</a>•) 6..70
      render_compare 17..40 6..70
      render_compare 42..65 40..70
      render_compare 87..110 65..70 [break]
      html: [Start(HtmlBlock), Html(Borrowed(<pre>•)), Html(Boxed(  <a href=")), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(">)), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(</a>•))]
  Html(Borrowed(</pre>•)) 70..77
  End(HtmlBlock) 0..77
  Start(Paragraph) 78..140
  InlineHtml(Borrowed(<a href="@@ZOLA_SC_PLACEHOLDER@@">)) 78..112
  ^^^^^^^^^^ ISSUE: render_shortcodes not called (issue propogates to next offsets)
  Text(Borrowed(@@ZOLA_SC_PLACEHOLDER@@)) 112..135
    text_render_shortcodes: Borrowed(@@ZOLA_SC_PLACEHOLDER@@) 112..135
      render_compare 87..110 112..135 [break]
      html: [Start(HtmlBlock), Html(Borrowed(<pre>•)), Html(Boxed(  <a href=")), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(">)), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(</a>•)), Html(Borrowed(</pre>•)), End(HtmlBlock), Start(Paragraph), InlineHtml(Borrowed(<a href="@@ZOLA_SC_PLACEHOLDER@@">)), Text(Boxed(@@ZOLA_SC_PLACEHOLDER@@))]
  InlineHtml(Borrowed(</a>)) 135..139
  End(Paragraph) 78..140
```

Step 6: Adding a test for the issue
- `can_use_shortcodes_in_inline_elements` in `components/markdown/tests/shortcodes.rs`
<img width="1200" alt="failed test" src="https://github.com/user-attachments/assets/3bf7bb7b-b8cd-49ac-ae08-05e0eea2a8eb">

Step 7: Fixing the issue by accounting for InlineHtml
```plaintext
logs:
  Start(HtmlBlock) 0..77
  Html(Borrowed(<pre>•)) 0..6
  Html(Borrowed(  <a href="@@ZOLA_SC_PLACEHOLDER@@">@@ZOLA_SC_PLACEHOLDER@@</a>•)) 6..70
    html_render_shortcodes: Borrowed(  <a href="@@ZOLA_SC_PLACEHOLDER@@">@@ZOLA_SC_PLACEHOLDER@@</a>•) 6..70
      render_compare 17..40 6..70
      render_compare 42..65 40..70
      render_compare 87..110 65..70 [break]
      html: [Start(HtmlBlock), Html(Borrowed(<pre>•)), Html(Boxed(  <a href=")), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(">)), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(</a>•))]
  Html(Borrowed(</pre>•)) 70..77
  End(HtmlBlock) 0..77
  Start(Paragraph) 78..140
  InlineHtml(Borrowed(<a href="@@ZOLA_SC_PLACEHOLDER@@">)) 78..112
    html_render_shortcodes: Borrowed(<a href="@@ZOLA_SC_PLACEHOLDER@@">) 78..112
      render_compare 87..110 78..112
      render_compare 112..135 110..112 [break]
      html: [Start(HtmlBlock), Html(Borrowed(<pre>•)), Html(Boxed(  <a href=")), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(">)), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(</a>•)), Html(Borrowed(</pre>•)), End(HtmlBlock), Start(Paragraph), Html(Boxed(<a href=")), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(">))]
  Text(Borrowed(@@ZOLA_SC_PLACEHOLDER@@)) 112..135
    text_render_shortcodes: Borrowed(@@ZOLA_SC_PLACEHOLDER@@) 112..135
      render_compare 112..135 112..135
      html: [Start(HtmlBlock), Html(Borrowed(<pre>•)), Html(Boxed(  <a href=")), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(">)), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(</a>•)), Html(Borrowed(</pre>•)), End(HtmlBlock), Start(Paragraph), Html(Boxed(<a href=")), Html(Boxed(<h4>Basic shortcode</h4>•)), Html(Boxed(">)), Html(Boxed(<h4>Basic shortcode</h4>•))]
  InlineHtml(Borrowed(</a>)) 135..139
  End(Paragraph) 78..140
```
<img width="600" alt="passes test" src="https://github.com/user-attachments/assets/c382a896-7651-429f-8483-170fbe9cc256">
