### PR TITLE
Allow nested shortcodes with markdown bodies

### DIFF
--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -11,7 +11,7 @@ use errors::{Context, Result};
 use markdown::{render_content, RenderContext};
 use utils::slugs::slugify_paths;
 use utils::table_of_contents::Heading;
-use utils::templates::{render_template, ShortcodeDefinition};
+use utils::templates::{render_template, ShortcodeDefinition, ShortcodeInvocationCounter};
 use utils::types::InsertAnchor;
 
 use crate::file_info::FileInfo;
@@ -212,14 +212,17 @@ impl Page {
         config: &Config,
         anchor_insert: InsertAnchor,
         shortcode_definitions: &HashMap<String, ShortcodeDefinition>,
+        shortcode_invoke_counter: &ShortcodeInvocationCounter,
     ) -> Result<()> {
+        shortcode_invoke_counter.reset();
         let mut context = RenderContext::new(
             tera,
             config,
-            &self.lang,
+            Some(&self.lang),
             &self.permalink,
             permalinks,
             anchor_insert,
+            shortcode_invoke_counter,
         );
         context.set_shortcode_definitions(shortcode_definitions);
         context.set_current_page_path(&self.file.relative);
@@ -329,6 +332,7 @@ Hello world"#;
             &config,
             InsertAnchor::None,
             &HashMap::new(),
+            &Default::default(),
         )
         .unwrap();
 
@@ -357,6 +361,7 @@ Hello world"#;
             &config,
             InsertAnchor::None,
             &HashMap::new(),
+            &Default::default(),
         )
         .unwrap();
 
@@ -527,6 +532,7 @@ Hello world
             &config,
             InsertAnchor::None,
             &HashMap::new(),
+            &Default::default(),
         )
         .unwrap();
         assert_eq!(page.summary, Some("<p>Hello world</p>\n".to_string()));
@@ -561,6 +567,7 @@ And here's another. [^3]
             &config,
             InsertAnchor::None,
             &HashMap::new(),
