### PR TITLE
README: adds logo; DOCS: logo in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zola (né Gutenberg)
+# zola (né Gutenberg) <img src="docs/static/logos/Zola-logo-main-coffee.svg" align="right" alt="zola logo" width="30%"/>
 
 [![Build Status](https://dev.azure.com/getzola/zola/_apis/build/status/getzola.zola?branchName=master)](https://dev.azure.com/getzola/zola/_build/latest?definitionId=1&branchName=master)
 ![GitHub all releases](https://img.shields.io/github/downloads/getzola/zola/total)

--- a/docs/sass/_header.scss
+++ b/docs/sass/_header.scss
@@ -1,8 +1,4 @@
 header {
-  .header__logo {
-    border-bottom: none;
-  }
-
   ul {
     padding-inline-start: 0;
     display: flex;
@@ -15,8 +11,15 @@ header {
   }
 
   .header__logo {
+    border-bottom: none;
     font-size: 2rem;
     font-weight: bold;
+
+    img {
+      height: 2.5rem;
+      width: auto;
+      display: block;
+    } 
 
     &:hover {
       text-decoration: none;

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -13,7 +13,11 @@
     <body>
 
         <header>
-            <a class="header__logo white" href="{{ config.base_url }}">Zola</a>
+		<a class="header__logo white" href="{{ config.base_url }}"><img
+			src="/logos/Zola-logo-white.svg"
+			title="Zola main logo in white"
+			alt="Zola"
+			/></a>
             <nav>
                 <ul>
                     <li><a class="white" href="{{ get_url(path='@/documentation/_index.md') }}" class="nav-link">Docs</a></li>


### PR DESCRIPTION
1. Adds the new logo to the README.md header.
2. Replaces documentation template header text with an image, adds an appropriate styling (not tested!).

It also would be nice to update the @getzola account logo with one of the square ones.