### PR TITLE
Update codeberg pages deployment guide to use from_secret

### DIFF
--- a/docs/content/documentation/deployment/codeberg-pages.md
+++ b/docs/content/documentation/deployment/codeberg-pages.md
@@ -56,13 +56,17 @@ steps:
 
   publish:
     image: bitnami/git
-    secrets: [mail, codeberg_token]
+    environment:
+      CBMAIL:
+        from_secret: "mail"
+      CBTOKEN:
+        from_secret: "codeberg_token"
     commands:
       # Configure Git
-      - git config --global user.email $MAIL
+      - git config --global user.email "$${CBMAIL}"
       - git config --global user.name "Woodpecker CI"
       # Clone the output branch
-      - git clone --branch pages https://$CODEBERG_TOKEN@codeberg.org/$CI_REPO.git $CI_REPO_NAME
+      - git clone --branch pages https://$${CBTOKEN}@codeberg.org/$CI_REPO.git $CI_REPO_NAME
       # Enter the output branch
       - cd $CI_REPO_NAME
       # Remove old files


### PR DESCRIPTION
secrets was deprecated in Woodpecker 3.0 in favor of from_secret. So, documentation is updated as without changes, CI will fail.

[Relevant Link to Woodpecker 3.0.0 Blog Post](https://woodpecker-ci.org/blog/release-v300)

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