+            &Default::default(),
         )
         .unwrap();
         assert_eq!(

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -9,7 +9,7 @@ use markdown::{render_content, RenderContext};
 use utils::fs::read_file;
 use utils::net::is_external_link;
 use utils::table_of_contents::Heading;
-use utils::templates::{render_template, ShortcodeDefinition};
+use utils::templates::{render_template, ShortcodeDefinition, ShortcodeInvocationCounter};
 
 use crate::file_info::FileInfo;
 use crate::front_matter::{split_section_content, SectionFrontMatter};
@@ -150,14 +150,17 @@ impl Section {
         tera: &Tera,
         config: &Config,
         shortcode_definitions: &HashMap<String, ShortcodeDefinition>,
+        shortcode_invoke_counter: &ShortcodeInvocationCounter,
     ) -> Result<()> {
+        shortcode_invoke_counter.reset();
         let mut context = RenderContext::new(
             tera,
             config,
-            &self.lang,
+            Some(&self.lang),
             &self.permalink,
             permalinks,
             self.meta.insert_anchor_links,
+            &shortcode_invoke_counter,
         );
         context.set_shortcode_definitions(shortcode_definitions);
         context.set_current_page_path(&self.file.relative);

--- a/components/markdown/benches/all.rs
+++ b/components/markdown/benches/all.rs
@@ -86,6 +86,7 @@ fn bench_render_content_with_highlighting(b: &mut test::Bencher) {
     tera.add_raw_template("shortcodes/youtube.html", "{{id}}").unwrap();
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default_for_test();
+    let invoke_counter = Default::default();
     config.markdown.highlight_code = true;
     let current_page_permalink = "";
     let mut context = RenderContext::new(
@@ -95,6 +96,7 @@ fn bench_render_content_with_highlighting(b: &mut test::Bencher) {
         current_page_permalink,
         &permalinks_ctx,
         InsertAnchor::None,
+        &invoke_counter,
     );
     let shortcode_def = utils::templates::get_shortcodes(&tera);
     context.set_shortcode_definitions(&shortcode_def);
@@ -107,6 +109,7 @@ fn bench_render_content_without_highlighting(b: &mut test::Bencher) {
     tera.add_raw_template("shortcodes/youtube.html", "{{id}}").unwrap();
     let permalinks_ctx = HashMap::new();
     let mut config = Config::default_for_test();
+    let invoke_counter = Default::default();
     config.markdown.highlight_code = false;
     let current_page_permalink = "";
     let mut context = RenderContext::new(
@@ -116,6 +119,7 @@ fn bench_render_content_without_highlighting(b: &mut test::Bencher) {
         current_page_permalink,
         &permalinks_ctx,
         InsertAnchor::None,
+        &invoke_counter,
     );
     let shortcode_def = utils::templates::get_shortcodes(&tera);
     context.set_shortcode_definitions(&shortcode_def);
@@ -127,6 +131,7 @@ fn bench_render_content_no_shortcode(b: &mut test::Bencher) {
     let tera = Tera::default();
     let content2 = CONTENT.replace(r#"{{ youtube(id="my_youtube_id") }}"#, "");
     let mut config = Config::default_for_test();
+    let invoke_counter = Default::default();
     config.markdown.highlight_code = false;
     let permalinks_ctx = HashMap::new();
     let current_page_permalink = "";
@@ -137,6 +142,7 @@ fn bench_render_content_no_shortcode(b: &mut test::Bencher) {
         current_page_permalink,
         &permalinks_ctx,
         InsertAnchor::None,
+        &invoke_counter,
     );
 
     b.iter(|| render_content(&content2, &context).unwrap());
@@ -149,6 +155,7 @@ fn bench_render_content_with_emoji(b: &mut test::Bencher) {
     let mut config = Config::default_for_test();
     config.markdown.highlight_code = false;
     config.markdown.render_emoji = true;
+    let invoke_counter = Default::default();
     let permalinks_ctx = HashMap::new();
     let current_page_permalink = "";
     let context = RenderContext::new(
@@ -158,6 +165,7 @@ fn bench_render_content_with_emoji(b: &mut test::Bencher) {
         current_page_permalink,
         &permalinks_ctx,
         InsertAnchor::None,
+        &invoke_counter,
     );
 
     b.iter(|| render_content(&content2, &context).unwrap());

--- a/components/markdown/src/content.pest
+++ b/components/markdown/src/content.pest
@@ -55,9 +55,9 @@ ignored_sc_body_end   = !{ "{%/*" ~ "end" ~ "*/%}" }
 shortcode_with_body         = !{ sc_body_start ~ text_in_body_sc ~ sc_body_end }
 ignored_shortcode_with_body = { ignored_sc_body_start ~ text_in_ignored_body_sc ~ ignored_sc_body_end }
 
-text_in_body_sc         = ${ (!(sc_body_end) ~ ANY)+ }
-text_in_ignored_body_sc = ${ (!(ignored_sc_body_end) ~ ANY)+ }
-text                    = ${ (!(inline_shortcode | ignored_inline_shortcode | shortcode_with_body | ignored_shortcode_with_body) ~ ANY)+ }
+text_in_body_sc         = ${ (!(sc_body_end) ~ content)+ }
+text_in_ignored_body_sc = ${ (!(ignored_sc_body_end) ~ content)+ }
+text                    = ${ (!(inline_shortcode | ignored_inline_shortcode | sc_body_start | ignored_sc_body_start | sc_body_end | ignored_sc_body_end) ~ ANY)+ }
 
 content = _{
     ignored_inline_shortcode |

--- a/components/markdown/src/lib.rs
+++ b/components/markdown/src/lib.rs
@@ -19,7 +19,8 @@ pub fn render_content(content: &str, context: &RenderContext) -> Result<markdown
 
     let definitions = context.shortcode_definitions.as_ref();
     // Extract all the defined shortcodes
-    let (content, shortcodes) = extract_shortcodes(content, definitions)?;
+    let (content, shortcodes) =
+        extract_shortcodes(content, definitions, &context.shortcode_invoke_counter)?;
 
     // Step 1: we render the MD shortcodes before rendering the markdown so they can get processed
     let (content, html_shortcodes) =

--- a/components/markdown/src/shortcode/mod.rs
+++ b/components/markdown/src/shortcode/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use errors::{Error, Result};
 use libs::tera;
-use utils::templates::{ShortcodeDefinition, ShortcodeFileType};
+use utils::templates::{ShortcodeDefinition, ShortcodeFileType, ShortcodeInvocationCounter};
 
 mod parser;
 
@@ -12,8 +12,9 @@ pub(crate) use parser::{parse_for_shortcodes, Shortcode, SHORTCODE_PLACEHOLDER};
 pub fn extract_shortcodes(
     source: &str,
     definitions: &HashMap<String, ShortcodeDefinition>,
+    invocation_counter: &ShortcodeInvocationCounter,
 ) -> Result<(String, Vec<Shortcode>)> {
-    let (out, mut shortcodes) = parse_for_shortcodes(source)?;
+    let (out, mut shortcodes) = parse_for_shortcodes(source, invocation_counter)?;
 
     for sc in &mut shortcodes {
         if let Some(def) = definitions.get(&sc.name) {

--- a/components/markdown/src/shortcode/parser.rs
+++ b/components/markdown/src/shortcode/parser.rs
@@ -5,8 +5,7 @@ use libs::tera::{to_value, Context, Map, Tera, Value};
 use pest::iterators::Pair;
 use pest::Parser;
 use pest_derive::Parser;
-use std::collections::HashMap;
-use utils::templates::ShortcodeFileType;
+use utils::templates::{ShortcodeFileType, ShortcodeInvocationCounter};
 
 pub const SHORTCODE_PLACEHOLDER: &str = "@@ZOLA_SC_PLACEHOLDER@@";
 
@@ -152,14 +151,11 @@ fn parse_shortcode_call(pair: Pair<Rule>) -> (String, Value) {
     (name.unwrap(), Value::Object(args))
 }
 
-pub fn parse_for_shortcodes(content: &str) -> Result<(String, Vec<Shortcode>)> {
+pub fn parse_for_shortcodes(
+    content: &str,
+    invocation_counter: &ShortcodeInvocationCounter,
+) -> Result<(String, Vec<Shortcode>)> {
     let mut shortcodes = Vec::new();
-    let mut nths = HashMap::new();
-    let mut get_invocation_count = |name: &str| {
-        let nth = nths.entry(String::from(name)).or_insert(0);
-        *nth += 1;
-        *nth
-    };
     let mut output = String::with_capacity(content.len());
 
     let mut pairs = match ContentParser::parse(Rule::page, content) {
@@ -207,7 +203,7 @@ pub fn parse_for_shortcodes(content: &str) -> Result<(String, Vec<Shortcode>)> {
             Rule::inline_shortcode => {
                 let start = output.len();
                 let (name, args) = parse_shortcode_call(p);
-                let nth = get_invocation_count(&name);
+                let nth = invocation_counter.get(&name);
                 shortcodes.push(Shortcode {
                     name,
                     args,
@@ -225,7 +221,7 @@ pub fn parse_for_shortcodes(content: &str) -> Result<(String, Vec<Shortcode>)> {
                 // we don't care about the closing tag
                 let (name, args) = parse_shortcode_call(inner.next().unwrap());
                 let body = inner.next().unwrap().as_span().as_str().trim();
-                let nth = get_invocation_count(&name);
+                let nth = invocation_counter.get(&name);
                 shortcodes.push(Shortcode {
                     name,
                     args,
@@ -403,6 +399,7 @@ mod tests {
     fn can_extract_basic_inline_shortcode_with_args() {
         let (out, shortcodes) = parse_for_shortcodes(
             "Inline shortcode: {{ hello(string='hey', int=1, float=2.1, bool=true, array=[true, false]) }} hey",
+            &ShortcodeInvocationCounter::new(),
         )
         .unwrap();
         assert_eq!(out, format!("Inline shortcode: {} hey", SHORTCODE_PLACEHOLDER));
@@ -423,8 +420,11 @@ mod tests {
 
     #[test]
     fn can_unignore_ignored_inline_shortcode() {
-        let (out, shortcodes) =
-            parse_for_shortcodes("Hello World {{/* youtube() */}} hey").unwrap();
+        let (out, shortcodes) = parse_for_shortcodes(
+            "Hello World {{/* youtube() */}} hey",
+            &ShortcodeInvocationCounter::new(),
+        )
+        .unwrap();
         assert_eq!(out, "Hello World {{ youtube() }} hey");
         assert_eq!(shortcodes.len(), 0);
     }
@@ -433,6 +433,7 @@ mod tests {
     fn can_extract_shortcode_with_body() {
         let (out, shortcodes) = parse_for_shortcodes(
             "Body shortcode\n {% quote(author='Bobby', array=[[true]]) %}DROP TABLES;{% end %} \n hey",
+            &ShortcodeInvocationCounter::new(),
         )
         .unwrap();
         assert_eq!(out, format!("Body shortcode\n {} \n hey", SHORTCODE_PLACEHOLDER));
@@ -451,9 +452,11 @@ mod tests {
 
     #[test]
     fn can_unignore_ignored_shortcode_with_body() {
-        let (out, shortcodes) =
-            parse_for_shortcodes("Hello World {%/* youtube() */%} Somebody {%/* end */%} hey")
-                .unwrap();
+        let (out, shortcodes) = parse_for_shortcodes(
+            "Hello World {%/* youtube() */%} Somebody {%/* end */%} hey",
+            &ShortcodeInvocationCounter::new(),
+        )
+        .unwrap();
         assert_eq!(out, "Hello World {% youtube() %} Somebody {% end %} hey");
         assert_eq!(shortcodes.len(), 0);
     }
@@ -462,6 +465,7 @@ mod tests {
     fn can_extract_multiple_shortcodes_and_increment_nth() {
         let (out, shortcodes) = parse_for_shortcodes(
             "Hello World {% youtube() %} Somebody {% end %} {{ hello() }}\n {{hello()}}",
+            &ShortcodeInvocationCounter::new(),
         )
         .unwrap();
         assert_eq!(
@@ -486,6 +490,7 @@ mod tests {
         {{ vimeo(id="210073083#hello", n_a_me="hello") }}
         {{ streamable(id="c0ic", n1=true) }}
         {{ gist(url="https://gist.github.com/Keats/32d26f699dcc13ebd41b") }}"#,
+            &ShortcodeInvocationCounter::new(),
         )
         .unwrap();
         assert_eq!(shortcodes.len(), 5);
@@ -495,6 +500,7 @@ mod tests {
     fn can_parse_nested_shortcodes() {
         let (out, shortcodes) = parse_for_shortcodes(
             "Hello World {% outer() %} Inside-Outside! {% inner() %} Inside-Inside! {% end %} Inside-Outside {% end %}",
+            &ShortcodeInvocationCounter::new(),
         )
         .unwrap();
         assert_eq!(out, format!("Hello World {}", SHORTCODE_PLACEHOLDER));

--- a/components/markdown/src/shortcode/parser.rs
+++ b/components/markdown/src/shortcode/parser.rs
@@ -497,13 +497,7 @@ mod tests {
             "Hello World {% outer() %} Inside-Outside! {% inner() %} Inside-Inside! {% end %} Inside-Outside {% end %}",
         )
         .unwrap();
-        assert_eq!(
-            out,
-            format!(
-                "Hello World {}",
-                SHORTCODE_PLACEHOLDER
-            )
-        );
+        assert_eq!(out, format!("Hello World {}", SHORTCODE_PLACEHOLDER));
         assert_eq!(shortcodes.len(), 1);
     }
 }

--- a/components/markdown/src/shortcode/parser.rs
+++ b/components/markdown/src/shortcode/parser.rs
@@ -490,4 +490,20 @@ mod tests {
         .unwrap();
         assert_eq!(shortcodes.len(), 5);
     }
+
+    #[test]
+    fn can_parse_nested_shortcodes() {
+        let (out, shortcodes) = parse_for_shortcodes(
+            "Hello World {% outer() %} Inside-Outside! {% inner() %} Inside-Inside! {% end %} Inside-Outside {% end %}",
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            format!(
+                "Hello World {}",
+                SHORTCODE_PLACEHOLDER
+            )
+        );
+        assert_eq!(shortcodes.len(), 1);
+    }
 }

--- a/components/markdown/tests/common.rs
+++ b/components/markdown/tests/common.rs
@@ -1,6 +1,9 @@
 #![allow(dead_code)]
 
-use std::{collections::HashMap, sync::{Arc, RwLock}};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 use libs::tera::Tera;
 
@@ -58,7 +61,11 @@ fn configurable_render(
 
     tera.register_filter(
         "markdown",
-        templates::filters::MarkdownFilter::new(config.clone(), permalinks.clone(), shared_tera.clone()),
+        templates::filters::MarkdownFilter::new(
+            config.clone(),
+            permalinks.clone(),
+            shared_tera.clone(),
+        ),
     );
     drop(tera);
     let tera = shared_tera.read().unwrap();

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -113,13 +113,15 @@ fn can_customise_anchor_template() {
     tera.add_raw_template("anchor-link.html", " (in {{ lang }})").unwrap();
     let permalinks_ctx = HashMap::new();
     let config = Config::default_for_test();
+    let invoke_counter = Default::default();
     let context = RenderContext::new(
         &tera,
         &config,
-        &config.default_language,
+        None,
         "",
         &permalinks_ctx,
         InsertAnchor::Right,
+        &invoke_counter,
     );
     let body = render_content("# Hello", &context).unwrap().body;
     insta::assert_snapshot!(body);

--- a/components/markdown/tests/shortcodes.rs
+++ b/components/markdown/tests/shortcodes.rs
@@ -357,3 +357,43 @@ fn can_render_markdown_in_nested_shortcodes_with_bodies() {
     .body;
     insta::assert_snapshot!(body);
 }
+
+#[test]
+fn can_render_nested_shortcodes_with_bodies_with_nth() {
+    let config = Config::default_for_test();
+    let body = common::render_with_config(
+        r#"
+{{ a() }}
+
+{{ a() }}
+
+{% render_md() %}
+
+{{ a() }}
+
+{{ a() }}
+
+{% render_md() %}
+
+{{ a() }}
+
+{{ a() }}
+
+{% end %}
+
+{{ a() }}
+
+{{ a() }}
+
+{% end %}
+
+{{ a() }}
+
+{{ a() }}
+    "#,
+        config,
+    )
+    .unwrap()
+    .body;
+    insta::assert_snapshot!(body);
+}

--- a/components/markdown/tests/shortcodes.rs
+++ b/components/markdown/tests/shortcodes.rs
@@ -323,3 +323,36 @@ Here is <span>{{ ex1(page="") }}</span> example.
     .body;
     insta::assert_snapshot!(body);
 }
+
+#[test]
+fn can_render_markdown_in_nested_shortcodes_with_bodies() {
+    let config = Config::default_for_test();
+    let body = common::render_with_config(r#"
+# Begin level 0  
+
+{% render_md() %}
+
+## Begin level 1
+
+{% render_md() %}
+
+### Begin level 2
+
+{% quote() %} Also a quote in the nested divs {% end %}
+
+### End level 2
+
+{% end %}
+
+## End level 1
+
+{% end %}
+
+# End level 0
+    "#,
+        config
+    )
+    .unwrap()
+    .body;
+    insta::assert_snapshot!(body);
+}

--- a/components/markdown/tests/shortcodes.rs
+++ b/components/markdown/tests/shortcodes.rs
@@ -327,7 +327,8 @@ Here is <span>{{ ex1(page="") }}</span> example.
 #[test]
 fn can_render_markdown_in_nested_shortcodes_with_bodies() {
     let config = Config::default_for_test();
-    let body = common::render_with_config(r#"
+    let body = common::render_with_config(
+        r#"
 # Begin level 0  
 
 {% render_md() %}
@@ -350,7 +351,7 @@ fn can_render_markdown_in_nested_shortcodes_with_bodies() {
 
 # End level 0
     "#,
-        config
+        config,
     )
     .unwrap()
     .body;

--- a/components/markdown/tests/snapshots/shortcodes__can_render_markdown_in_nested_shortcodes_with_bodies.snap
+++ b/components/markdown/tests/snapshots/shortcodes__can_render_markdown_in_nested_shortcodes_with_bodies.snap
@@ -1,0 +1,11 @@
+---
+source: components/markdown/tests/shortcodes.rs
+assertion_line: 357
+expression: body
+---
+<h1 id="begin-level-0">Begin level 0</h1>
+<div><h2 id="begin-level-1">Begin level 1</h2>
+<div><h3 id="begin-level-2">Begin level 2</h3>
+<quote>Also a quote in the nested divs</quote><h3 id="end-level-2">End level 2</h3>
+</div><h2 id="end-level-1">End level 1</h2>
+</div><h1 id="end-level-0">End level 0</h1>

--- a/components/markdown/tests/snapshots/shortcodes__can_render_nested_shortcodes_with_bodies_with_nth.snap
+++ b/components/markdown/tests/snapshots/shortcodes__can_render_nested_shortcodes_with_bodies_with_nth.snap
@@ -1,0 +1,6 @@
+---
+source: components/markdown/tests/shortcodes.rs
+assertion_line: 398
+expression: body
+---
+<p>a: 1</p><p>a: 2</p><div><p>a: 5</p><p>a: 6</p><div><p>a: 9</p><p>a: 10</p></div><p>a: 7</p><p>a: 8</p></div><p>a: 3</p><p>a: 4</p>

--- a/components/site/src/feeds.rs
+++ b/components/site/src/feeds.rs
@@ -86,7 +86,7 @@ pub fn render_feeds(
 
         context.insert("feed_url", &feed_url);
         context = additional_context_fn(context);
-        feeds.push(render_template(feed_filename, &site.tera, context, &site.config.theme)?);
+        feeds.push(render_template(feed_filename, &*site.tera()?, context, &site.config.theme)?);
     }
 
     Ok(Some(feeds))

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -706,7 +706,8 @@ impl Site {
             return Ok(());
         }
 
-        let output = page.render_html(&*self.tera()?, &self.config, &self.library.read().unwrap())?;
+        let output =
+            page.render_html(&*self.tera()?, &self.config, &self.library.read().unwrap())?;
         let content = self.inject_livereload(output);
         let components: Vec<&str> = page.path.split('/').collect();
         let current_path = self.write_content(&components, "index.html", content)?;
@@ -942,8 +943,11 @@ impl Site {
 
         components.push(taxonomy.slug.as_ref());
 
-        let list_output =
-            taxonomy.render_all_terms(&*self.tera()?, &self.config, &self.library.read().unwrap())?;
+        let list_output = taxonomy.render_all_terms(
+            &*self.tera()?,
+            &self.config,
+            &self.library.read().unwrap(),
+        )?;
         let content = self.inject_livereload(list_output);
         self.write_content(&components, "index.html", content)?;
 
@@ -1010,7 +1014,8 @@ impl Site {
             // Create single sitemap
             let mut context = Context::new();
             context.insert("entries", &all_sitemap_entries);
-            let sitemap = render_template("sitemap.xml", &*self.tera()?, context, &self.config.theme)?;
+            let sitemap =
+                render_template("sitemap.xml", &*self.tera()?, context, &self.config.theme)?;
             self.write_content(&[], "sitemap.xml", sitemap)?;
             return Ok(());
         }
@@ -1022,7 +1027,8 @@ impl Site {
         {
             let mut context = Context::new();
             context.insert("entries", &chunk);
-            let sitemap = render_template("sitemap.xml", &*self.tera()?, context, &self.config.theme)?;
+            let sitemap =
+                render_template("sitemap.xml", &*self.tera()?, context, &self.config.theme)?;
             let file_name = format!("sitemap{}.xml", i + 1);
             self.write_content(&[], &file_name, sitemap)?;
             let mut sitemap_url = self.config.make_permalink(&file_name);

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -1,16 +1,15 @@
 use crate::Site;
 use libs::tera::Result as TeraResult;
-use std::sync::Arc;
+use std::sync::{Arc, PoisonError};
 use templates::{filters, global_fns};
 
 /// Adds global fns that are to be available to shortcodes while rendering markdown
 pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
-    site.tera.register_filter(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_filter(
         "num_format",
         filters::NumFormatFilter::new(&site.config.default_language),
     );
-
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_url",
         global_fns::GetUrl::new(
             site.base_path.clone(),
@@ -19,7 +18,7 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.output_path.clone(),
         ),
     );
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "resize_image",
         global_fns::ResizeImage::new(
             site.base_path.clone(),
@@ -28,7 +27,7 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.output_path.clone(),
         ),
     );
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_image_metadata",
         global_fns::GetImageMetadata::new(
             site.base_path.clone(),
@@ -36,7 +35,7 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.output_path.clone(),
         ),
     );
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "load_data",
         global_fns::LoadData::new(
             site.base_path.clone(),
@@ -44,8 +43,8 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.output_path.clone(),
         ),
     );
-    site.tera.register_function("trans", global_fns::Trans::new(site.config.clone()));
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function("trans", global_fns::Trans::new(site.config.clone()));
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_taxonomy_url",
         global_fns::GetTaxonomyUrl::new(
             &site.config.default_language,
@@ -53,7 +52,7 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.config.slugify.taxonomies,
         ),
     );
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_hash",
         global_fns::GetHash::new(
             site.base_path.clone(),
@@ -61,7 +60,7 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.output_path.clone(),
         ),
     );
-    site.tera.register_filter(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_filter(
         "markdown",
         filters::MarkdownFilter::new(
             site.config.clone(),
@@ -69,7 +68,6 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.tera.clone(),
         ),
     );
-
     Ok(())
 }
 
@@ -77,7 +75,7 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
 pub fn register_tera_global_fns(site: &mut Site) {
     let language_list: Arc<Vec<String>> =
         Arc::new(site.config.languages.keys().map(|s| s.to_string()).collect());
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_page",
         global_fns::GetPage::new(
             site.base_path.clone(),
@@ -86,7 +84,7 @@ pub fn register_tera_global_fns(site: &mut Site) {
             site.library.clone(),
         ),
     );
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_section",
         global_fns::GetSection::new(
             site.base_path.clone(),
@@ -95,7 +93,7 @@ pub fn register_tera_global_fns(site: &mut Site) {
             site.library.clone(),
         ),
     );
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_taxonomy",
         global_fns::GetTaxonomy::new(
             &site.config.default_language,
@@ -103,7 +101,7 @@ pub fn register_tera_global_fns(site: &mut Site) {
             site.library.clone(),
         ),
     );
-    site.tera.register_function(
+    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_taxonomy_term",
         global_fns::GetTaxonomyTerm::new(
             &site.config.default_language,

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -43,7 +43,10 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.output_path.clone(),
         ),
     );
-    site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function("trans", global_fns::Trans::new(site.config.clone()));
+    site.tera
+        .write()
+        .unwrap_or_else(PoisonError::into_inner)
+        .register_function("trans", global_fns::Trans::new(site.config.clone()));
     site.tera.write().unwrap_or_else(PoisonError::into_inner).register_function(
         "get_taxonomy_url",
         global_fns::GetTaxonomyUrl::new(

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -69,6 +69,7 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.config.clone(),
             site.permalinks.clone(),
             site.tera.clone(),
+            site.shortcode_invoke_counter.clone(),
         ),
     );
     Ok(())

--- a/components/templates/src/filters.rs
+++ b/components/templates/src/filters.rs
@@ -21,7 +21,11 @@ pub struct MarkdownFilter {
 }
 
 impl MarkdownFilter {
-    pub fn new(config: Config, permalinks: HashMap<String, String>, tera: Arc<RwLock<Tera>>) -> Self {
+    pub fn new(
+        config: Config,
+        permalinks: HashMap<String, String>,
+        tera: Arc<RwLock<Tera>>,
+    ) -> Self {
         Self { config, permalinks, tera }
     }
 }
@@ -34,9 +38,7 @@ impl TeraFilter for MarkdownFilter {
         // markdown respecting language preferences.
         let mut context = RenderContext::from_config(&self.config);
         context.permalinks = Cow::Borrowed(&self.permalinks);
-        let tera = self.tera.read().map_err(|lock_err| {
-            TeraError::msg(lock_err.to_string())
-        })?;
+        let tera = self.tera.read().map_err(|lock_err| TeraError::msg(lock_err.to_string()))?;
         context.tera = Cow::Borrowed(&tera);
         let def = utils::templates::get_shortcodes(&tera);
         context.set_shortcode_definitions(&def);
@@ -163,7 +165,10 @@ impl TeraFilter for NumFormatFilter {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::{Arc, RwLock}};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, RwLock},
+    };
 
     use libs::tera::{to_value, Filter, Tera};
 
@@ -174,8 +179,12 @@ mod tests {
 
     #[test]
     fn markdown_filter() {
-        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Arc::new(RwLock::new(Tera::default())))
-            .filter(&to_value(&"# Hey").unwrap(), &HashMap::new());
+        let result = MarkdownFilter::new(
+            Config::default(),
+            HashMap::new(),
+            Arc::new(RwLock::new(Tera::default())),
+        )
+        .filter(&to_value(&"# Hey").unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value(&"<h1 id=\"hey\">Hey</h1>\n").unwrap());
     }
@@ -201,11 +210,12 @@ mod tests {
     fn markdown_filter_inline() {
         let mut args = HashMap::new();
         args.insert("inline".to_string(), to_value(true).unwrap());
-        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Arc::new(RwLock::new(Tera::default())))
-            .filter(
-                &to_value(&"Using `map`, `filter`, and `fold` instead of `for`").unwrap(),
-                &args,
-            );
+        let result = MarkdownFilter::new(
+            Config::default(),
+            HashMap::new(),
+            Arc::new(RwLock::new(Tera::default())),
+        )
+        .filter(&to_value(&"Using `map`, `filter`, and `fold` instead of `for`").unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value(&"Using <code>map</code>, <code>filter</code>, and <code>fold</code> instead of <code>for</code>").unwrap());
     }
@@ -215,19 +225,23 @@ mod tests {
     fn markdown_filter_inline_tables() {
         let mut args = HashMap::new();
         args.insert("inline".to_string(), to_value(true).unwrap());
-        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Arc::new(RwLock::new(Tera::default())))
-            .filter(
-                &to_value(
-                    &r#"
+        let result = MarkdownFilter::new(
+            Config::default(),
+            HashMap::new(),
+            Arc::new(RwLock::new(Tera::default())),
+        )
+        .filter(
+            &to_value(
+                &r#"
 |id|author_id|       timestamp_created|title                 |content           |
 |-:|--------:|-----------------------:|:---------------------|:-----------------|
 | 1|        1|2018-09-05 08:03:43.141Z|How to train your ORM |Badly written blog|
 | 2|        1|2018-08-22 13:11:50.050Z|How to bake a nice pie|Badly written blog|
         "#,
-                )
-                .unwrap(),
-                &args,
-            );
+            )
+            .unwrap(),
+            &args,
+        );
         assert!(result.is_ok());
         assert!(result.unwrap().as_str().unwrap().contains("<table>"));
     }
@@ -241,14 +255,19 @@ mod tests {
         config.markdown.external_links_target_blank = true;
 
         let md = "Hello <https://google.com> :smile: ...";
-        let result = MarkdownFilter::new(config.clone(), HashMap::new(), Arc::new(RwLock::new(Tera::default())))
-            .filter(&to_value(&md).unwrap(), &HashMap::new());
+        let result = MarkdownFilter::new(
+            config.clone(),
+            HashMap::new(),
+            Arc::new(RwLock::new(Tera::default())),
+        )
+        .filter(&to_value(&md).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value(&"<p>Hello <a rel=\"noopener\" target=\"_blank\" href=\"https://google.com\">https://google.com</a> 😄 …</p>\n").unwrap());
 
         let md = "```py\ni=0\n```";
-        let result = MarkdownFilter::new(config, HashMap::new(), Arc::new(RwLock::new(Tera::default())))
-            .filter(&to_value(&md).unwrap(), &HashMap::new());
+        let result =
+            MarkdownFilter::new(config, HashMap::new(), Arc::new(RwLock::new(Tera::default())))
+                .filter(&to_value(&md).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert!(result.unwrap().as_str().unwrap().contains("style"));
     }
@@ -258,8 +277,12 @@ mod tests {
         let mut permalinks = HashMap::new();
         permalinks.insert("blog/_index.md".to_string(), "/foo/blog".to_string());
         let md = "Hello. Check out [my blog](@/blog/_index.md)!";
-        let result = MarkdownFilter::new(Config::default(), permalinks, Arc::new(RwLock::new(Tera::default())))
-            .filter(&to_value(&md).unwrap(), &HashMap::new());
+        let result = MarkdownFilter::new(
+            Config::default(),
+            permalinks,
+            Arc::new(RwLock::new(Tera::default())),
+        )
+        .filter(&to_value(&md).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap(),

--- a/components/templates/src/filters.rs
+++ b/components/templates/src/filters.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::hash::BuildHasher;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 use config::Config;
 
@@ -17,11 +17,11 @@ use markdown::{render_content, RenderContext};
 pub struct MarkdownFilter {
     config: Config,
     permalinks: HashMap<String, String>,
-    tera: Tera,
+    tera: Arc<RwLock<Tera>>,
 }
 
 impl MarkdownFilter {
-    pub fn new(config: Config, permalinks: HashMap<String, String>, tera: Tera) -> Self {
+    pub fn new(config: Config, permalinks: HashMap<String, String>, tera: Arc<RwLock<Tera>>) -> Self {
         Self { config, permalinks, tera }
     }
 }
@@ -34,8 +34,11 @@ impl TeraFilter for MarkdownFilter {
         // markdown respecting language preferences.
         let mut context = RenderContext::from_config(&self.config);
         context.permalinks = Cow::Borrowed(&self.permalinks);
-        context.tera = Cow::Borrowed(&self.tera);
-        let def = utils::templates::get_shortcodes(&self.tera);
+        let tera = self.tera.read().map_err(|lock_err| {
+            TeraError::msg(lock_err.to_string())
+        })?;
+        context.tera = Cow::Borrowed(&tera);
+        let def = utils::templates::get_shortcodes(&tera);
         context.set_shortcode_definitions(&def);
 
         let s = try_get_value!("markdown", "value", String, value);
@@ -160,7 +163,7 @@ impl TeraFilter for NumFormatFilter {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::{Arc, RwLock}};
 
     use libs::tera::{to_value, Filter, Tera};
 
@@ -171,7 +174,7 @@ mod tests {
 
     #[test]
     fn markdown_filter() {
-        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Tera::default())
+        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Arc::new(RwLock::new(Tera::default())))
             .filter(&to_value(&"# Hey").unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value(&"<h1 id=\"hey\">Hey</h1>\n").unwrap());
@@ -187,7 +190,7 @@ mod tests {
         let permalinks = HashMap::new();
         let mut tera = Tera::default();
         tera.add_raw_template("shortcodes/explicitlang.html", "a{{ lang }}a").unwrap();
-        let filter = MarkdownFilter { config, permalinks, tera };
+        let filter = MarkdownFilter { config, permalinks, tera: Arc::new(RwLock::new(tera)) };
         let result = filter.filter(&to_value(&"{{ explicitlang(lang='jp') }}").unwrap(), &args);
         println!("{:?}", result);
         assert!(result.is_ok());
@@ -198,7 +201,7 @@ mod tests {
     fn markdown_filter_inline() {
         let mut args = HashMap::new();
         args.insert("inline".to_string(), to_value(true).unwrap());
-        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Tera::default())
+        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Arc::new(RwLock::new(Tera::default())))
             .filter(
                 &to_value(&"Using `map`, `filter`, and `fold` instead of `for`").unwrap(),
                 &args,
@@ -212,7 +215,7 @@ mod tests {
     fn markdown_filter_inline_tables() {
         let mut args = HashMap::new();
         args.insert("inline".to_string(), to_value(true).unwrap());
-        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Tera::default())
+        let result = MarkdownFilter::new(Config::default(), HashMap::new(), Arc::new(RwLock::new(Tera::default())))
             .filter(
                 &to_value(
                     &r#"
@@ -238,13 +241,13 @@ mod tests {
         config.markdown.external_links_target_blank = true;
 
         let md = "Hello <https://google.com> :smile: ...";
-        let result = MarkdownFilter::new(config.clone(), HashMap::new(), Tera::default())
+        let result = MarkdownFilter::new(config.clone(), HashMap::new(), Arc::new(RwLock::new(Tera::default())))
             .filter(&to_value(&md).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value(&"<p>Hello <a rel=\"noopener\" target=\"_blank\" href=\"https://google.com\">https://google.com</a> 😄 …</p>\n").unwrap());
 
         let md = "```py\ni=0\n```";
-        let result = MarkdownFilter::new(config, HashMap::new(), Tera::default())
+        let result = MarkdownFilter::new(config, HashMap::new(), Arc::new(RwLock::new(Tera::default())))
             .filter(&to_value(&md).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert!(result.unwrap().as_str().unwrap().contains("style"));
@@ -255,7 +258,7 @@ mod tests {
         let mut permalinks = HashMap::new();
         permalinks.insert("blog/_index.md".to_string(), "/foo/blog".to_string());
         let md = "Hello. Check out [my blog](@/blog/_index.md)!";
-        let result = MarkdownFilter::new(Config::default(), permalinks, Tera::default())
+        let result = MarkdownFilter::new(Config::default(), permalinks, Arc::new(RwLock::new(Tera::default())))
             .filter(&to_value(&md).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(

--- a/components/utils/src/templates.rs
+++ b/components/utils/src/templates.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, PoisonError, RwLock},
+};
 
 use libs::tera::{Context, Tera};
 
@@ -31,6 +34,26 @@ impl ShortcodeDefinition {
         let tera_name = tera_name.to_string();
 
         ShortcodeDefinition { file_type, tera_name }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ShortcodeInvocationCounter {
+    amounts: Arc<RwLock<HashMap<String, usize>>>,
+}
+impl ShortcodeInvocationCounter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn get(&self, str: &str) -> usize {
+        let mut amounts = self.amounts.write().unwrap_or_else(PoisonError::into_inner);
+        let nth = amounts.entry(str.into()).or_insert(0);
+        *nth += 1;
+        return *nth;
+    }
+    pub fn reset(&self) {
+        let mut amounts = self.amounts.write().unwrap_or_else(PoisonError::into_inner);
+        amounts.clear();
     }
 }
 


### PR DESCRIPTION
This PR will allow the use of nested shortcodes with markdown bodies. For example, with the shortcodes...
- `shortcodes/div_md.html`: `<div>{{ body | markdown | safe }}</div>`
- `shortcodes/quote.html`: `<quote>{{body}}</quote>`

Zola will now convert the following markdown...
```md
# Begin level 0  

{% div_md() %}

## Begin level 1

{% div_md() %}

### Begin level 2

{% quote() %} Also a quote in the nested divs {% end %}

### End level 2

{% end %}

## End level 1

{% end %}

# End level 0
```
...into the following HTML.
```html
<h1 id="begin-level-0">Begin level 0</h1>
<div>
	<h2 id="begin-level-1">Begin level 1</h2>
	<div>
		<h3 id="begin-level-2">Begin level 2</h3>
		<quote>Also a quote in the nested divs</quote>
		<h3 id="end-level-2">End level 2</h3>
	</div>
	<h2 id="end-level-1">End level 1</h2>
</div>
<h1 id="end-level-0">End level 0</h1>
```

Fixes #515

I am assuming this is still a desired feature as the issue is still open.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
  * #1475 was not merged, and it is currently incompatible with the latest version of Zola

## Code changes
* `templates::filters::MarkdownFilter` and `site::Site` have been changed to share a single `Tera` instance using a `RwLock`. This gives the `MarkdownFilter` the ability to eventually call itself.
* The shortcode parser has been changed to stop at the appropriate `{% end %}`, instead of the first-encountered `{% end %}`. (Thanks to #1475)
* `cargo test --all` was ran prior to PR submission
* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?
  * As far as I'm aware, the documentation does not explicitly prohibit nested short-codes.



