### PR TITLE
Add `ko` to build_search_index

### DIFF
--- a/components/libs/Cargo.toml
+++ b/components/libs/Cargo.toml
@@ -9,7 +9,7 @@ ammonia = "4"
 atty = "0.2.11"
 base64 = "0.22"
 csv = "1"
-elasticlunr-rs = { version = "3.0.2", features = ["da", "no", "de", "du", "es", "fi", "fr", "hu", "it", "pt", "ro", "ru", "sv", "tr"] }
+elasticlunr-rs = { version = "3.0.2", features = ["da", "no", "de", "du", "es", "fi", "fr", "hu", "it", "pt", "ro", "ru", "sv", "tr", "ko"] }
 filetime = "0.2"
 gh-emoji = "1"
 glob = "0.3"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

> https://zola.discourse.group/t/add-search-index-support-for-korean-ko/2597

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?


## Tests

### Zola build
config.toml
```toml
[languages.ko]
build_search_index = true
```

build & check index file
```bash
# build
/zola_repo/target/release/zola/zola build

ls public | grep search_index
# search_index.en.json
# search_index.ko.json
```

### Size
```bash
# build master branch
wc -c target/release/zola
 34567728 target/release/zola

# build add-ko-to-build-search-index branch
wc -c target/release/zola
 34600768 target/release/zola
```