### PR TITLE
Refactor external link styling to use `external_links_class`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: build
-        uses: shalzz/zola-deploy-action@v0.19.2
+        uses: shalzz/zola-deploy-action@v0.20.0
         env:
           BUILD_DIR: docs/
           BUILD_ONLY: true
@@ -28,7 +28,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.19.2
+        uses: shalzz/zola-deploy-action@v0.20.0
         env:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: docs/

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -15,7 +15,7 @@ index_format = "elasticlunr_json"
 [markdown]
 highlight_code = true
 highlight_theme = "kronuz"
-external_links_no_referrer = true
+external_links_class = "external"
 #highlight_theme = "css"
 #highlight_themes_css = [
 #  { theme = "base16-ocean-dark", filename = "syntax-theme-dark.css" },

--- a/docs/sass/_base.scss
+++ b/docs/sass/_base.scss
@@ -87,7 +87,7 @@ a {
     }
   }
 
-  &[rel~="noreferrer"] {
+  &.external {
     padding-right: 1em;
     background-size: 14px;
     background-image: $external-link-icon;

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -18,8 +18,8 @@
                 <ul>
                     <li><a class="white" href="{{ get_url(path='@/documentation/_index.md') }}" class="nav-link">Docs</a></li>
                     <li><a class="white" href="{{ get_url(path='@/themes/_index.md') }}" class="nav-link">Themes</a></li>
-                    <li><a class="white" rel="noreferrer" href="https://zola.discourse.group/" class="nav-link">Forum</a></li>
-                    <li><a class="white" rel="noreferrer" href="https://github.com/getzola/zola" class="nav-link">GitHub</a></li>
+                    <li><a class="white external" href="https://zola.discourse.group/" class="nav-link">Forum</a></li>
+                    <li><a class="white external" href="https://github.com/getzola/zola" class="nav-link">GitHub</a></li>
                 </ul>
                 <div class="search-container">
                     <input id="search" type="search" placeholder="🔎 Search the docs">


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Since this is a small refactor, I did not discuss it first. Feel free to close this if it's not wanted!

---

## Code changes

External link styling added in #2522 was implemented before the PR that added external link classes (#2717).

This PR follows up on both by refactoring the config so as to remove the `external_links_no_referrer = true` line, as it was just added as a workaround to style external links.

The styling is now done through the `external` class, by setting `external_links_class = "external"`.

The site looks identical, before and after this change.

* [ ] Are you doing the PR on the `next` branch?

Since it's tiny and only affects the docs/site, I'm targeting `master`. Let me know if you'd prefer this in `next`.