### PR TITLE
Sort pages by permalink if sort_by is unspecified

### DIFF
--- a/components/content/src/library.rs
+++ b/components/content/src/library.rs
@@ -6,7 +6,7 @@ use libs::ahash::{AHashMap, AHashSet};
 use crate::ser::TranslatedContent;
 use crate::sorting::sort_pages;
 use crate::taxonomies::{Taxonomy, TaxonomyFound};
-use crate::{Page, Section, SortBy};
+use crate::{Page, Section};
 
 macro_rules! set {
     ($($key:expr,)+) => (set!($($key),+));
@@ -177,10 +177,7 @@ impl Library {
         let mut updates = AHashMap::new();
         for (path, section) in &self.sections {
             let pages: Vec<_> = section.pages.iter().map(|p| &self.pages[p]).collect();
-            let (sorted_pages, cannot_be_sorted_pages) = match section.meta.sort_by {
-                SortBy::None => continue,
-                _ => sort_pages(&pages, section.meta.sort_by),
-            };
+            let (sorted_pages, cannot_be_sorted_pages) = sort_pages(&pages, section.meta.sort_by);
 
             updates
                 .insert(path.clone(), (sorted_pages, cannot_be_sorted_pages, section.meta.sort_by));
@@ -378,7 +375,7 @@ impl Library {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::FileInfo;
+    use crate::{FileInfo, SortBy};
     use config::{LanguageOptions, TaxonomyConfig};
     use std::collections::HashMap;
     use utils::slugs::SlugifyStrategy;

--- a/components/content/src/sorting.rs
+++ b/components/content/src/sorting.rs
@@ -17,7 +17,7 @@ pub fn sort_pages(pages: &[&Page], sort_by: SortBy) -> (Vec<PathBuf>, Vec<PathBu
             SortBy::Title | SortBy::TitleBytes => page.meta.title.is_some(),
             SortBy::Weight => page.meta.weight.is_some(),
             SortBy::Slug => true,
-            SortBy::None => unreachable!(),
+            SortBy::None => true, // fallback to permalink sorting
         });
 
     can_be_sorted.par_sort_unstable_by(|a, b| {
@@ -34,7 +34,7 @@ pub fn sort_pages(pages: &[&Page], sort_by: SortBy) -> (Vec<PathBuf>, Vec<PathBu
             }
             SortBy::Weight => a.meta.weight.unwrap().cmp(&b.meta.weight.unwrap()),
             SortBy::Slug => natural_lexical_cmp(&a.slug, &b.slug),
-            SortBy::None => unreachable!(),
+            SortBy::None => Ordering::Equal, // fallback to permalink sorting
         };
 
         if ord == Ordering::Equal {

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -145,7 +145,7 @@ This would iterate over the posts in the order specified
 by the `sort_by` variable set in the `_index.md` page for the corresponding
 section.  The `sort_by` variable can be given a few values: `date`, `update_date`
 `title`, `title_bytes`, `weight`, `slug` or `none`.  If `sort_by` is not set, the pages will be
-sorted in the `none` order, which is not intended for sorted content.
+sorted by their permalink, which is usually not desired.
 
 Any page that is missing the data it needs to be sorted will be ignored and
 won't be rendered. For example, if a page is missing the date variable and its


### PR DESCRIPTION
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?
* [x] Are you doing the PR on the `next` branch?
* [x] Have you created/updated the relevant documentation page(s)?

I think this is consistent with the fact that the permalink is already used to break ties if two pages have the same `date` or `weight`.