### PR TITLE
Add optional parsing of definition lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Exclude paginated pages in sitemap by default
 - Allow treating a missing highlight language as error
 - Handle more editors with change detection in `zola serve`
+- Add optional parsing of Markdown definition lists
 
 
 ## 0.19.2 (2024-08-15)

--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -47,6 +47,8 @@ pub struct Markdown {
     pub external_links_no_referrer: bool,
     /// Whether smart punctuation is enabled (changing quotes, dashes, dots etc in their typographic form)
     pub smart_punctuation: bool,
+    /// Whether parsing of definition lists is enabled
+    pub definition_list: bool,
     /// Whether footnotes are rendered at the bottom in the style of GitHub.
     pub bottom_footnotes: bool,
     /// A list of directories to search for additional `.sublime-syntax` and `.tmTheme` files in.
@@ -227,6 +229,7 @@ impl Default for Markdown {
             external_links_no_follow: false,
             external_links_no_referrer: false,
             smart_punctuation: false,
+            definition_list: false,
             bottom_footnotes: false,
             extra_syntaxes_and_themes: vec![],
             extra_syntax_set: None,

--- a/components/libs/Cargo.toml
+++ b/components/libs/Cargo.toml
@@ -21,7 +21,7 @@ nom-bibtex = "0.5"
 num-format = "0.4"
 once_cell = "1"
 percent-encoding = "2"
-pulldown-cmark = { version = "0.11", default-features = false, features = ["html", "simd"] }
+pulldown-cmark = { version = "0.12.2", default-features = false, features = ["html", "simd"] }
 pulldown-cmark-escape = { version = "0.11", default-features = false }
 quickxml_to_serde = "0.6"
 rayon = "1"

--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -440,6 +440,9 @@ pub fn markdown_to_html(
     if context.config.markdown.smart_punctuation {
         opts.insert(Options::ENABLE_SMART_PUNCTUATION);
     }
+    if context.config.markdown.definition_list {
+        opts.insert(Options::ENABLE_DEFINITION_LIST);
+    }
 
     // we reverse their order so we can pop them easily in order
     let mut html_shortcodes: Vec<_> = html_shortcodes.into_iter().rev().collect();

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -153,6 +153,18 @@ fn can_use_smart_punctuation() {
 }
 
 #[test]
+fn can_use_definition_list() {
+    let mut config = Config::default_for_test();
+    config.markdown.definition_list = true;
+    let content = r#"
+term
+: definition
+    "#;
+    let body = common::render_with_config(content, config).unwrap().body;
+    insta::assert_snapshot!(body);
+}
+
+#[test]
 fn can_use_external_links_class() {
     let mut config = Config::default_for_test();
 

--- a/components/markdown/tests/snapshots/markdown__can_use_definition_list.snap
+++ b/components/markdown/tests/snapshots/markdown__can_use_definition_list.snap
@@ -1,0 +1,8 @@
+---
+source: components/markdown/tests/markdown.rs
+expression: body
+---
+<dl>
+<dt>term</dt>
+<dd>definition</dd>
+</dl>

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -145,6 +145,9 @@ external_links_no_referrer = false
 # For example, `...` into `…`, `"quote"` into `“curly”` etc
 smart_punctuation = false
 
+# Whether parsing of definition lists is enabled
+definition_list = false
+
 # Whether to set decoding="async" and loading="lazy" for all images
 # When turned on, the alt text must be plain text.
 # For example, `![xx](...)` is ok but `![*x*x](...)` isn’t ok


### PR DESCRIPTION
`pulldown-cmark` Markdown parser added support for definition lists in
https://github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.12.0

Parsing of definition lists using zola is optional and can be enabled
using configuration variable `definition_list = true` (default is
false).

Closes https://github.com/getzola/zola/issues/2718

Update `pulldown-cmark` to 0.12.2

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



