### PR TITLE
Hash input file contents for imageproc output filenames

### DIFF
--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -190,7 +190,6 @@ impl Processor {
     pub fn enqueue(
         &mut self,
         op: ResizeOperation,
-        input_src: String,
         input_path: PathBuf,
         format: &str,
         quality: Option<u8>,
@@ -207,7 +206,7 @@ impl Processor {
         // We get the output format
         let format = Format::from_args(meta.is_lossy(), format, quality, speed)?;
         // Now we have all the data we need to generate the output filename and the response
-        let filename = get_processed_filename(&input_path, &input_src, &op, &format);
+        let filename = get_processed_filename(&input_path, &op, &format)?;
         let url = format!("{}{}", self.base_url, filename);
         let static_path = Path::new("static").join(RESIZED_SUBDIR).join(&filename);
         let output_path = self.output_dir.join(&filename);

--- a/components/imageproc/tests/resize_image.rs
+++ b/components/imageproc/tests/resize_image.rs
@@ -49,8 +49,7 @@ fn image_op_test(
     let mut proc = Processor::new(tmpdir.clone(), &config);
     let resize_op = ResizeOperation::from_args(op, width, height).unwrap();
 
-    let resp =
-        proc.enqueue(resize_op, source_img.into(), source_path, format, quality, speed).unwrap();
+    let resp = proc.enqueue(resize_op, source_path, format, quality, speed).unwrap();
     assert_processed_path_matches(&resp.url, "https://example.com/processed_images/", expect_ext);
     assert_processed_path_matches(&resp.static_path, PROCESSED_PREFIX.as_str(), expect_ext);
     assert_eq!(resp.width, expect_width);
@@ -585,7 +584,7 @@ fn resize_and_check(source_img: &str) -> bool {
     let mut proc = Processor::new(tmpdir.clone(), &config);
     let resize_op = ResizeOperation::from_args("scale", Some(16), Some(16)).unwrap();
 
-    let resp = proc.enqueue(resize_op, source_img.into(), source_path, "jpg", None, None).unwrap();
+    let resp = proc.enqueue(resize_op, source_path, "jpg", None, None).unwrap();
 
     proc.do_process().unwrap();
     let processed_path = PathBuf::from(&resp.static_path);

--- a/components/templates/src/functions/files.rs
+++ b/components/templates/src/functions/files.rs
@@ -114,7 +114,7 @@ impl Function<TeraResult<String>> for GetUrl {
                     &self.output_path,
                 )
                 .map_err(|e| Error::message(format!("`get_url`: {}", e)))?
-                .and_then(|(p, _)| fs::File::open(p).ok())
+                .and_then(|p| fs::File::open(p).ok())
                 .and_then(|mut f| {
                     let mut contents = Vec::new();
                     f.read_to_end(&mut contents).ok()?;
@@ -176,7 +176,7 @@ impl Function<TeraResult<String>> for GetHash {
                     match search_for_file(&self.base_path, &path_v, &self.theme, &self.output_path)
                         .map_err(|e| Error::message(format!("`get_hash`: {}", e)))?
                     {
-                        Some((f, _)) => f,
+                        Some(f) => f,
                         None => {
                             return Err(Error::message(format!(
                                 "`get_hash`: Cannot find file: {}",

--- a/components/templates/src/functions/images.rs
+++ b/components/templates/src/functions/images.rs
@@ -199,12 +199,12 @@ mod tests {
             data.get(&"static_path".into()).unwrap(),
             &Value::from(format!(
                 "{}",
-                static_path.join("gutenberg.e99218b5a3185c99.jpg").display()
+                static_path.join("gutenberg.9786ef7a62f75bc4.jpg").display()
             ))
         );
         assert_eq!(
             data.get(&"url".into()).unwrap(),
-            &Value::from("http://a-website.com/processed_images/gutenberg.e99218b5a3185c99.jpg")
+            &Value::from("http://a-website.com/processed_images/gutenberg.9786ef7a62f75bc4.jpg")
         );
 
         // 2. resizing an image in content with a relative path
@@ -219,12 +219,12 @@ mod tests {
             data.get(&"static_path".into()).unwrap(),
             &Value::from(format!(
                 "{}",
-                static_path.join("gutenberg.155d032b1aae0133.jpg").display()
+                static_path.join("gutenberg.9786ef7a62f75bc4.jpg").display()
             ))
         );
         assert_eq!(
             data.get(&"url".into()).unwrap(),
-            &Value::from("http://a-website.com/processed_images/gutenberg.155d032b1aae0133.jpg")
+            &Value::from("http://a-website.com/processed_images/gutenberg.9786ef7a62f75bc4.jpg")
         );
 
         // 3. resizing with an absolute path is the same as the above
@@ -255,11 +255,11 @@ mod tests {
         let data = data.as_map().unwrap();
         assert_eq!(
             data.get(&"static_path".into()).unwrap(),
-            &Value::from(format!("{}", static_path.join("asset.160461e0d0be19e6.jpg").display()))
+            &Value::from(format!("{}", static_path.join("asset.9786ef7a62f75bc4.jpg").display()))
         );
         assert_eq!(
             data.get(&"url".into()).unwrap(),
-            &Value::from("http://a-website.com/processed_images/asset.160461e0d0be19e6.jpg")
+            &Value::from("http://a-website.com/processed_images/asset.9786ef7a62f75bc4.jpg")
         );
 
         // 6. Looking up a file in the theme
@@ -274,12 +274,12 @@ mod tests {
             data.get(&"static_path".into()).unwrap(),
             &Value::from(format!(
                 "{}",
-                static_path.join("in-theme.d8f4f6eef30de1b2.jpg").display()
+                static_path.join("in-theme.9786ef7a62f75bc4.jpg").display()
             ))
         );
         assert_eq!(
             data.get(&"url".into()).unwrap(),
-            &Value::from("http://a-website.com/processed_images/in-theme.d8f4f6eef30de1b2.jpg")
+            &Value::from("http://a-website.com/processed_images/in-theme.9786ef7a62f75bc4.jpg")
         );
     }
 

--- a/components/templates/src/functions/images.rs
+++ b/components/templates/src/functions/images.rs
@@ -57,7 +57,7 @@ impl Function<TeraResult<Value>> for ResizeImage {
             .map_err(|e| Error::message(format!("`resize_image`: {}", e)))?;
 
         let mut imageproc = self.imageproc.lock().unwrap();
-        let (file_path, unified_path) =
+        let (file_path, _) =
             match search_for_file(&self.base_path, &path, &self.theme, &self.output_path)
                 .map_err(|e| Error::message(format!("`resize_image`: {}", e)))?
             {
@@ -71,7 +71,7 @@ impl Function<TeraResult<Value>> for ResizeImage {
             };
 
         let response = imageproc
-            .enqueue(resize_op, unified_path, file_path, &format, quality, speed)
+            .enqueue(resize_op, file_path, &format, quality, speed)
             .map_err(|e| Error::message(format!("`resize_image`: {}", e)))?;
 
         Ok(Value::from_serializable(&response))

--- a/components/templates/src/functions/load_data.rs
+++ b/components/templates/src/functions/load_data.rs
@@ -111,7 +111,7 @@ impl DataSource {
             return match search_for_file(base_path, &path, theme, output_path)
                 .map_err(|e| Error::message(format!("`load_data`: {}", e)))?
             {
-                Some((f, _)) => Ok(Some(DataSource::Path(f))),
+                Some(f) => Ok(Some(DataSource::Path(f))),
                 None => Ok(None),
             };
         }

--- a/components/templates/src/helpers.rs
+++ b/components/templates/src/helpers.rs
@@ -14,14 +14,13 @@ use utils::fs::is_path_in_directory;
 ///
 /// A path starting with @/ will replace it with `content/` and a path starting with `/` will have
 /// it removed.
-/// It also returns the unified path so it can be used as unique hash for a given file.
 /// It will error if the file is not contained in the Zola directory.
 pub fn search_for_file(
     base_path: &Path,
     path: &str,
     theme: &Option<String>,
     output_path: &Path,
-) -> Result<Option<(PathBuf, String)>> {
+) -> Result<Option<PathBuf>> {
     let mut search_paths =
         vec![base_path.join("static"), base_path.join("content"), base_path.join(output_path)];
     if let Some(t) = theme {
@@ -52,5 +51,5 @@ pub fn search_for_file(
         }
     }
 
-    if file_exists { Ok(Some((file_path, actual_path.into_owned()))) } else { Ok(None) }
+    if file_exists { Ok(Some(file_path)) } else { Ok(None) }
 }

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -49,9 +49,9 @@ Zola performs image processing during the build process and places the resized i
 static/processed_images/
 ```
 
-The filename of each resized image is a hash of the function arguments,
+The filename of each resized image is a hash of the input file contents and the other `resize_image` arguments,
 which means that once an image is resized in a certain way, it will be stored in the above directory and will not
-need to be resized again during subsequent builds (unless the image itself, the dimensions, or other arguments have changed).
+need to be resized again during subsequent builds (unless the input file contents or other `resize_image` arguments have changed).
 
 The function returns an object with the following schema:
 


### PR DESCRIPTION
It doesn't seem quite right to me that `resize_image`'s output filename hash reads the *path* of the input file; shouldn't it read the *contents* instead? That way:

- if an input file is modified in place, Zola will not reuse the now-stale processed file
- if an input file is moved but retains the original filename, Zola will be able to reuse the existing processed file
  - (This one begs the question: should the original filename be included in the processed output filename at all? Should the processed output filename just be a hash digest and an extension? It would minimize the impact of renames and maybe even allow multiple identical input files to reuse a single processed output file.)

(Also, `GetImageMetadata::call` can just use the full path to the file as its cache key, so the return signature of `search_for_file` can be simplified.)

Since #2862/#2872 have changed the hash behavior on `next`, I figure this is maybe a good time to consider this, too, as it also affects the imageproc hash behavior.