### PR TITLE
[Feature] Manage `before` and `after` attribute in frontmatter

### DIFF
--- a/components/content/src/front_matter/page.rs
+++ b/components/content/src/front_matter/page.rs
@@ -66,6 +66,16 @@ pub struct PageFrontMatter {
     /// Defaults to `true` but is only used if search if explicitly enabled in the config.
     #[serde(skip_serializing)]
     pub in_search_index: bool,
+    /// Page is valid until `date_before`
+    #[serde(default, deserialize_with = "from_unknown_datetime")]
+    pub before: Option<String>,
+    #[serde(default, skip_deserializing)]
+    pub before_datetime: Option<OffsetDateTime>,
+    /// Page is valid after `date_after`
+    #[serde(default, deserialize_with = "from_unknown_datetime")]
+    pub after: Option<String>,
+    #[serde(default, skip_deserializing)]
+    pub after_datetime: Option<OffsetDateTime>,
     /// Any extra parameter present in the front matter
     pub extra: Map<String, Value>,
 }
@@ -135,6 +145,10 @@ impl PageFrontMatter {
         self.updated_datetime = self.updated.as_ref().map(|s| s.as_ref()).and_then(parse_datetime);
         self.updated_datetime_tuple =
             self.updated_datetime.map(|dt| (dt.year(), dt.month().into(), dt.day()));
+
+        self.before_datetime = self.before.as_ref().map(|s| s.as_ref()).and_then(parse_datetime);
+
+        self.after_datetime = self.after.as_ref().map(|s| s.as_ref()).and_then(parse_datetime);
     }
 
     pub fn weight(&self) -> usize {
@@ -163,6 +177,10 @@ impl Default for PageFrontMatter {
             authors: Vec::new(),
             aliases: Vec::new(),
             template: None,
+            before: None,
+            after: None,
+            before_datetime: None,
+            after_datetime: None,
             extra: Map::new(),
         }
     }

--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -70,6 +70,8 @@ pub struct SerializingPage<'a> {
     higher: Option<Box<SerializingPage<'a>>>,
     translations: Vec<TranslatedContent<'a>>,
     backlinks: Vec<BackLink<'a>>,
+    before: &'a Option<String>,
+    after: &'a Option<String>,
 }
 
 impl<'a> SerializingPage<'a> {
@@ -130,6 +132,8 @@ impl<'a> SerializingPage<'a> {
             assets: &page.serialized_assets,
             draft: page.meta.draft,
             lang: &page.lang,
+            before: &page.meta.before,
+            after: &page.meta.after,
             lower,
             higher,
             translations,

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -7,6 +7,7 @@ include = ["src/**/*"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+time = { version = "0.3", features = ["macros"] }
 
 errors = { path = "../errors" }
 config = { path = "../config" }

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -22,7 +22,7 @@ fn can_parse_site() {
     let library = site.library.read().unwrap();
 
     // Correct number of pages (sections do not count as pages, draft are ignored)
-    assert_eq!(library.pages.len(), 36);
+    assert_eq!(library.pages.len(), 38);
     let posts_path = path.join("content").join("posts");
 
     // Make sure the page with a url doesn't have any sections
@@ -35,11 +35,11 @@ fn can_parse_site() {
     assert_eq!(asset_folder_post.file.components, vec!["posts".to_string()]);
 
     // That we have the right number of sections
-    assert_eq!(library.sections.len(), 13);
+    assert_eq!(library.sections.len(), 14);
 
     // And that the sections are correct
     let index_section = library.sections.get(&path.join("content").join("_index.md")).unwrap();
-    assert_eq!(index_section.subsections.len(), 5);
+    assert_eq!(index_section.subsections.len(), 6);
     assert_eq!(index_section.pages.len(), 5);
     assert!(index_section.ancestors.is_empty());
 
@@ -283,7 +283,7 @@ fn can_build_site_with_live_reload_and_drafts() {
 
     // drafted sections are included
     let library = site.library.read().unwrap();
-    assert_eq!(library.sections.len(), 15);
+    assert_eq!(library.sections.len(), 16);
 
     assert!(file_exists!(public, "secret_section/index.html"));
     assert!(file_exists!(public, "secret_section/draft-page/index.html"));
@@ -926,6 +926,20 @@ fn can_find_site_and_page_authors() {
     assert_eq!(1, p1.meta.authors.len());
     assert_eq!("page@example.com (Page Author)", p1.meta.authors.get(0).unwrap());
     assert_eq!(0, p2.meta.authors.len());
+}
+
+#[test]
+fn test_before_after() {
+    let (_, _tmp_dir, public) = build_site("test_site");
+
+    assert!(&public.exists());
+    assert!(file_exists!(public, "index.html"));
+
+    assert!(file_exists!(public, "before_after/after-1980/index.html"));
+    assert!(file_exists!(public, "before_after/before-2100/index.html"));
+
+    assert!(!file_exists!(public, "before_after/before-1980/index.html"));
+    assert!(!file_exists!(public, "before_after/after-2100/index.html"));
 }
 
 // Follows test_site/themes/sample/templates/current_path.html

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -141,6 +141,14 @@ in_search_index = true
 # Template to use to render this page.
 template = "page.html"
 
+# Page will be generated if current date < before
+# Format is same as date field
+before =
+
+# Page will be generated if current date >= after
+# Format is same as date field
+after =
+
 # The taxonomies for this page. The keys need to be the same as the taxonomy
 # names configured in `config.toml` and the values are an array of String objects. For example,
 # tags = ["rust", "web"].

--- a/test_site/content/before_after/_index.md
+++ b/test_site/content/before_after/_index.md
@@ -1,0 +1,3 @@
++++
+render = false
++++

--- a/test_site/content/before_after/after_1950.md
+++ b/test_site/content/before_after/after_1950.md
@@ -1,0 +1,6 @@
++++
+title = "After 2100"
+after = 2100-01-01
++++
+
+Hello

--- a/test_site/content/before_after/after_1980.md
+++ b/test_site/content/before_after/after_1980.md
@@ -1,0 +1,6 @@
++++
+title = "After 1980"
+after = 1980-01-01
++++
+
+Hello

--- a/test_site/content/before_after/after_2100.md
+++ b/test_site/content/before_after/after_2100.md
@@ -1,0 +1,6 @@
++++
+title = "After 2100"
+after = 2100-01-01
++++
+
+Hello

--- a/test_site/content/before_after/before_1980.md
+++ b/test_site/content/before_after/before_1980.md
@@ -1,0 +1,6 @@
++++
+title = "Before 1980"
+before = 1980-01-01
++++
+
+Hello

--- a/test_site/content/before_after/before_2100.md
+++ b/test_site/content/before_after/before_2100.md
@@ -1,0 +1,6 @@
++++
+title = "Before 2100"
+before = 2100-01-01
++++
+
+Hello


### PR DESCRIPTION
It allows to specify a publication date.
Not a filter, but it's managed by page.

For ticket #2619 