### PR TITLE
Handle file events emitted by Nova on macOS

### DIFF
--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -35,6 +35,10 @@ pub type MeaningfulEvent = (PathBuf, PathBuf, SimpleFileSystemEventKind);
 /// return `None`.
 fn get_relevant_event_kind(event_kind: &EventKind) -> Option<SimpleFileSystemEventKind> {
     match event_kind {
+        // Nova on macOS reports this as it's final event on change
+        EventKind::Modify(ModifyKind::Name(RenameMode::Any)) => {
+            Some(SimpleFileSystemEventKind::Modify)
+        }
         EventKind::Create(CreateKind::File) | EventKind::Create(CreateKind::Folder) => {
             Some(SimpleFileSystemEventKind::Create)
         }


### PR DESCRIPTION
As per the bug report https://github.com/getzola/zola/issues/2663, I've added a branch to the match expression to catch EventKind::Modify(ModifyKind::Name(RenameMode::Any)) events made by Nova on macOS when editing files.

It appears that this is the only event that makes it to meaningful_events: HashMap<PathBuf, (PathBuf, SimpleFileSystemEventKind, ChangeKind)> when using Nova.

In testing this change, I discovered that other editors including Helix 24.7 and Vim 9.0.2142 also emit this event, but go on to emit others.

This change didn't introduce problems when editing with:

Helix 24.7
Vim 9.0.2142
Sublime Text Build 4180
on macOS 14.6.1.
Let me know if you want further testing (or tests) added.

**NOTE:** This supersedes PR #2672 where I had based my change on `master` not `next`, and therefore including other changes. Apologies.

Cheers, Jamie.



