### PR TITLE
Hide pages and sections by adding `hidden` to frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.21.0 (unreleased)
+
+
 ## 0.20.0 (2025-02-14)
 
 - Add `name` annotation for codeblock

--- a/components/content/src/front_matter/page.rs
+++ b/components/content/src/front_matter/page.rs
@@ -39,6 +39,8 @@ pub struct PageFrontMatter {
     pub datetime_tuple: Option<(i32, u8, u8)>,
     /// Whether this page is a draft
     pub draft: bool,
+    /// Whether this page is hidden
+    pub hidden: Option<bool>,
     /// Prevent generation of a folder for current page
     /// Defaults to `true`
     #[serde(skip_serializing)]
@@ -155,6 +157,7 @@ impl Default for PageFrontMatter {
             datetime: None,
             datetime_tuple: None,
             draft: false,
+            hidden: None,
             render: true,
             slug: None,
             path: None,

--- a/components/content/src/front_matter/section.rs
+++ b/components/content/src/front_matter/section.rs
@@ -47,6 +47,8 @@ pub struct SectionFrontMatter {
     /// to be used directly, like a posts section in a personal site
     #[serde(skip_serializing)]
     pub render: bool,
+    /// Whether to render all of the pages in this section, but not list them by defaulting their `hidden` to `true`
+    pub hidden: Option<bool>,
     /// Whether to redirect when landing on that section. Defaults to `None`.
     /// Useful for the same reason as `render` but when you don't want a 404 when
     /// landing on the root section page
@@ -107,6 +109,7 @@ impl Default for SectionFrontMatter {
             paginate_reversed: false,
             paginate_path: DEFAULT_PAGINATE_PATH.to_string(),
             render: true,
+            hidden: None,
             redirect_to: None,
             insert_anchor_links: None,
             in_search_index: true,

--- a/components/content/src/pagination.rs
+++ b/components/content/src/pagination.rs
@@ -155,7 +155,7 @@ impl<'a> Paginator<'a> {
                 // Add page hidden meta to the chain, to fold into final value
                 .chain([page.meta.hidden].into_iter())
                 // Accumulate together as `accumulator || boolean` unless value explicitely
-                // set by a section's frontmatter as `hidden = false`
+                // set by a section's or page's frontmatter as `hidden = false`
                 .fold(false, |accumulator, boolean| match (accumulator, boolean) {
                     (_, Some(value)) => value,
                     (value, None) => value,

--- a/components/markdown/src/codeblock/fence.rs
+++ b/components/markdown/src/codeblock/fence.rs
@@ -25,6 +25,7 @@ pub struct FenceSettings<'a> {
     pub highlight_lines: Vec<RangeInclusive<usize>>,
     pub hide_lines: Vec<RangeInclusive<usize>>,
     pub name: Option<&'a str>,
+    pub enable_copy: bool,
 }
 
 impl<'a> FenceSettings<'a> {
@@ -36,6 +37,7 @@ impl<'a> FenceSettings<'a> {
             highlight_lines: Vec::new(),
             hide_lines: Vec::new(),
             name: None,
+            enable_copy: false,
         };
 
         for token in FenceIter::new(fence_info) {
@@ -46,6 +48,7 @@ impl<'a> FenceSettings<'a> {
                 FenceToken::HighlightLines(lines) => me.highlight_lines.extend(lines),
                 FenceToken::HideLines(lines) => me.hide_lines.extend(lines),
                 FenceToken::Name(n) => me.name = Some(n),
+                FenceToken::EnableCopy => me.enable_copy = true,
             }
         }
 
@@ -61,6 +64,7 @@ enum FenceToken<'a> {
     HighlightLines(Vec<RangeInclusive<usize>>),
     HideLines(Vec<RangeInclusive<usize>>),
     Name(&'a str),
+    EnableCopy,
 }
 
 struct FenceIter<'a> {
@@ -112,6 +116,7 @@ impl<'a> Iterator for FenceIter<'a> {
                         return Some(FenceToken::Name(n));
                     }
                 }
+                "copy" => return Some(FenceToken::EnableCopy),
                 lang => {
                     if tok_split.next().is_some() {
                         eprintln!("Warning: Unknown annotation {}", lang);

--- a/components/markdown/src/codeblock/mod.rs
+++ b/components/markdown/src/codeblock/mod.rs
@@ -17,10 +17,14 @@ fn opening_html(
     pre_style: Option<String>,
     pre_class: Option<String>,
     line_numbers: bool,
+    enable_copy: bool,
 ) -> String {
     let mut html = String::from("<pre");
     if line_numbers {
         html.push_str(" data-linenos");
+    }
+    if enable_copy {
+        html.push_str(" data-copy");
     }
     let mut classes = String::new();
 
@@ -112,6 +116,7 @@ impl<'config> CodeBlock<'config> {
             highlighter.pre_style(),
             highlighter.pre_class(),
             fence.line_numbers,
+            fence.enable_copy,
         );
         Ok((
             Self {

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -112,6 +112,10 @@ weight = 0
 # A draft page is only loaded if the `--drafts` flag is passed to `zola build`, `zola serve` or `zola check`.
 draft = false
 
+# A hidden page is loaded and created, but won't be added to Paginators,
+# set to true to hide page or false to override a parent section's `hidden = true` 
+hidden = false
+
 # When set to "false" Zola will not create a separate folder with index.html inside for this page.
 render = false
 

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -48,6 +48,10 @@ description = ""
 # A draft section is only loaded if the `--drafts` flag is passed to `zola build`, `zola serve` or `zola check`.
 draft = false
 
+# A hidden section is loaded and created, but won't be added to Paginators,
+# set to true to hide section's pages or false to override a parent section's `hidden = true` 
+hidden = false
+
 # Used to sort pages by "date", "update_date", "title", "title_bytes", "weight", "slug" or "none". See below for more information.
 sort_by = "none"
 


### PR DESCRIPTION
This feature is implemented based on discussion on the [forum](https://zola.discourse.group/t/solved-hidden-posts/455/10) as well as #2391 

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?

---

I've added `hidden` to both `PageFrontMatter` & `SectionFrontMatter` and made sure to filter them in the Paginator, which covers my use case. 

Work that I can still do to bring this to completion:
* [x] Update documentation
* [ ] Make sure it filters out of search index (not sure how to do this, would love pointers)
* [x] Make sure it filters out of any generated feed

Lemme know what y'all think ✨


