### PR TITLE
Avoid creating empty/incomplete processed image files

### DIFF
--- a/components/imageproc/Cargo.toml
+++ b/components/imageproc/Cargo.toml
@@ -6,11 +6,9 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 kamadak-exif = "0.6"
+tempfile = "3"
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }
 config = { path = "../config" }
 libs = { path = "../libs" }
-
-[dev-dependencies]
-tempfile = "3"

--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -41,6 +41,7 @@ impl ImageOp {
             return Ok(());
         }
 
+        let input_permissions = fs::metadata(&self.input_path)?.permissions();
         let reader =
             ImageReader::open(&self.input_path).and_then(ImageReader::with_guessed_format)?;
         let mut decoder = reader.into_decoder()?;
@@ -97,6 +98,7 @@ impl ImageOp {
             }
         };
 
+        fs::set_permissions(&tmp_output_file, input_permissions)?;
         fs::rename(&tmp_output_file, &self.output_path)?;
 
         Ok(())

--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -97,7 +97,7 @@ impl ImageOp {
             }
         };
 
-        fs::hard_link(&tmp_output_file, &self.output_path)?;
+        fs::rename(&tmp_output_file, &self.output_path)?;
 
         Ok(())
     }


### PR DESCRIPTION
`ImageOp` creates the output file before writing to it (of course), but if writing the image into the file fails with some error, the file is left around (despite being empty or corrupted). This means a subsequent `zola build` raises no errors, and it "looks like" it worked on the second attempt, but the file(s) are empty or corrupt.

I think a good solution here is to write to a `tempfile` and then move it to the final destination.

---

The following events now occur when running a `zola build` that needs to create one new processed image (in this case `example.1345f5935a4925f7.avif`):

```
static/processed_images/ CREATE .tmpE0FV7i
static/processed_images/ OPEN .tmpE0FV7i
static/processed_images/ MODIFY .tmpE0FV7i
static/processed_images/ ATTRIB .tmpE0FV7i
static/processed_images/ MOVED_FROM .tmpE0FV7i
static/processed_images/ MOVED_TO example.1345f5935a4925f7.avif
static/processed_images/ CLOSE_WRITE,CLOSE example.1345f5935a4925f7.avif
```