### PR TITLE
Fix broken links (getzola.com -> getzola.org)

### DIFF
--- a/docs/content/themes/codinfox-zola/index.md
+++ b/docs/content/themes/codinfox-zola/index.md
@@ -23,11 +23,11 @@ homepage = "https://svavs.github.io/"
 
 ![Zola Deploy to Github Pages on push](https://github.com/svavs/codinfox-zola/workflows/Zola%20Deploy%20to%20Pages%20on%20push/badge.svg?branch=master)
 
-This is a [Zola](https://www.getzola.com) theme inspired to [Codinfox-Lanyon](https://codinfox.github.com/), a Lanyon based theme for [Jekyll](http://jekyllrb.com). See a live demo [here](https://codinfox-zola.vercel.app/).
+This is a [Zola](https://www.getzola.org) theme inspired to [Codinfox-Lanyon](https://codinfox.github.com/), a Lanyon based theme for [Jekyll](http://jekyllrb.com). See a live demo [here](https://codinfox-zola.vercel.app/).
 
 This theme places content first by tucking away navigation in a hidden drawer.
 
-* Built for [Zola](https://www.getzola.com)
+* Built for [Zola](https://www.getzola.org)
 * Developed on GitHub and hosted for free on [GitHub Pages](https://pages.github.com) and [Vercel](https://vercel.com)
 * Coded with [Spacemacs](https://www.spacemacs.org)
 

--- a/docs/content/themes/particle/index.md
+++ b/docs/content/themes/particle/index.md
@@ -38,7 +38,7 @@ The Theme features:
 
 ## Basic Setup
 
-1. [Install Zola](https://getzola.com)
+1. [Install Zola](https://getzola.org)
 2. Clone the particle theme: `git clone https://github.com/svavs/particle-zola.git`
 3. Edit `config.toml` to personalize your site.
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [ ] Are you doing the PR on the `next` branch?

No. CONTRIBUTING.md:

> As the documentation site is automatically built on commits to master, all development happens on the next branch, unless it is fixing the current documentation.

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?

---

I noticed a few references to getzola.com, when the correct url is getzola.org.