### PR TITLE
Improved AVIF support

### DIFF
--- a/components/imageproc/src/format.rs
+++ b/components/imageproc/src/format.rs
@@ -2,8 +2,8 @@ use errors::{anyhow, Result};
 use std::hash::{Hash, Hasher};
 
 const DEFAULT_Q_JPG: u8 = 75;
-const DEFAULT_Q_AVIF: u8 = 70;
-const DEFAULT_S_AVIF: u8 = 10;
+const DEFAULT_Q_AVIF: u8 = 80;
+const DEFAULT_S_AVIF: u8 = 5;
 
 /// Thumbnail image format
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/components/imageproc/src/format.rs
+++ b/components/imageproc/src/format.rs
@@ -1,9 +1,11 @@
 use errors::{anyhow, Result};
 use std::hash::{Hash, Hasher};
 
-const DEFAULT_Q_JPG: u8 = 75;
-const DEFAULT_Q_AVIF: u8 = 80;
-const DEFAULT_S_AVIF: u8 = 5;
+const DEFAULT_QUALITY_JPEG: u8 = 75;
+// The following AVIF defaults are the same as `ravif` uses:
+// https://github.com/kornelski/cavif-rs/blob/ed676dd1a3d9726b740ad679843bad55d3a84ebd/ravif/src/av1encoder.rs#L82-L84
+const DEFAULT_QUALITY_AVIF: u8 = 80;
+const DEFAULT_SPEED_AVIF: u8 = 5;
 
 /// Thumbnail image format
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,19 +34,22 @@ impl Format {
         if let Some(speed) = speed {
             assert!(speed > 0 && speed <= 10, "Speed must be within the range [1; 10]");
         }
-        let jpg_quality = quality.unwrap_or(DEFAULT_Q_JPG);
+        let jpeg_quality = quality.unwrap_or(DEFAULT_QUALITY_JPEG);
         match format {
             "auto" => {
                 if is_lossy {
-                    Ok(Jpeg(jpg_quality))
+                    Ok(Jpeg(jpeg_quality))
                 } else {
                     Ok(Png)
                 }
             }
-            "jpeg" | "jpg" => Ok(Jpeg(jpg_quality)),
+            "jpeg" | "jpg" => Ok(Jpeg(jpeg_quality)),
             "png" => Ok(Png),
             "webp" => Ok(WebP(quality)),
-            "avif" => Ok(Avif(quality.unwrap_or(DEFAULT_Q_AVIF), speed.unwrap_or(DEFAULT_S_AVIF))),
+            "avif" => Ok(Avif(
+                quality.unwrap_or(DEFAULT_QUALITY_AVIF),
+                speed.unwrap_or(DEFAULT_SPEED_AVIF),
+            )),
             _ => Err(anyhow!("Invalid image format: {}", format)),
         }
     }

