### PR TITLE
feat: make urls clickable in github action logs

### DIFF
--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -282,7 +282,7 @@ pub fn check_external_links(site: &Site) -> Vec<String> {
 
             for (page_path, link, check_res) in errors {
                 messages.push(format!(
-                    "Broken link in {} to {}: {}",
+                    "Broken link in {} to {} : {}",
                     page_path.to_string_lossy(),
                     link,
                     link_checker::message(&check_res)


### PR DESCRIPTION
With the colon joined to the url , clicking resulted in the wrong link. Added a space to move away the colon.

Closes https://github.com/getzola/zola/issues/2751#issuecomment-2564813357


Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)? (Didn't seem applicable)