### PR TITLE
Remove COPR recommendation for installation

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -47,15 +47,6 @@ Grab the latest `.deb` for your Debian version then simply run:
 $ sudo dpkg -i zola_<version>_amd64_debian_<debian_version>.deb
 ```
 
-### Fedora
-
-On Fedora, Zola is available via [COPR](https://fedoraproject.org/wiki/Category:Copr).
-
-```sh
-$ sudo dnf copr enable fz0x1/zola
-$ sudo dnf install zola
-```
-
 ### Gentoo
 
 Zola is available via [GURU](https://wiki.gentoo.org/wiki/Project:GURU).


### PR DESCRIPTION
The package hasn't been updated since Zola 0.12, which led to me being quite confused when the syntax highlighting instructions in the docs didn't work.