### PR TITLE
Add `include` attribute for code fences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.21.0 (unreleased)
+
+
 ## 0.20.0 (2025-02-14)
 
 - Add `name` annotation for codeblock

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -223,6 +223,7 @@ impl Page {
         );
         context.set_shortcode_definitions(shortcode_definitions);
         context.set_current_page_path(&self.file.relative);
+        context.set_parent_absolute(&self.file.parent);
         context.tera_context.insert("page", &SerializingPage::new(self, None, false));
 
         let res = render_content(&self.raw_content, &context)

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -161,6 +161,7 @@ impl Section {
         );
         context.set_shortcode_definitions(shortcode_definitions);
         context.set_current_page_path(&self.file.relative);
+        context.set_parent_absolute(&self.file.parent);
         context
             .tera_context
             .insert("section", &SerializingSection::new(self, SectionSerMode::ForMarkdown));

--- a/components/markdown/src/codeblock/fence.rs
+++ b/components/markdown/src/codeblock/fence.rs
@@ -25,6 +25,7 @@ pub struct FenceSettings<'a> {
     pub highlight_lines: Vec<RangeInclusive<usize>>,
     pub hide_lines: Vec<RangeInclusive<usize>>,
     pub name: Option<&'a str>,
+    pub enable_copy: bool,
 }
 
 impl<'a> FenceSettings<'a> {
@@ -36,6 +37,7 @@ impl<'a> FenceSettings<'a> {
             highlight_lines: Vec::new(),
             hide_lines: Vec::new(),
             name: None,
+            enable_copy: false,
         };
 
         for token in FenceIter::new(fence_info) {
@@ -46,6 +48,7 @@ impl<'a> FenceSettings<'a> {
                 FenceToken::HighlightLines(lines) => me.highlight_lines.extend(lines),
                 FenceToken::HideLines(lines) => me.hide_lines.extend(lines),
                 FenceToken::Name(n) => me.name = Some(n),
+                FenceToken::EnableCopy => me.enable_copy = true,
             }
         }
 
@@ -61,6 +64,7 @@ enum FenceToken<'a> {
     HighlightLines(Vec<RangeInclusive<usize>>),
     HideLines(Vec<RangeInclusive<usize>>),
     Name(&'a str),
+    EnableCopy,
 }
 
 struct FenceIter<'a> {
@@ -112,6 +116,7 @@ impl<'a> Iterator for FenceIter<'a> {
                         return Some(FenceToken::Name(n));
                     }
                 }
