### PR TITLE
Fix .gitlab-ci.yaml with v0.20.0 having multiple different build artifacts for linux available

### DIFF
--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -78,7 +78,7 @@ pages:
         github_api_url="https://api.github.com/repos/getzola/zola/releases/latest"
         zola_url=$(
           wget --output-document - $github_api_url |
-          grep "browser_download_url.*linux-gnu.tar.gz" |
+          grep "browser_download_url.*x86_64.*linux-gnu.tar.gz" |
           cut --delimiter : --fields 2,3 |
           tr --delete "\" "
         )


### PR DESCRIPTION
Just pick x86_64, the previous default.

Previous grep for download link returned two links

```
wget --output-document - https://api.github.com/repos/getzola/zola/releases/latest | grep "browser_download_url.*linux-gnu.tar.gz"
      "browser_download_url": "https://github.com/getzola/zola/releases/download/v0.20.0/zola-v0.20.0-aarch64-unknown-linux-gnu.tar.gz"
      "browser_download_url": "https://github.com/getzola/zola/releases/download/v0.20.0/zola-v0.20.0-x86_64-unknown-linux-gnu.tar.gz"
```

making the subsequent tar command fail with the error

```
tar: zola-v0.20.0-x86_64-unknown-linux-gnu.tar.gz: Not found in archive
```

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?


