### PR TITLE
Better port `0` handling

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -543,7 +543,9 @@ pub fn serve(
 
                 println!(
                     "Web server is available at {} (bound to {})\n",
-                    &constructed_base_url, &bind_address
+                    &constructed_base_url
+                        .replace(&bind_address.to_string(), &server.local_addr().to_string()),
+                    &server.local_addr()
                 );
                 if open {
                     if let Err(err) = open::that(&constructed_base_url) {


### PR DESCRIPTION
If a user chooses to use port 0, then the operating system will choose one of the available ports automatically. This is very useful in cases where you want to allow a `zola serve` for a broader user base which might already bind a subset of their ports and if you don't know which ones they might use.

This feature was already supported by zola, however, the printed output just printed port 0 and didn't report which port the operating system actually chose.

Example output of `zola serve -p 0` before the change

```
Web server is available at http://127.0.0.1:0 (bound to 127.0.0.1:0)
```

Example output of `zola serve -p 0` after the change

```
Web server is available at http://127.0.0.1:37327 (bound to 127.0.0.1:37327)
```

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [ ] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



