### PR TITLE
Add `--skip-external-links` CLI flag to `check` subcommand

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -65,6 +65,8 @@ pub struct Site {
     include_drafts: bool,
     build_mode: BuildMode,
     shortcode_definitions: HashMap<String, ShortcodeDefinition>,
+    /// Whether to check external links
+    check_external_links: bool,
 }
 
 impl Site {
@@ -108,6 +110,7 @@ impl Site {
             library: Arc::new(RwLock::new(Library::default())),
             build_mode: BuildMode::Disk,
             shortcode_definitions,
+            check_external_links: true,
         };
 
         Ok(site)
@@ -124,6 +127,11 @@ impl Site {
     /// Needs to be called before loading it
     pub fn include_drafts(&mut self) {
         self.include_drafts = true;
+    }
+
+    /// Set the site checker to skip external links check.
+    pub fn skip_external_links_check(&mut self) {
+        self.check_external_links = false;
     }
 
     /// The index sections are ALWAYS at those paths
@@ -344,7 +352,7 @@ impl Site {
         }
 
         // check external links, log the results, and error out if needed
-        if self.config.is_in_check_mode() {
+        if self.config.is_in_check_mode() && self.check_external_links {
             let external_link_messages = link_checking::check_external_links(self);
             if !external_link_messages.is_empty() {
                 let messages: Vec<String> = external_link_messages

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -852,6 +852,32 @@ fn panics_on_invalid_external_domain() {
 }
 
 #[test]
+fn external_links_ignored_on_check() {
+    let (mut site, _tmp_dir, _public) = build_site("test_site");
+
+    // remove the invalid domain skip prefix
+    let i = site
+        .config
+        .link_checker
+        .skip_prefixes
+        .iter()
+        .position(|prefix| prefix == "http://invaliddomain")
+        .unwrap();
+    site.config.link_checker.skip_prefixes.remove(i);
+
+    // confirm the invalid domain skip prefix was removed
+    assert_eq!(site.config.link_checker.skip_prefixes, vec!["http://[2001:db8::]/"]);
+
+    // set a flag to skip external links check
+    site.skip_external_links_check();
+
+    // check the test site with all external links (including invalid domain) skipped, which should
+    // not cause a panic
+    site.config.enable_check_mode();
+    site.load().expect("link check test_site");
+}
+
+#[test]
 fn can_find_site_and_page_authors() {
     let mut path = env::current_dir().unwrap().parent().unwrap().parent().unwrap().to_path_buf();
     path.push("test_site");

--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -114,6 +114,8 @@ The check subcommand will try to build all pages just like the build command wou
 results to disk. Additionally, it will also check all external links in Markdown files by trying to fetch
 them (links in the template files are not checked).
 
+You can skip link checking for all the external links by `--skip-external-links` flag.
+
 By default, drafts are not loaded. If you wish to include them, pass the `--drafts` flag.
 
 ## Colored output

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,6 +100,9 @@ pub enum Command {
         /// Include drafts when loading the site
         #[clap(long)]
         drafts: bool,
+        /// Skip external links
+        #[clap(long)]
+        skip_external_links: bool,
     },
 
     /// Generate shell completion

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -11,6 +11,7 @@ pub fn check(
     base_path: Option<&str>,
     base_url: Option<&str>,
     include_drafts: bool,
+    skip_external_links: bool,
 ) -> Result<()> {
     let bp = base_path.map(PathBuf::from).unwrap_or_else(|| PathBuf::from(root_dir));
     let mut site = Site::new(bp, config_file)?;
@@ -21,6 +22,9 @@ pub fn check(
     }
     if include_drafts {
         site.include_drafts();
+    }
+    if skip_external_links {
+        site.skip_external_links_check();
     }
     site.load()?;
     messages::check_site_summary(&site);

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,11 +121,11 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        Command::Check { drafts } => {
+        Command::Check { drafts, skip_external_links } => {
             console::info("Checking site...");
             let start = Instant::now();
             let (root_dir, config_file) = get_config_file_path(&cli_dir, &cli.config);
-            match cmd::check(&root_dir, &config_file, None, None, drafts) {
+            match cmd::check(&root_dir, &config_file, None, None, drafts, skip_external_links) {
                 Ok(()) => messages::report_elapsed_time(start),
                 Err(e) => {
                     messages::unravel_errors("Failed to check the site", &e);


### PR DESCRIPTION
Adds `--skip-external-links` flag to skip checking for all the external links.
This will be useful when users will run `zola check` very frequently or the site contains so much external links.

The default behavior is preserved, `zola check` checks the external links if the new flag is not specified.

Discussed in [CLI flag to skip external links check - Feature requests - Zola](https://zola.discourse.group/t/cli-flag-to-skip-external-links-check/2427).

* * *

<!--
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.
-->

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
<!--(Delete or ignore this section for documentation changes)-->

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
