### PR TITLE
Update syntax-highlighting.md to fix alignment between line numbers and lines of code in the example snippet

### DIFF
--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -331,6 +331,7 @@ pre table td {
 /* The line number cells */
 pre table td:nth-of-type(1) {
   text-align: center;
+  vertical-align: top;
   user-select: none;
 }
 pre mark {


### PR DESCRIPTION
Fixes #2795. See details there.

The code blocks are tables. This prevents misalignment b/w the line nos. and line-of-code when the line wraps to the next line.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?






