### PR TITLE
Allow treating a missing highlight language as error

### DIFF
--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -27,6 +27,8 @@ pub struct ThemeCss {
 pub struct Markdown {
     /// Whether to highlight all code blocks found in markdown files. Defaults to false
     pub highlight_code: bool,
+    /// Emit an error for missing highlight languages. Defaults to false
+    pub error_on_missing_highlight: bool,
     /// Which themes to use for code highlighting. See Readme for supported themes
     /// Defaults to "base16-ocean-dark"
     pub highlight_theme: String,
@@ -198,6 +200,7 @@ impl Default for Markdown {
     fn default() -> Markdown {
         Markdown {
             highlight_code: false,
+            error_on_missing_highlight: false,
             highlight_theme: DEFAULT_HIGHLIGHT_THEME.to_owned(),
             highlight_themes_css: Vec::new(),
             render_emoji: false,

--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -559,7 +559,13 @@ pub fn markdown_to_html(
                         cmark::CodeBlockKind::Fenced(fence_info) => FenceSettings::new(fence_info),
                         _ => FenceSettings::new(""),
                     };
-                    let (block, begin) = CodeBlock::new(fence, context.config, path);
+                    let (block, begin) = match CodeBlock::new(fence, context.config, path) {
+                        Ok(cb) => cb,
+                        Err(e) => {
+                            error = Some(e);
+                            break;
+                        }
+                    };
                     code_block = Some(block);
                     events.push(Event::Html(begin.into()));
                 }

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -114,6 +114,9 @@ generate_robots_txt = true
 # When set to "true", all code blocks are highlighted.
 highlight_code = false
 
+# When set to "true", missing highlight languages are treated as errors. Defaults to false.
+error_on_missing_highlight = false
+
 # A list of directories used to search for additional `.sublime-syntax` and `.tmTheme` files.
 extra_syntaxes_and_themes = []
 


### PR DESCRIPTION
This is a tiny non-breaking feature. I already did the work before seeing the note about your forum in the pull request template. I hope I'm not being too rude by skipping making a post there :sweat_smile: 

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



