### PR TITLE
fix(search/fuse.js): skip serializing null keys when filtering them via zola config

### DIFF
--- a/components/search/src/fuse.rs
+++ b/components/search/src/fuse.rs
@@ -10,9 +10,13 @@ pub fn build_index(lang: &str, library: &Library, config: &Search) -> Result<Str
     #[derive(serde::Serialize)]
     struct Item<'a> {
         url: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
         title: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         body: Option<String>, // AMMONIA.clean has to allocate anyway
+        #[serde(skip_serializing_if = "Option::is_none")]
         path: Option<&'a str>,
     }
     let mut items: Vec<Item> = Vec::new();


### PR DESCRIPTION
Closes:
https://github.com/getzola/zola/issues/2889

Currently, even if you filter fields out of your `fuse.js` index:
```
[search]
index_format = "fuse_json"
include_path = true
include_title = true
include_content = false
include_description = false
include_date = false
```

They show up in the index as null fields, which bloats the index size for large sites:
```
[{"url":"https://my-url", title":"my-title","description":null,"body":null,"path":"/my-path0/"}]
```

This change adds a  `#[serde(skip_serializing_if = "Option::is_none")]` to the optional fields, so that they are instead just left out of the index.

## Testing

The new result for the equivalent example above is:
`[{"url":"https://my-url", title":"my-title","path":"/my-path0/"}]`

I have tested that `fuse.js`'s javascript bundle still handle this properly with the null fields missing. I did so by locally staging my site with `zola serve`, as well as manually inspect the index in console to make sure it was reflecting changes.

Everything worked fine. This cut 10mb off my index size.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?
n/a


