### PR TITLE
Fix footnotes semantic organization for accessibility

### DIFF
--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -306,7 +306,7 @@ fn convert_footnotes_to_github_style(old_events: &mut Vec<Event>) {
     }
 
     old_events
-        .push(Event::Html("<footer class=\"footnotes\">\n<ol class=\"footnotes-list\">\n".into()));
+        .push(Event::Html("<section class=\"footnotes\">\n<ol class=\"footnotes-list\">\n".into()));
 
     // Step 2: retain only footnotes which was actually referenced
     footnotes.retain(|f| match f.first() {
@@ -396,7 +396,7 @@ fn convert_footnotes_to_github_style(old_events: &mut Vec<Event>) {
     });
 
     old_events.extend(footnotes);
-    old_events.push(Event::Html("</ol>\n</footer>\n".into()));
+    old_events.push(Event::Html("</ol>\n</section>\n".into()));
 }
 
 pub fn markdown_to_html(

--- a/components/markdown/src/snapshots/markdown__markdown__tests__def_before_use.snap
+++ b/components/markdown/src/snapshots/markdown__markdown__tests__def_before_use.snap
@@ -3,10 +3,10 @@ source: components/markdown/src/markdown.rs
 expression: html
 ---
 <p>There is footnote definition?<sup class="footnote-reference" id="fr-1-1"><a href="#fn-1">1</a></sup></p>
-<footer class="footnotes">
+<section class="footnotes">
 <ol class="footnotes-list">
 <li id="fn-1">
 <p>It's before the reference. <a href="#fr-1-1">↩</a></p>
 </li>
 </ol>
-</footer>
+</section>

--- a/components/markdown/src/snapshots/markdown__markdown__tests__footnote_inside_footnote.snap
+++ b/components/markdown/src/snapshots/markdown__markdown__tests__footnote_inside_footnote.snap
@@ -3,7 +3,7 @@ source: components/markdown/src/markdown.rs
 expression: html
 ---
 <p>This text has a footnote<sup class="footnote-reference" id="fr-1-1"><a href="#fn-1">1</a></sup></p>
-<footer class="footnotes">
+<section class="footnotes">
 <ol class="footnotes-list">
 <li id="fn-1">
 <p>But the footnote has another footnote<sup class="footnote-reference" id="fr-2-1"><a href="#fn-2">2</a></sup>. <a href="#fr-1-1">↩</a></p>
@@ -12,4 +12,4 @@ expression: html
 <p>That's it. <a href="#fr-2-1">↩</a></p>
 </li>
 </ol>
-</footer>
+</section>

--- a/components/markdown/src/snapshots/markdown__markdown__tests__multiple_refs.snap
+++ b/components/markdown/src/snapshots/markdown__markdown__tests__multiple_refs.snap
@@ -3,10 +3,10 @@ source: components/markdown/src/markdown.rs
 expression: html
 ---
 <p>This text has two<sup class="footnote-reference" id="fr-1-1"><a href="#fn-1">1</a></sup> identical footnotes<sup class="footnote-reference" id="fr-1-2"><a href="#fn-1">1</a></sup></p>
-<footer class="footnotes">
+<section class="footnotes">
 <ol class="footnotes-list">
 <li id="fn-1">
 <p>So one is present. <a href="#fr-1-1">↩</a> <a href="#fr-1-2">↩2</a></p>
 </li>
 </ol>
-</footer>
+</section>

--- a/components/markdown/src/snapshots/markdown__markdown__tests__reordered_footnotes.snap
+++ b/components/markdown/src/snapshots/markdown__markdown__tests__reordered_footnotes.snap
@@ -3,7 +3,7 @@ source: components/markdown/src/markdown.rs
 expression: html
 ---
 <p>This text has two<sup class="footnote-reference" id="fr-2-1"><a href="#fn-2">1</a></sup> footnotes<sup class="footnote-reference" id="fr-1-1"><a href="#fn-1">2</a></sup></p>
-<footer class="footnotes">
+<section class="footnotes">
 <ol class="footnotes-list">
 <li id="fn-2">
 <p>But they are <a href="#fr-2-1">↩</a></p>
@@ -12,4 +12,4 @@ expression: html
 <p>not sorted. <a href="#fr-1-1">↩</a></p>
 </li>
 </ol>
-</footer>
+</section>

--- a/components/markdown/src/snapshots/markdown__markdown__tests__single_footnote.snap
+++ b/components/markdown/src/snapshots/markdown__markdown__tests__single_footnote.snap
@@ -3,10 +3,10 @@ source: components/markdown/src/markdown.rs
 expression: html
 ---
 <p>This text has a footnote<sup class="footnote-reference" id="fr-1-1"><a href="#fn-1">1</a></sup></p>
-<footer class="footnotes">
+<section class="footnotes">
 <ol class="footnotes-list">
 <li id="fn-1">
 <p>But it is meaningless. <a href="#fr-1-1">↩</a></p>
 </li>
 </ol>
-</footer>
+</section>

--- a/components/markdown/tests/snapshots/markdown__github_style_footnotes.snap
+++ b/components/markdown/tests/snapshots/markdown__github_style_footnotes.snap
@@ -8,7 +8,7 @@ expression: body
 <p>This text has two<sup class="footnote-reference" id="fr-5-1"><a href="#fn-5">5</a></sup> identical footnotes<sup class="footnote-reference" id="fr-5-2"><a href="#fn-5">5</a></sup></p>
 <p>This text has a footnote<sup class="footnote-reference" id="fr-7-1"><a href="#fn-7">6</a></sup></p>
 <p>Footnotes can also be referenced with identifiers<sup class="footnote-reference" id="fr-first-1"><a href="#fn-first">8</a></sup>.</p>
-<footer class="footnotes">
+<section class="footnotes">
 <ol class="footnotes-list">
 <li id="fn-1">
 <p>But it is meaningless. <a href="#fr-1-1">↩</a></p>
@@ -35,4 +35,4 @@ expression: body
 <p>Like this: <code>[^first]</code>. <a href="#fr-first-1">↩</a></p>
 </li>
 </ol>
-</footer>
+</section>


### PR DESCRIPTION
Footnotes are currently excluded in certain accessibility tools such as Firefox Reader View. This is because footnotes are nested underneath an HTML5 `footer` element, which permits the accessibility tool to discard the contents as irrelevant to the current section text under consideration.

Semantically, the [`footer` element](https://html.spec.whatwg.org/multipage/sections.html#the-footer-element) represents metainformation for its nearest ancestor sectioning content (e.g. publication timestamps, related links, authorship copyright, etc.). It's incorrect to place footnotes underneath the `footer` element because, while footnotes may be _thematically_ distinct from the main content, they are considered **semantically** part of that content. Footnotes are merely a different _section_ of content: their role is that of content supplementation, not metainformation.

In order to properly indicate the semantic relationship between the main content and its footnotes, the footnotes should be nested underneath a [`section` element](https://html.spec.whatwg.org/multipage/sections.html#the-section-element) which adequately communicates this relationship. This isn't just speculation, but is in fact the exact way the WHATWG HTML5 specification document recommends implementing the [footnotes with reciprocal backlinks](https://html.spec.whatwg.org/multipage/semantics-other.html#footnotes) idiom.

```html
<p> Announcer: Number 16: The <i>hand</i>.
<p> Interviewer: Good evening. I have with me in the studio tonight
Mr Norman St John Polevaulter, who for the past few years has been
contradicting people. Mr Polevaulter, why <em>do</em> you
contradict people?
<p> Norman: I don't. <sup><a href="#fn1" id="r1">[1]</a></sup>
<p> Interviewer: You told me you did!
...
<section>
 <p id="fn1"><a href="#r1">[1]</a> This is, naturally, a lie,
 but paradoxically if it were true he could not say so without
 contradicting the interviewer and thus making it false.</p>
</section>
```

To that end, this patch changes the footnotes `footer` element to a `section` element. The `class="footnotes"` attribute remains the same so that user stylesheets may not be affected by this bug fix:

```html
    <section class="footnotes">
    <ol class="footnotes-list">
    ...
    </ol>
    </section>
```

Test snapshots are also updated to reflect the adjustment.

Fixes: c4a84a8e ("Improve accessibility by nesting bottom footnotes inside footer element (#2688)")
Link: https://github.com/getzola/zola/pull/2688

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



