### PR TITLE
Add pagination info to sections

### DIFF
--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -162,6 +162,9 @@ pub struct SerializingSection<'a> {
     backlinks: Vec<BackLink<'a>>,
     generate_feeds: bool,
     transparent: bool,
+    paginated: bool,
+    paginate_by: Option<usize>,
+    paginate_reversed: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -203,6 +206,19 @@ impl<'a> SerializingSection<'a> {
             }
         }
 
+        let paginated;
+        let paginate_by;
+        let paginate_reversed;
+        if let Some(_) = section.meta.paginate_by.filter(|nb_pages| *nb_pages > 0) {
+            paginated = true;
+            paginate_by = section.meta.paginate_by;
+            paginate_reversed = Some(section.meta.paginate_reversed);
+        } else {
+            paginated = false;
+            paginate_by = None;
+            paginate_reversed = None;
+        }
+
         Self {
             relative_path: &section.file.relative,
             colocated_path: &section.file.colocated_path,
@@ -226,6 +242,9 @@ impl<'a> SerializingSection<'a> {
             subsections,
             translations,
             backlinks,
+            paginated,
+            paginate_by,
+            paginate_reversed,
         }
     }
 }

--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -162,9 +162,8 @@ pub struct SerializingSection<'a> {
     backlinks: Vec<BackLink<'a>>,
     generate_feeds: bool,
     transparent: bool,
-    paginated: bool,
-    paginate_by: Option<usize>,
-    paginate_reversed: Option<bool>,
+    paginate_by: &'a Option<usize>,
+    paginate_reversed: bool,
 }
 
 #[derive(Debug)]
@@ -206,19 +205,6 @@ impl<'a> SerializingSection<'a> {
             }
         }
 
-        let paginated;
-        let paginate_by;
-        let paginate_reversed;
-        if let Some(_) = section.meta.paginate_by.filter(|nb_pages| *nb_pages > 0) {
-            paginated = true;
-            paginate_by = section.meta.paginate_by;
-            paginate_reversed = Some(section.meta.paginate_reversed);
-        } else {
-            paginated = false;
-            paginate_by = None;
-            paginate_reversed = None;
-        }
-
         Self {
             relative_path: &section.file.relative,
             colocated_path: &section.file.colocated_path,
@@ -242,9 +228,8 @@ impl<'a> SerializingSection<'a> {
             subsections,
             translations,
             backlinks,
-            paginated,
-            paginate_by,
-            paginate_reversed,
+            paginate_by: &section.meta.paginate_by,
+            paginate_reversed: section.meta.paginate_reversed,
         }
     }
 }

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -112,13 +112,10 @@ backlinks: Array<{permalink: String, title: String?}>;
 generate_feeds: bool;
 // Whether this section is transparent. Taken from the front-matter if set
 transparent: bool;
-// Information about pagination (see below)
-// Whether this section is paginated.
-paginated: bool;
-// How many items per pager
+// How many items per pager (if defined)
 paginate_by: Number?;
-// If items order is reversed in the pagination
-paginate_reversed: bool?;
+// If items order is reversed in the pagination (defaults to false)
+paginate_reversed: bool;
 ```
 
 Information about pagination is useful when using the `get_section` Tera function for which the `paginator` is not available.

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -112,7 +112,18 @@ backlinks: Array<{permalink: String, title: String?}>;
 generate_feeds: bool;
 // Whether this section is transparent. Taken from the front-matter if set
 transparent: bool;
+// Information about pagination (see below)
+// Whether this section is paginated.
+paginated: bool;
+// How many items per pager
+paginate_by: Number?;
+// If items order is reversed in the pagination
+paginate_reversed: bool?;
 ```
+
+Information about pagination is useful when using the `get_section` Tera function for which the `paginator` is not available.
+
+See [pagination template documentation](@/documentation/templates/pagination.md) for more information on the `paginator` variable.
 
 ## Table of contents
 


### PR DESCRIPTION
Objective of this small update is to add some minimal information about pagination in the section itself for cases where the paginator is not available (e.g. when using `get_section`).

A small site for testing the feature is attached to this PR: [testsite.zip](https://github.com/user-attachments/files/17179446/testsite.zip).

This feature has been discussed in issue [2473](https://github.com/getzola/zola/issues/2473).

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [X] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [X] Have you created/updated the relevant documentation page(s)?



