### PR TITLE
Update Zola build deploy version to v0.19.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: build
-        uses: shalzz/zola-deploy-action@v0.18.0
+        uses: shalzz/zola-deploy-action@v0.19.2
         env:
           BUILD_DIR: docs/
           BUILD_ONLY: true
@@ -28,7 +28,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.18.0
+        uses: shalzz/zola-deploy-action@v0.19.2
         env:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: docs/

--- a/docs/templates/theme.html
+++ b/docs/templates/theme.html
@@ -17,10 +17,12 @@
               <div>
               <p>Tags:</p>
               <ul style="list-style-type: none;">
-              {% for t in page.taxonomies["theme-tags"] %}
-                {% set term = get_taxonomy_term(kind="theme-tags", term = t) %}
-                <li><a href="{{ term.permalink }}">{{ term.name }}</a></li>
-                {% endfor %}
+              {% for termname in page.taxonomies["theme-tags"] %}
+                {% set termurl = get_taxonomy_url(kind="theme-tags", name=termname, required=false) %}
+                {% if termurl %}
+                  <li><a href="{{ termurl }}">{{ termname }}</a></li>
+                {% endif %}
+              {% endfor %}
               </div>
             {% endif %}
             <p><b>Last updated:</b> {{page.extra.updated }}</p>

--- a/docs/templates/theme.html
+++ b/docs/templates/theme.html
@@ -7,7 +7,16 @@
         <div class="metadata">
             <h1>{{ page.title }}</h1>
             <p>{{ page.description }}</p>
-            <p><b>Author:</b> {{page.extra.author.name}}</p>
+            <p><b>Author:</b>
+            {% if page.extra.author.homepage %}
+              <a href="{{ page.extra.author.homepage }}">{{ page.extra.author.name }}</a>
+            {% else %}
+              {{ page.extra.author.name }}
+              {% endif %}
+            </p>
+            {% if page.extra.minimum_version %}
+              <p>This theme requires Zola version {{ page.extra.minimum_version }} and above</p>
+            {% endif %}
             <p><b>License:</b> {{page.extra.license}}</p>
             <p><b>Homepage:</b> <a href="{{page.extra.homepage}}">{{page.extra.homepage}}</a></p>
             {% if page.extra.demo %}


### PR DESCRIPTION
I thought latest adding tag failure is because of the Zola's build version used in this site, because it works in 0.19.2

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [ ] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



