### PR TITLE
Updated github action version

### DIFF
--- a/docs/content/documentation/deployment/github-pages.md
+++ b/docs/content/documentation/deployment/github-pages.md
@@ -49,7 +49,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.17.2
+        uses: shalzz/zola-deploy-action@master
         env:
           # Target branch
           PAGES_BRANCH: gh-pages
@@ -80,7 +80,7 @@ jobs:
       - name: 'checkout'
         uses: actions/checkout@v4
       - name: 'build'
-        uses: shalzz/zola-deploy-action@v0.17.2
+        uses: shalzz/zola-deploy-action@master
         env:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: .
@@ -93,7 +93,7 @@ jobs:
       - name: 'checkout'
         uses: actions/checkout@v4
       - name: 'build and deploy'
-        uses: shalzz/zola-deploy-action@v0.17.2
+        uses: shalzz/zola-deploy-action@master
         env:
           PAGES_BRANCH: master
           BUILD_DIR: .


### PR DESCRIPTION
The github action version in the example snipped does not work. 
See issue:
https://github.com/shalzz/zola-deploy-action/issues/71



