### PR TITLE
Update GitLab Pages deployment documentation

### DIFF
--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -44,7 +44,14 @@ We provide you with a template to accomplish this task easily.
 Create a file called `.gitlab-ci.yml` in the root directory of your
 repository and copy the contents of the template below.
 
-You are free to change the version of the Alpine Linux image and of Zola used to build your site.
+Note:
+
+Each version of Alpine Linux supports a single version of Zola, for example:
+
+Alpine Linux 3.20 supports Zola version 0.18.0.
+Alpine Linux 3.21 supports Zola version 0.19.2.
+
+Make sure the version of Zola you specify in `ZOLA_VERSION` is supported by your version of the Alpine image.
 
 ```yaml
 stages:
@@ -58,18 +65,19 @@ variables:
   # set to "recursive".
   GIT_SUBMODULE_STRATEGY: "recursive"
 
-  # Make sure you specify a supported version of Zola whenever you upgrade
-  # the version of the Alpine image.
+  # Make sure you specify a supported version of Zola whenever
+  # you upgrade the version of the Alpine image.
+  # Use semantic versioning (semver) format (x.y.z).
   # See https://pkgs.alpinelinux.org/packages
   ZOLA_VERSION:
-    description: "The version of Zola used to build the site, as defined in the Alpine Package Index."
-    value: "0.19.2-r0"
+    description: "The version of Zola used to build the site"
+    value: "0.19.2"
 
 pages:
   stage: deploy
   script:
     - |
-      apk add zola=${ZOLA_VERSION}
+      apk add zola=~${ZOLA_VERSION}
       zola build --base-url $CI_PAGES_URL
 
   artifacts:

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -71,10 +71,10 @@ pages:
     - |
       apt-get update
       DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends wget ca-certificates
-      zola_url="https://github.com/getzola/zola/releases/download/v$ZOLA_VERSION/zola-v$ZOLA_VERSION-x86_64-unknown-linux-gnu.tar.gz"
+      zola_url="https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
       if ! wget --quiet --spider $zola_url; then
-        echo "A Zola release with the specified version could not be found.";
-        exit 1;
+        echo "A Zola release with the specified version could not be found."
+        exit 1
       fi
       wget $zola_url
       tar -xzf *.tar.gz

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -44,41 +44,41 @@ We provide you with a template to accomplish this task easily.
 Create a file called `.gitlab-ci.yml` in the root directory of your
 repository and copy the contents of the template below.
 
-Note:
-
-Each version of Alpine Linux supports a single version of Zola, for example:
-
-Alpine Linux 3.20 supports Zola version 0.18.0.
-Alpine Linux 3.21 supports Zola version 0.19.2.
-
-Make sure the version of Zola you specify in `ZOLA_VERSION` is supported by your version of the Alpine image.
+Make sure you specify a version of Zola in the `ZOLA_VERSION` variable.
 
 ```yaml
 stages:
   - deploy
 
 default:
-  image: alpine:3.21
+  image: debian:stable-slim
 
 variables:
   # The runner will be able to pull your Zola theme when the strategy is
   # set to "recursive".
   GIT_SUBMODULE_STRATEGY: "recursive"
 
-  # Make sure you specify a supported version of Zola whenever
-  # you upgrade the version of the Alpine image.
-  # Use semantic versioning (semver) format (x.y.z).
-  # See https://pkgs.alpinelinux.org/packages
+  # Make sure you specify a version of Zola here.
+  # Use the semver format (x.y.z) to specify a version.
+  # For example: "0.17.2" or "0.18.0".
   ZOLA_VERSION:
     description: "The version of Zola used to build the site."
-    value: "0.19.2"
+    value: ""
 
 pages:
   stage: deploy
   script:
     - |
-      apk add zola=~${ZOLA_VERSION}
-      zola build --base-url $CI_PAGES_URL
+      apt-get update
+      DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends wget ca-certificates
+      zola_url="https://github.com/getzola/zola/releases/download/v$ZOLA_VERSION/zola-v$ZOLA_VERSION-x86_64-unknown-linux-gnu.tar.gz"
+      if ! wget --quiet --spider $zola_url; then
+        echo "A Zola release with the specified version could not be found.";
+        exit 1;
+      fi
+      wget $zola_url
+      tar -xzf *.tar.gz
+      ./zola build --base-url $CI_PAGES_URL
 
   artifacts:
     paths:

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -69,8 +69,8 @@ pages:
   stage: deploy
   script:
     - |
