### PR TITLE
Adds minify option to build command

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -175,6 +175,10 @@ impl Site {
         self.output_path = path.as_ref().to_path_buf();
     }
 
+    pub fn minify(&mut self) {
+        self.config.minify_html = true;
+    }
+
     /// Reads all .md files in the `content` directory and create pages/sections
     /// out of them
     pub fn load(&mut self) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,10 @@ pub enum Command {
         /// Include drafts when loading the site
         #[clap(long)]
         drafts: bool,
+
+        /// Minify generated HTML files
+        #[clap(long)]
+        minify: bool,
     },
 
     /// Serve the site. Rebuild and reload on change automatically

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -12,6 +12,7 @@ pub fn build(
     output_dir: Option<&Path>,
     force: bool,
     include_drafts: bool,
+    minify: bool,
 ) -> Result<()> {
     let mut site = Site::new(root_dir, config_file)?;
     if let Some(output_dir) = output_dir {
@@ -29,6 +30,9 @@ pub fn build(
     }
     if include_drafts {
         site.include_drafts();
+    }
+    if minify {
+        site.minify();
     }
     site.load()?;
     messages::notify_site_size(&site);

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        Command::Build { base_url, output_dir, force, drafts } => {
+        Command::Build { base_url, output_dir, force, drafts, minify } => {
             console::info("Building site...");
             let start = Instant::now();
             let (root_dir, config_file) = get_config_file_path(&cli_dir, &cli.config);
@@ -68,6 +68,7 @@ fn main() {
                 output_dir.as_deref(),
                 force,
                 drafts,
+                minify,
             ) {
                 Ok(()) => messages::report_elapsed_time(start),
                 Err(e) => {


### PR DESCRIPTION
Now the build command supports minification and you can run `zola build --minify` to get the minified result only at build time. Closes #1924.

Now if the pull request is correct. Sorry for the previous one that I made a mix of branches.

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [X] Are you doing the PR on the `next` branch?


