### PR TITLE
Revert x86_64-unknown-linux-gnu build runner from Ubuntu 22.04 to 20.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-20.04-arm
             target: aarch64-unknown-linux-gnu
           - os: macos-13
             target: x86_64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - os: windows-2022
             target: x86_64-pc-windows-msvc
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
Very minor change to the Github workflow reverting the unnecessary upgrade of the Github built in runner for x86_64 from Ubuntu 20.04 to 22.04 in #2777.

This reduces the version of glibc required from 2.35 to 2.31, retoring compatibility with Redhat 9 & Ubuntu 20.04.

Fixes #2841 .

* [ ] Are you doing the PR on the `next` branch?
 - Could be merged into next too




