### PR TITLE
Revert x86_64-unknown-linux-gnu release workflow back to using Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl          
           - aarch64-unknown-linux-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -23,8 +24,10 @@ jobs:
         include:
           - os: windows-2022
             target: x86_64-pc-windows-msvc
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl            
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - os: macos-13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -32,6 +33,8 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-20.04           
+            target: x86_64-unknown-linux-musl
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - os: macos-13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - os: windows-2022
             target: x86_64-pc-windows-msvc
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

[ See issue #2841 ]

Extremely minor change to revert the x86_64-unknown-linux-gnu target back to using Ubuntu 20.04.

This means the x86_64 binary will only requires glibc >= 2.31, instead of glibc >=2.35, and work on Redhat / Centos >=9 again.

Built on my fork, passed all tests, deployed to my production - it works.




