### PR TITLE
fix: zola panic if no static dir

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -48,7 +48,7 @@ use ws::{Message, Sender, WebSocket};
 use errors::{anyhow, Context, Error, Result};
 use site::sass::compile_sass;
 use site::{Site, SITE_CONTENT};
-use utils::fs::{clean_site_output_folder, copy_file};
+use utils::fs::{clean_site_output_folder, copy_file, create_directory};
 
 use crate::fs_utils::{filter_events, ChangeKind, SimpleFileSystemEventKind};
 use crate::messages;
@@ -502,6 +502,7 @@ pub fn serve(
     let ws_port = site.live_reload;
     let ws_address = format!("{}:{}", interface, ws_port.unwrap());
     let output_path = site.output_path.clone();
+    create_directory(&output_path)?;
 
     // static_root needs to be canonicalized because we do the same for the http server.
     let static_root = std::fs::canonicalize(&output_path).unwrap();


### PR DESCRIPTION
Fixes: #2604

### Root Cause:
- Application panicked at this code `std::fs::canonicalize(&output_path).unwrap()` when there is no static directory and compile_sass is set to false
- Reason for this is `output_path` (which in default case is public) does not get created
  - Folder gets created when there is a static folder or we have compile_sass set
- Added `create_directory` code to create the directory if it does not exist before canonicalize

### Alternate fix
Handle unwrap and show an error