### PR TITLE
Allow arbitrary file extensions for templates

### DIFF
--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -44,8 +44,7 @@ pub fn render_redirect_template(url: &str, tera: &Tera) -> Result<String> {
 }
 
 pub fn load_tera(path: &Path, config: &Config) -> Result<Tera> {
-    let tpl_glob =
-        format!("{}/{}", path.to_string_lossy().replace('\\', "/"), "templates/**/*.{*ml,md,txt}");
+    let tpl_glob = format!("{}/{}", path.to_string_lossy().replace('\\', "/"), "templates/**/*");
 
     // Only parsing as we might be extending templates from themes and that would error
     // as we haven't loaded them yet
@@ -60,7 +59,7 @@ pub fn load_tera(path: &Path, config: &Config) -> Result<Tera> {
         }
 
         let theme_tpl_glob = format!(
-            "{}/themes/{}/templates/**/*.{{*ml,md}}",
+            "{}/themes/{}/templates/**/*",
             path.to_string_lossy().replace('\\', "/"),
             theme
         );


### PR DESCRIPTION
There is no benefit to restricting file extensions of templates. Allowing it will enable things like custom JSON feeds. Users can also choose to use `.tera` as the extension for their templates, enabling some text editors to handle syntax highlighting better.

closes #2772