+                "copy" => return Some(FenceToken::EnableCopy),
                 lang => {
                     if tok_split.next().is_some() {
                         eprintln!("Warning: Unknown annotation {}", lang);

--- a/components/markdown/src/codeblock/fence.rs
+++ b/components/markdown/src/codeblock/fence.rs
@@ -25,6 +25,7 @@ pub struct FenceSettings<'a> {
     pub highlight_lines: Vec<RangeInclusive<usize>>,
     pub hide_lines: Vec<RangeInclusive<usize>>,
     pub name: Option<&'a str>,
+    pub include: Option<&'a str>,
 }
 
 impl<'a> FenceSettings<'a> {
@@ -36,6 +37,7 @@ impl<'a> FenceSettings<'a> {
             highlight_lines: Vec::new(),
             hide_lines: Vec::new(),
             name: None,
+            include: None,
         };
 
         for token in FenceIter::new(fence_info) {
@@ -46,6 +48,7 @@ impl<'a> FenceSettings<'a> {
                 FenceToken::HighlightLines(lines) => me.highlight_lines.extend(lines),
                 FenceToken::HideLines(lines) => me.hide_lines.extend(lines),
                 FenceToken::Name(n) => me.name = Some(n),
+                FenceToken::Include(file) => me.include = Some(file),
             }
         }
 
@@ -61,6 +64,7 @@ enum FenceToken<'a> {
     HighlightLines(Vec<RangeInclusive<usize>>),
     HideLines(Vec<RangeInclusive<usize>>),
     Name(&'a str),
+    Include(&'a str),
 }
 
 struct FenceIter<'a> {
@@ -110,6 +114,11 @@ impl<'a> Iterator for FenceIter<'a> {
                 "name" => {
                     if let Some(n) = tok_split.next() {
                         return Some(FenceToken::Name(n));
+                    }
+                }
+                "include" => {
+                    if let Some(file) = tok_split.next() {
+                        return Some(FenceToken::Include(file));
                     }
                 }
                 lang => {

--- a/components/markdown/src/codeblock/mod.rs
+++ b/components/markdown/src/codeblock/mod.rs
@@ -129,15 +129,13 @@ impl<'config> CodeBlock<'config> {
         ))
     }
 
-    pub fn include(&self, base: Option<&PathBuf>) -> Option<String> {
-        let path = base?.join(self.include.as_ref()?);
-        let res = read_file(&path);
-        match res {
-            Ok(content) => Some(content),
-            Err(e) => {
-                eprintln!("Warning: Failed to include {:?}: {}", path, e);
-                None
-            }
+    pub fn include(&self, base: Option<&PathBuf>) -> Result<Option<String>> {
+        if let Some(base) = base {
+            let path = base.join(&self.include.as_ref().expect("No include path"));
+            let content = read_file(&path)?;
+            Ok(Some(content))
+        } else {
+            Ok(None)
         }
     }
 

--- a/components/markdown/src/codeblock/mod.rs
+++ b/components/markdown/src/codeblock/mod.rs
@@ -17,10 +17,14 @@ fn opening_html(
     pre_style: Option<String>,
     pre_class: Option<String>,
     line_numbers: bool,
+    enable_copy: bool,
 ) -> String {
     let mut html = String::from("<pre");
     if line_numbers {
         html.push_str(" data-linenos");
+    }
+    if enable_copy {
+        html.push_str(" data-copy");
     }
     let mut classes = String::new();
 
@@ -112,6 +116,7 @@ impl<'config> CodeBlock<'config> {
             highlighter.pre_style(),
             highlighter.pre_class(),
             fence.line_numbers,
+            fence.enable_copy,
         );
         Ok((
             Self {

--- a/components/markdown/src/context.rs
+++ b/components/markdown/src/context.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use config::Config;
 use libs::tera::{Context, Tera};
@@ -13,6 +14,7 @@ pub struct RenderContext<'a> {
     pub config: &'a Config,
     pub tera_context: Context,
     pub current_page_path: Option<&'a str>,
+    pub parent_absolute: Option<&'a PathBuf>,
     pub current_page_permalink: &'a str,
     pub permalinks: Cow<'a, HashMap<String, String>>,
     pub insert_anchor: InsertAnchor,
@@ -43,6 +45,7 @@ impl<'a> RenderContext<'a> {
             config,
             lang,
             shortcode_definitions: Cow::Owned(HashMap::new()),
+            parent_absolute: None,
         }
     }
 
@@ -55,6 +58,11 @@ impl<'a> RenderContext<'a> {
     /// Same as above
     pub fn set_current_page_path(&mut self, path: &'a str) {
         self.current_page_path = Some(path);
+    }
+
+    /// Same as above
+    pub fn set_parent_absolute(&mut self, path: &'a PathBuf) {
+        self.parent_absolute = Some(path);
     }
 
     // In use in the markdown filter
@@ -71,6 +79,7 @@ impl<'a> RenderContext<'a> {
             config,
             lang: &config.default_language,
             shortcode_definitions: Cow::Owned(HashMap::new()),
+            parent_absolute: None,
         }
     }
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

https://zola.discourse.group/t/include-and-copy-attributes-for-code-fences/

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?

This PR adds support for two fence settings:

<code>```include=<filename></code>

- Allows including a local file as the content of this codeblock, useful for large files

<code>```copy</code>

- Adds a `data-copy` attribute to the code-block, useful if you want to add copy buttons only to some blocks.


