### PR TITLE
Add support for building for x86_64-unknown-linux-musl

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -25,6 +26,8 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - os: macos-13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -32,6 +33,8 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - os: macos-13
@@ -47,8 +50,19 @@ jobs:
         with:
           toolchain: ${{ matrix.rustup_toolchain }}
 
+      - name: Install Zig
+        run: |
+          curl -sSfL https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz | tar -xJf -
+          export PATH=$PWD/zig-linux-x86_64-0.14.0:$PATH
+        if: ${{ endsWith(matrix.target, 'linux-musl') }}
+
       - name: Cargo build
         run: cargo build --release --target ${{ matrix.target }}
+        if: ${{ ! endsWith(matrix.target, 'linux-musl') }}
+
+      - name: Cargo zigbuild
+        run: cargo zigbuild --release --target ${{ matrix.target }}
+        if: ${{ endsWith(matrix.target, 'linux-musl') }}
 
       - name: Show version
         run: ./target/${{ matrix.target }}/release/zola --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,11 @@ jobs:
         with:
           toolchain: ${{ matrix.rustup_toolchain }}
 
-      - name: Install Zig
+      - name: Install Zig and cargo-zigbuild
         run: |
           curl -sSfL https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz | tar -xJf -
           export PATH=$PWD/zig-linux-x86_64-0.14.0:$PATH
+          cargo install --locked cargo-zigbuild
         if: ${{ endsWith(matrix.target, 'linux-musl') }}
 
       - name: Cargo build


### PR DESCRIPTION
This PR adds support for compiling for `x86_64-unknown-linux-musl`, which produces a statically-linked binary that does not depend on a specific version of glibc. This is useful in environments that might be using an older version of glibc than the one that Zola was built with when compiling on `ubuntu-22.04`. For example, Amazon Linux 2023 currently uses glibc 2.34, whereas `ubuntu-22.04` results in a binary depending on glibc 2.35.

Originally, I intended to accomplish this using `musl-tools`, but was unable to accomplish this due to the `webp` and `ring` packages not compiling correctly. `cargo-zigbuild` uses Zig as the compiler and linker, which seemed like an easier way than trying to figure out the magic combination of flags.

I've tested the produced binary on Amazon Linux 2023 and it runs successfully. Tools like `objdump` and `ldd` confirm it's a statically linked binary.

Fixes #2365 

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?


