### PR TITLE
Adds *.txt to the list of template files loaded by Tera

### DIFF
--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -45,7 +45,7 @@ pub fn render_redirect_template(url: &str, tera: &Tera) -> Result<String> {
 
 pub fn load_tera(path: &Path, config: &Config) -> Result<Tera> {
     let tpl_glob =
-        format!("{}/{}", path.to_string_lossy().replace('\\', "/"), "templates/**/*.{*ml,md}");
+        format!("{}/{}", path.to_string_lossy().replace('\\', "/"), "templates/**/*.{*ml,md,txt}");
 
     // Only parsing as we might be extending templates from themes and that would error
     // as we haven't loaded them yet

--- a/docs/content/documentation/templates/robots.md
+++ b/docs/content/documentation/templates/robots.md
@@ -15,3 +15,14 @@ Disallow:
 Allow: /
 Sitemap: {{/* get_url(path="sitemap.xml") */}}
 ```
+
+The file can be extended & expanded like other templates using e.g. Tera's `include` tag:
+
+```jinja2
+User-agent: *
+Disallow:
+Allow: /
+Sitemap: {{/* get_url(path="sitemap.xml") */}}
+
+{% include "path/to/other/robots.txt" %}
+```


### PR DESCRIPTION
Closes #2768

## Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
- As motivation for this and prior art revolves around `robots.txt`, I've added a short blurb to that page in the `Templates` section about extending it with a `.txt` file. If this is not appropriate to be included in this PR then it can be easily removed, it's a separate commit that should be easily reverted.