### PR TITLE
fix: ensure musl target is installed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rustup_toolchain }}
+          targets: ${{ matrix.target }}
 
       - name: Install Zig and cargo-zigbuild
         run: |


### PR DESCRIPTION
This PR ensures that the `x86_64-unknown-linux-musl` target gets installed when setting up the Rust toolchain. Without a `targets` argument, `rust-toolchain` will install the default toolchain. In the case of musl, we want to make sure that's installed instead.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