--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -60,20 +60,20 @@ impl ImageOp {
             Format::Png => {
                 img.write_to(&mut buffered_f, ImageFormat::Png)?;
             }
-            Format::Jpeg(q) => {
-                let mut encoder = JpegEncoder::new_with_quality(&mut buffered_f, q);
+            Format::Jpeg { quality } => {
+                let mut encoder = JpegEncoder::new_with_quality(&mut buffered_f, quality);
                 encoder.encode_image(&img)?;
             }
-            Format::WebP(q) => {
+            Format::WebP { quality } => {
                 let encoder = webp::Encoder::from_image(&img)
                     .map_err(|_| anyhow!("Unable to load this kind of image with webp"))?;
-                let memory = match q {
+                let memory = match quality {
                     Some(q) => encoder.encode(q as f32),
                     None => encoder.encode_lossless(),
                 };
                 buffered_f.write_all(memory.as_bytes())?;
             }
-            Format::Avif(quality, speed) => {
+            Format::Avif { quality, speed } => {
                 let mut avif: Vec<u8> = Vec::new();
                 let color_type = match img.color() {
                     image::ColorType::L8 => Ok(ExtendedColorType::L8),

--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -75,10 +75,19 @@ impl ImageOp {
             }
             Format::Avif(quality, speed) => {
                 let mut avif: Vec<u8> = Vec::new();
-                let color_type = match img.color().has_alpha() {
-                    true => ExtendedColorType::Rgba8,
-                    false => ExtendedColorType::Rgb8,
-                };
+                let color_type = match img.color() {
+                    image::ColorType::L8 => Ok(ExtendedColorType::L8),
+                    image::ColorType::La8 => Ok(ExtendedColorType::La8),
+                    image::ColorType::Rgb8 => Ok(ExtendedColorType::Rgb8),
+                    image::ColorType::Rgba8 => Ok(ExtendedColorType::Rgba8),
+                    image::ColorType::L16 => Ok(ExtendedColorType::L16),
+                    image::ColorType::La16 => Ok(ExtendedColorType::La16),
+                    image::ColorType::Rgb16 => Ok(ExtendedColorType::Rgb16),
+                    image::ColorType::Rgba16 => Ok(ExtendedColorType::Rgba16),
+                    image::ColorType::Rgb32F => Ok(ExtendedColorType::Rgb32F),
+                    image::ColorType::Rgba32F => Ok(ExtendedColorType::Rgba32F),
+                    c => Err(anyhow!("Unknown image color type '{:?}' for AVIF", c)),
+                }?;
                 let encoder = AvifEncoder::new_with_speed_quality(&mut avif, speed, quality);
                 encoder.write_image(
                     &img.as_bytes(),

--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -73,13 +73,13 @@ impl ImageOp {
                 };
                 buffered_f.write_all(memory.as_bytes())?;
             }
-            Format::Avif(q) => {
+            Format::Avif(quality, speed) => {
                 let mut avif: Vec<u8> = Vec::new();
                 let color_type = match img.color().has_alpha() {
                     true => ExtendedColorType::Rgba8,
                     false => ExtendedColorType::Rgb8,
                 };
-                let encoder = AvifEncoder::new_with_speed_quality(&mut avif, 10, q.unwrap_or(70));
+                let encoder = AvifEncoder::new_with_speed_quality(&mut avif, speed, quality);
                 encoder.write_image(
                     &img.as_bytes(),
                     img.dimensions().0,
@@ -162,6 +162,7 @@ impl Processor {
         input_path: PathBuf,
         format: &str,
         quality: Option<u8>,
+        speed: Option<u8>,
     ) -> Result<EnqueueResponse> {
         // First we load metadata from the cache if possible, otherwise from the file itself
         if !self.meta_cache.contains_key(&input_path) {
@@ -172,7 +173,7 @@ impl Processor {
         // We will have inserted it just above
         let meta = &self.meta_cache[&input_path];
         // We get the output format
-        let format = Format::from_args(meta.is_lossy(), format, quality)?;
+        let format = Format::from_args(meta.is_lossy(), format, quality, speed)?;
         // Now we have all the data we need to generate the output filename and the response
         let filename = get_processed_filename(&input_path, &input_src, &op, &format);
         let url = format!("{}{}", self.base_url, filename);

--- a/components/imageproc/tests/resize_image.rs
+++ b/components/imageproc/tests/resize_image.rs
@@ -50,7 +50,7 @@ fn image_op_test(
     let mut proc = Processor::new(tmpdir.clone(), &config);
     let resize_op = ResizeOperation::from_args(op, width, height).unwrap();
 
-    let resp = proc.enqueue(resize_op, source_img.into(), source_path, format, None).unwrap();
+    let resp = proc.enqueue(resize_op, source_img.into(), source_path, format, None, None).unwrap();
     assert_processed_path_matches(&resp.url, "https://example.com/processed_images/", expect_ext);
     assert_processed_path_matches(&resp.static_path, PROCESSED_PREFIX.as_str(), expect_ext);
     assert_eq!(resp.width, expect_width);
@@ -247,7 +247,7 @@ fn resize_and_check(source_img: &str) -> bool {
     let mut proc = Processor::new(tmpdir.clone(), &config);
     let resize_op = ResizeOperation::from_args("scale", Some(16), Some(16)).unwrap();
 
-    let resp = proc.enqueue(resize_op, source_img.into(), source_path, "jpg", None).unwrap();
+    let resp = proc.enqueue(resize_op, source_img.into(), source_path, "jpg", None, None).unwrap();
 
     proc.do_process().unwrap();
     let processed_path = PathBuf::from(&resp.static_path);

--- a/components/imageproc/tests/resize_image.rs
+++ b/components/imageproc/tests/resize_image.rs
@@ -38,6 +38,8 @@ fn image_op_test(
     width: Option<u32>,
     height: Option<u32>,
     format: &str,
+    quality: Option<u8>,
+    speed: Option<u8>,
     expect_ext: &str,
     expect_width: u32,
     expect_height: u32,
@@ -50,7 +52,8 @@ fn image_op_test(
     let mut proc = Processor::new(tmpdir.clone(), &config);
     let resize_op = ResizeOperation::from_args(op, width, height).unwrap();
 
-    let resp = proc.enqueue(resize_op, source_img.into(), source_path, format, None, None).unwrap();
+    let resp =
+        proc.enqueue(resize_op, source_img.into(), source_path, format, quality, speed).unwrap();
     assert_processed_path_matches(&resp.url, "https://example.com/processed_images/", expect_ext);
     assert_processed_path_matches(&resp.static_path, PROCESSED_PREFIX.as_str(), expect_ext);
     assert_eq!(resp.width, expect_width);
@@ -74,67 +77,380 @@ fn image_meta_test(source_img: &str) -> ImageMetaResponse {
 
 #[test]
 fn resize_image_scale() {
-    image_op_test("jpg.jpg", "scale", Some(150), Some(150), "auto", "jpg", 150, 150, 300, 380);
+    image_op_test(
+        "jpg.jpg",
+        "scale",
+        Some(150),
+        Some(150),
+        "auto",
+        None,
+        None,
+        "jpg",
+        150,
+        150,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_fit_width() {
-    image_op_test("jpg.jpg", "fit_width", Some(150), None, "auto", "jpg", 150, 190, 300, 380);
+    image_op_test(
+        "jpg.jpg",
+        "fit_width",
+        Some(150),
+        None,
+        "auto",
+        None,
+        None,
+        "jpg",
+        150,
+        190,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_fit_height() {
-    image_op_test("webp.webp", "fit_height", None, Some(190), "auto", "jpg", 150, 190, 300, 380);
+    image_op_test(
+        "webp.webp",
+        "fit_height",
+        None,
+        Some(190),
+        "auto",
+        None,
+        None,
+        "jpg",
+        150,
+        190,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_fit1() {
-    image_op_test("jpg.jpg", "fit", Some(150), Some(200), "auto", "jpg", 150, 190, 300, 380);
+    image_op_test(
+        "jpg.jpg",
+        "fit",
+        Some(150),
+        Some(200),
+        "auto",
+        None,
+        None,
+        "jpg",
+        150,
+        190,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_fit2() {
-    image_op_test("jpg.jpg", "fit", Some(160), Some(180), "auto", "jpg", 142, 180, 300, 380);
+    image_op_test(
+        "jpg.jpg",
+        "fit",
+        Some(160),
+        Some(180),
+        "auto",
+        None,
+        None,
+        "jpg",
+        142,
+        180,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_fit3() {
-    image_op_test("jpg.jpg", "fit", Some(400), Some(400), "auto", "jpg", 300, 380, 300, 380);
+    image_op_test(
+        "jpg.jpg",
+        "fit",
+        Some(400),
+        Some(400),
+        "auto",
+        None,
+        None,
+        "jpg",
+        300,
+        380,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_fill1() {
-    image_op_test("jpg.jpg", "fill", Some(100), Some(200), "auto", "jpg", 100, 200, 300, 380);
+    image_op_test(
+        "jpg.jpg",
+        "fill",
+        Some(100),
+        Some(200),
+        "auto",
+        None,
+        None,
+        "jpg",
+        100,
+        200,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_fill2() {
-    image_op_test("jpg.jpg", "fill", Some(200), Some(100), "auto", "jpg", 200, 100, 300, 380);
+    image_op_test(
+        "jpg.jpg",
+        "fill",
+        Some(200),
+        Some(100),
+        "auto",
+        None,
+        None,
+        "jpg",
+        200,
+        100,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_png_png() {
-    image_op_test("png.png", "scale", Some(150), Some(150), "auto", "png", 150, 150, 300, 380);
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "auto",
+        None,
+        None,
+        "png",
+        150,
+        150,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_png_jpg() {
-    image_op_test("png.png", "scale", Some(150), Some(150), "jpg", "jpg", 150, 150, 300, 380);
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "jpg",
+        None,
+        None,
+        "jpg",
+        150,
+        150,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_png_webp() {
-    image_op_test("png.png", "scale", Some(150), Some(150), "webp", "webp", 150, 150, 300, 380);
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "webp",
+        None,
+        None,
+        "webp",
+        150,
+        150,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_png_avif() {
-    image_op_test("png.png", "scale", Some(150), Some(150), "avif", "avif", 150, 150, 300, 380);
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "avif",
+        None,
+        None,
+        "avif",
+        150,
+        150,
+        300,
+        380,
+    );
 }
 
 #[test]
 fn resize_image_webp_jpg() {
-    image_op_test("webp.webp", "scale", Some(150), Some(150), "auto", "jpg", 150, 150, 300, 380);
+    image_op_test(
+        "webp.webp",
+        "scale",
+        Some(150),
+        Some(150),
+        "auto",
+        None,
+        None,
+        "jpg",
+        150,
+        150,
+        300,
+        380,
+    );
+}
+
+#[test]
+fn resize_image_png_jpg_min_quality() {
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "jpeg",
+        Some(1),
+        None,
+        "jpg",
+        150,
+        150,
+        300,
+        380,
+    );
+}
+
+#[test]
+fn resize_image_png_jpg_max_quality() {
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "jpeg",
+        Some(100),
+        None,
+        "jpg",
+        150,
+        150,
+        300,
+        380,
+    );
+}
+
+#[test]
+fn resize_image_png_webp_min_quality() {
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "webp",
+        Some(0),
+        None,
+        "webp",
+        150,
+        150,
+        300,
+        380,
+    );
+}
+
+#[test]
+fn resize_image_png_webp_max_quality() {
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "webp",
+        Some(100),
+        None,
+        "webp",
+        150,
+        150,
+        300,
+        380,
+    );
+}
+
+#[test]
+fn resize_image_png_avif_min_quality_min_speed() {
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "avif",
+        Some(1),
+        Some(1),
+        "avif",
+        150,
+        150,
+        300,
+        380,
+    );
+}
+
+#[test]
+fn resize_image_png_avif_min_quality_max_speed() {
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "avif",
+        Some(1),
+        Some(10),
+        "avif",
+        150,
+        150,
+        300,
+        380,
+    );
+}
+
+#[test]
+fn resize_image_png_avif_max_quality_min_speed() {
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "avif",
+        Some(100),
+        Some(1),
+        "avif",
+        150,
+        150,
+        300,
+        380,
+    );
+}
+
+#[test]
+fn resize_image_png_avif_max_quality_max_speed() {
+    image_op_test(
+        "png.png",
+        "scale",
+        Some(150),
+        Some(150),
+        "avif",
+        Some(100),
+        Some(10),
+        "avif",
+        150,
+        150,
+        300,
+        380,
+    );
 }
 
 #[test]
@@ -270,21 +586,138 @@ fn check_img(img: DynamicImage) -> bool {
 #[test]
 fn asymmetric_resize_with_exif_orientations() {
     // No exif metadata
-    image_op_test("exif_0.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_0.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
     // 1: Horizontal (normal)
-    image_op_test("exif_1.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_1.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
     // 2: Mirror horizontal
-    image_op_test("exif_2.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_2.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
     // 3: Rotate 180
-    image_op_test("exif_3.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_3.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
     // 4: Mirror vertical
-    image_op_test("exif_4.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_4.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
     // 5: Mirror horizontal and rotate 270 CW
-    image_op_test("exif_5.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_5.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
     // 6: Rotate 90 CW
-    image_op_test("exif_6.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_6.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
     // 7: Mirror horizontal and rotate 90 CW
-    image_op_test("exif_7.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_7.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
     // 8: Rotate 270 CW
-    image_op_test("exif_8.jpg", "scale", Some(16), Some(32), "auto", "jpg", 16, 32, 16, 16);
+    image_op_test(
+        "exif_8.jpg",
+        "scale",
+        Some(16),
+        Some(32),
+        "auto",
+        None,
+        None,
+        "jpg",
+        16,
+        32,
+        16,
+        16,
+    );
 }

--- a/components/templates/src/global_fns/images.rs
+++ b/components/templates/src/global_fns/images.rs
@@ -60,6 +60,13 @@ impl TeraFn for ResizeImage {
                 return Err("`resize_image`: `quality` must be in range 1-100".to_string().into());
             }
         }
+        let speed =
+            optional_arg!(u8, args.get("speed"), "`resize_image`: `speed` must be a number");
+        if let Some(speed) = speed {
+            if speed == 0 || speed > 10 {
+                return Err("`resize_image`: `speed` must be in range 1-10".to_string().into());
+            }
+        }
         let resize_op = imageproc::ResizeOperation::from_args(&op, width, height)
             .map_err(|e| format!("`resize_image`: {}", e))?;
         let mut imageproc = self.imageproc.lock().unwrap();
@@ -74,7 +81,7 @@ impl TeraFn for ResizeImage {
             };
 
         let response = imageproc
-            .enqueue(resize_op, unified_path, file_path, &format, quality)
+            .enqueue(resize_op, unified_path, file_path, &format, quality, speed)
             .map_err(|e| format!("`resize_image`: {}", e))?;
 
         to_value(response).map_err(Into::into)

--- a/components/templates/src/global_fns/images.rs
+++ b/components/templates/src/global_fns/images.rs
@@ -55,18 +55,8 @@ impl TeraFn for ResizeImage {
 
         let quality =
             optional_arg!(u8, args.get("quality"), "`resize_image`: `quality` must be a number");
-        if let Some(quality) = quality {
-            if quality == 0 || quality > 100 {
-                return Err("`resize_image`: `quality` must be in range 1-100".to_string().into());
-            }
-        }
         let speed =
             optional_arg!(u8, args.get("speed"), "`resize_image`: `speed` must be a number");
-        if let Some(speed) = speed {
-            if speed == 0 || speed > 10 {
-                return Err("`resize_image`: `speed` must be in range 1-10".to_string().into());
-            }
-        }
         let resize_op = imageproc::ResizeOperation::from_args(&op, width, height)
             .map_err(|e| format!("`resize_image`: {}", e))?;
         let mut imageproc = self.imageproc.lock().unwrap();

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -38,7 +38,8 @@ resize_image(path, width, height, op, format, quality)
 
   The default is `"auto"`, this means that the format is chosen based on input image format.
   JPEG is chosen for JPEGs and other lossy formats, and PNG is chosen for PNGs and other lossless formats.
-- `quality` (_optional_): Quality of the resized image, in percent. Only used when encoding JPEGs, WebPs or AVIFs; for JPEG default value is `75`, for WebP default is lossless, for Avif default is `70`.
+- `quality` (_optional_): Quality of the resized image, in percent. Quality is only used when encoding JPEGs, WebPs or AVIFs; the default quality for JPEG is `75`, the default for WebP is to encode in lossless mode, and the default quality for AVIF is `70`.
+- `speed` (_optional_): Speed of encoding the resized image, 1-10. Speed is only used when encoding AVIFs; the default speed is `10`. Speed 10 should process images the fastest, but may not produce the best compression. Speed 1 is much slower but produces the best compression.
 
 ### Image processing and return value
 

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -9,7 +9,7 @@ which is available in template code as well as in shortcodes.
 The function usage is as follows:
 
 ```jinja2
-resize_image(path, width, height, op, format, quality)
+resize_image(path, width, height, op, format, quality, speed)
 ```
 
 ### Arguments

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -38,8 +38,8 @@ resize_image(path, width, height, op, format, quality, speed)
 
   The default is `"auto"`, this means that the format is chosen based on input image format.
   JPEG is chosen for JPEGs and other lossy formats, and PNG is chosen for PNGs and other lossless formats.
-- `quality` (_optional_): Quality of the resized image, in percent. Quality is only used when encoding JPEGs, WebPs or AVIFs; the default quality for JPEG is `75`, the default for WebP is to encode in lossless mode, and the default quality for AVIF is `80`.
-- `speed` (_optional_): Speed of encoding the resized image, 1-10. Speed is only used when encoding AVIFs; the default speed is `5`. Speed 10 should process images the fastest, but may not produce the best compression. Speed 1 is much slower but produces the best compression.
+- `quality` (_optional_): Quality of the resized image. Quality is only used when encoding JPEGs, WebPs or AVIFs. Quality for JPEG ranges from 1 to 100 and defaults to 75. Quality for WebP ranges from 0 to 100 and defaults to lossless encoding. Quality for AVIF ranges from 1 to 100 and defaults to 80.
+- `speed` (_optional_): Speed of encoding the resized image. Speed is only used when encoding AVIFs. Speed for AVIF ranges from 1 to 10 and defaults to 5. Speed 10 should process images the fastest, but may not produce the best compression; speed 1 is much slower but produces the best compression.
 
 ### Image processing and return value
 

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -38,8 +38,8 @@ resize_image(path, width, height, op, format, quality, speed)
 
   The default is `"auto"`, this means that the format is chosen based on input image format.
   JPEG is chosen for JPEGs and other lossy formats, and PNG is chosen for PNGs and other lossless formats.
-- `quality` (_optional_): Quality of the resized image, in percent. Quality is only used when encoding JPEGs, WebPs or AVIFs; the default quality for JPEG is `75`, the default for WebP is to encode in lossless mode, and the default quality for AVIF is `70`.
-- `speed` (_optional_): Speed of encoding the resized image, 1-10. Speed is only used when encoding AVIFs; the default speed is `10`. Speed 10 should process images the fastest, but may not produce the best compression. Speed 1 is much slower but produces the best compression.
+- `quality` (_optional_): Quality of the resized image, in percent. Quality is only used when encoding JPEGs, WebPs or AVIFs; the default quality for JPEG is `75`, the default for WebP is to encode in lossless mode, and the default quality for AVIF is `80`.
+- `speed` (_optional_): Speed of encoding the resized image, 1-10. Speed is only used when encoding AVIFs; the default speed is `5`. Speed 10 should process images the fastest, but may not produce the best compression. Speed 1 is much slower but produces the best compression.
 
 ### Image processing and return value
 


### PR DESCRIPTION
This follows up #2780 with the ability to control the AVIF encoder speed (1-10) and fixes handling of non-RGB8/RGBA8 color modes when encoding AVIF.

---

Regarding non-RGB color support, Zola currently blows up if an input image for AVIF resizing is not RGB `u8`, I think because `image` hits asserts regarding the buffer size. :(

```
➜ zola build                    
Building site...
Checking all internal links with anchors.
> Successfully checked 0 internal link(s) with anchors.
-> Creating 23 pages (0 orphan) and 0 sections
thread '<unnamed>' panicked at components/imageproc/src/processor.rs:83:25:
assertion `left == right` failed: Invalid buffer length: expected 507000 got 169000 for 500x338 image
  left: 507000
 right: 169000
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at components/imageproc/src/processor.rs:83:25:
assertion `left == right` failed: Invalid buffer length: expected 7482240 got 2494080 for 1920x1299 image
  left: 7482240
 right: 2494080
```

This fixes that by supporting all the (known) values for `image::ColorType`.