-    apk add zola=${ZOLA_VERSION}
-    zola build --base-url $CI_PAGES_URL
+      apk add zola=${ZOLA_VERSION}
+      zola build --base-url $CI_PAGES_URL
 
   artifacts:
     paths:

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -70,7 +70,7 @@ variables:
   # Use semantic versioning (semver) format (x.y.z).
   # See https://pkgs.alpinelinux.org/packages
   ZOLA_VERSION:
-    description: "The version of Zola used to build the site"
+    description: "The version of Zola used to build the site."
     value: "0.19.2"
 
 pages:

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -44,53 +44,37 @@ We provide you with a template to accomplish this task easily.
 Create a file called `.gitlab-ci.yml` in the root directory of your
 repository and copy the contents of the template below.
 
+You are free to change the version of the Alpine Linux image and of Zola used to build your site.
+
 ```yaml
 stages:
   - deploy
 
 default:
-  image: debian:stable-slim
+  image: alpine:3.21
 
 variables:
   # The runner will be able to pull your Zola theme when the strategy is
   # set to "recursive".
   GIT_SUBMODULE_STRATEGY: "recursive"
 
-  # If you don't set a version here, your site will be built with the latest
-  # version of Zola available in GitHub releases.
-  # Use the semver (x.y.z) format to specify a version. For example: "0.17.2" or "0.18.0".
+  # Make sure you specify a supported version of Zola whenever you upgrade
+  # the version of the Alpine image.
+  # See https://pkgs.alpinelinux.org/packages
   ZOLA_VERSION:
     description: "The version of Zola used to build the site."
-    value: ""
+    value: "0.19.2-r0"
 
 pages:
   stage: deploy
   script:
     - |
-      apt-get update --assume-yes && apt-get install --assume-yes --no-install-recommends wget ca-certificates
-      if [ $ZOLA_VERSION ]; then
-        zola_url="https://github.com/getzola/zola/releases/download/v$ZOLA_VERSION/zola-v$ZOLA_VERSION-x86_64-unknown-linux-gnu.tar.gz"
-        if ! wget --quiet --spider $zola_url; then
-          echo "A Zola release with the specified version could not be found.";
-          exit 1;
-        fi
-      else
-        github_api_url="https://api.github.com/repos/getzola/zola/releases/latest"
-        zola_url=$(
-          wget --output-document - $github_api_url |
-          grep "browser_download_url.*x86_64.*linux-gnu.tar.gz" |
-          cut --delimiter : --fields 2,3 |
-          tr --delete "\" "
-        )
-      fi
-      wget $zola_url
-      tar -xzf *.tar.gz
-      ./zola build --base-url $CI_PAGES_URL
+    apk add zola=${ZOLA_VERSION}
+    zola build --base-url $CI_PAGES_URL
 
   artifacts:
     paths:
-      # This is the directory whose contents will be deployed to the GitLab Pages
-      # server.
+      # This is the directory whose contents will be deployed to the GitLab Pages server.
       # GitLab Pages expects a directory with this name by default.
       - public
 

--- a/docs/content/documentation/deployment/gitlab-pages.md
+++ b/docs/content/documentation/deployment/gitlab-pages.md
@@ -62,7 +62,7 @@ variables:
   # the version of the Alpine image.
   # See https://pkgs.alpinelinux.org/packages
   ZOLA_VERSION:
-    description: "The version of Zola used to build the site."
+    description: "The version of Zola used to build the site, as defined in the Alpine Package Index."
     value: "0.19.2-r0"
 
 pages:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

---

The current version of the documentation to deploy on GitLab Pages offers a template which retrieves the latest version of Zola if the user does not specify one. To avoid breaking changes to Zola from making GitLab pipelines fail unexpectedly, I suggest removing this functionality from the template.