### PR TITLE
Add github alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.21.0 (unreleased)
 
+- Allow `github_alerts` at config.toml level
 
 ## 0.20.0 (2025-02-14)
 

--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -65,6 +65,8 @@ pub struct Markdown {
     /// Whether to insert a link for each header like the ones you can see in this site if you hover one
     /// The default template can be overridden by creating a `anchor-link.html` in the `templates` directory
     pub insert_anchor_links: InsertAnchor,
+    /// Whether to enable GitHub-style alerts
+    pub github_alerts: bool,
 }
 
 impl Markdown {
@@ -240,6 +242,7 @@ impl Default for Markdown {
             extra_theme_set: Arc::new(None),
             lazy_async_image: false,
             insert_anchor_links: InsertAnchor::None,
+            github_alerts: false,
         }
     }
 }

--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -443,6 +443,9 @@ pub fn markdown_to_html(
     if context.config.markdown.definition_list {
         opts.insert(Options::ENABLE_DEFINITION_LIST);
     }
+    if context.config.markdown.github_alerts {
+        opts.insert(Options::ENABLE_GFM);
+    }
 
     // we reverse their order so we can pop them easily in order
     let mut html_shortcodes: Vec<_> = html_shortcodes.into_iter().rev().collect();

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -449,3 +449,29 @@ Footnotes can also be referenced with identifiers[^first].
     let body = common::render_with_config(&markdown, config).unwrap().body;
     insta::assert_snapshot!(body);
 }
+
+#[test]
+fn github_alerts() {
+    let mut config = Config::default_for_test();
+    config.markdown.github_alerts = true;
+
+    let markdown = r#"
+> [!NOTE]  
+> alert note
+
+> [!TIP]
+> alert tip
+
+> [!IMPORTANT]  
+> alert important
+
+> [!WARNING]  
+> alert warning
+
+> [!CAUTION]
+> alert caution
+"#;
+
+    let body = common::render_with_config(&markdown, config).unwrap().body;
+    insta::assert_snapshot!(body);
+}

--- a/components/markdown/tests/snapshots/markdown__github_alerts.snap
+++ b/components/markdown/tests/snapshots/markdown__github_alerts.snap
@@ -1,0 +1,19 @@
+---
+source: components/markdown/tests/markdown.rs
+expression: body
+---
+<blockquote class="markdown-alert-note">
+<p>alert note</p>
+</blockquote>
+<blockquote class="markdown-alert-tip">
+<p>alert tip</p>
+</blockquote>
+<blockquote class="markdown-alert-important">
+<p>alert important</p>
+</blockquote>
+<blockquote class="markdown-alert-warning">
+<p>alert warning</p>
+</blockquote>
+<blockquote class="markdown-alert-caution">
+<p>alert caution</p>
+</blockquote>


### PR DESCRIPTION
This PR wants to add github flavor alerts.

## Code changes
I followed your guide in the issue adding the feature with the proposed name `github_alerts` and default to `false`.
Added also the test, not sure if it's the proper way, this is my first contribution to the project.

Ref: #2817 




