### PR TITLE
Adjust ImageMeta dimensions based on Exif orientation data

### DIFF
--- a/components/imageproc/src/helpers.rs
+++ b/components/imageproc/src/helpers.rs
@@ -10,13 +10,7 @@ use libs::image::DynamicImage;
 /// Apply image rotation based on EXIF data
 /// Returns `None` if no transformation is needed
 pub fn fix_orientation(img: &DynamicImage, path: &Path) -> Option<DynamicImage> {
-    let file = std::fs::File::open(path).ok()?;
-    let mut buf_reader = std::io::BufReader::new(&file);
-    let exif_reader = exif::Reader::new();
-    let exif = exif_reader.read_from_container(&mut buf_reader).ok()?;
-    let orientation =
-        exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY)?.value.get_uint(0)?;
-    match orientation {
+    match get_orientation(path)? {
         // Values are taken from the page 30 of
         // https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf
         // For more details check http://sylvana.net/jpegcrop/exif_orientation.html
@@ -30,6 +24,24 @@ pub fn fix_orientation(img: &DynamicImage, path: &Path) -> Option<DynamicImage> 
         8 => Some(img.rotate270()),
         _ => None,
     }
+}
+
+/// Adjusts the width and height of an image based on EXIF rotation data.
+/// Returns `None` if no transformation is needed.
+pub fn get_rotated_size(w: u32, h: u32, path: &Path) -> Option<(u32, u32)> {
+    // See fix_orientation for the meaning of these values.
+    match get_orientation(path)? {
+        5 | 6 | 7 | 8 => Some((h, w)),
+        _ => None,
+    }
+}
+
+fn get_orientation(path: &Path) -> Option<u32> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut buf_reader = std::io::BufReader::new(&file);
+    let exif_reader = exif::Reader::new();
+    let exif = exif_reader.read_from_container(&mut buf_reader).ok()?;
+    Some(exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY)?.value.get_uint(0)?)
 }
 
 /// We only use the input_path to get the file stem.

--- a/components/imageproc/src/lib.rs
+++ b/components/imageproc/src/lib.rs
@@ -4,7 +4,7 @@ mod meta;
 mod ops;
 mod processor;
 
-pub use helpers::fix_orientation;
+pub use helpers::{fix_orientation, get_rotated_size};
 pub use meta::{read_image_metadata, ImageMeta, ImageMetaResponse};
 pub use ops::{ResizeInstructions, ResizeOperation};
 pub use processor::{EnqueueResponse, Processor, RESIZED_SUBDIR};

--- a/components/imageproc/src/meta.rs
+++ b/components/imageproc/src/meta.rs
@@ -9,6 +9,8 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
+use crate::get_rotated_size;
+
 /// Size and format read cheaply with `image`'s `Reader`.
 #[derive(Debug)]
 pub struct ImageMeta {
@@ -21,7 +23,11 @@ impl ImageMeta {
     pub fn read(path: &Path) -> ImageResult<Self> {
         let reader = ImageReader::open(path).and_then(ImageReader::with_guessed_format)?;
         let format = reader.format();
-        let size = reader.into_dimensions()?;
+        let mut size = reader.into_dimensions()?;
+
+        if let Some((w, h)) = get_rotated_size(size.0, size.1, path) {
+            size = (w, h);
+        }
 
         Ok(Self { size, format })
     }

--- a/components/imageproc/tests/resize_image.rs
+++ b/components/imageproc/tests/resize_image.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::{PathBuf, MAIN_SEPARATOR as SLASH};
 
 use config::Config;
-use imageproc::{fix_orientation, ImageMetaResponse, Processor, ResizeOperation};
+use imageproc::{fix_orientation, get_rotated_size, ImageMetaResponse, Processor, ResizeOperation};
 use libs::image::{self, DynamicImage, GenericImageView, Pixel};
 use libs::once_cell::sync::Lazy;
 
@@ -511,6 +511,27 @@ fn read_image_metadata_avif() {
             mime: Some("image/avif")
         }
     );
+}
+
+#[test]
+fn get_rotated_size_test() {
+    fn is_landscape(img_name: &str) -> bool {
+        let path = TEST_IMGS.join(img_name);
+        let img = image::open(&path).unwrap();
+        let w = img.width() + 1; // Test images are square, add an offset so we can tell if the dimensions actually changed.
+        let h = img.height();
+        let (w, h) = get_rotated_size(w, h, &path).unwrap_or((w, h));
+        w > h
+    }
+    assert!(is_landscape("exif_0.jpg"));
+    assert!(is_landscape("exif_1.jpg"));
+    assert!(is_landscape("exif_2.jpg"));
+    assert!(is_landscape("exif_3.jpg"));
+    assert!(is_landscape("exif_4.jpg"));
+    assert!(!is_landscape("exif_5.jpg"));
+    assert!(!is_landscape("exif_6.jpg"));
+    assert!(!is_landscape("exif_7.jpg"));
+    assert!(!is_landscape("exif_8.jpg"));
 }
 
 #[test]

--- a/components/imageproc/tests/resize_image.rs
+++ b/components/imageproc/tests/resize_image.rs
@@ -518,11 +518,10 @@ fn get_rotated_size_test() {
     fn is_landscape(img_name: &str) -> bool {
         let path = TEST_IMGS.join(img_name);
         let mut decoder = ImageReader::open(path).unwrap().into_decoder().unwrap();
+        let (mut w, mut h) = decoder.dimensions();
+        w = w + 1; // Test images are square, add an offset so we can tell if the dimensions actually changed.
         let metadata = decoder.exif_metadata().unwrap();
-        let img = DynamicImage::from_decoder(decoder).unwrap();
-        let w = img.width() + 1; // Test images are square, add an offset so we can tell if the dimensions actually changed.
-        let h = img.height();
-        let (w, h) = get_rotated_size(w, h, metadata).unwrap_or((w, h));
+        (w, h) = get_rotated_size(w, h, metadata).unwrap_or((w, h));
         w > h
     }
     assert!(is_landscape("exif_0.jpg"));


### PR DESCRIPTION
The current handling of image dimensions when rotated with Exif data is relatively poor, as it's only handled in `ImageOp.perform`. This means that other image operations such as `get_image_metadata` and `resize_image` will be operating with the expected width and height flipped.

This proved to be problematic for a macro I had written to automatically create multiple scaled versions of images. It works fine for landscape images, but squishes portrait images into the size as if it wasn't rotated at all.
<details>
<summary>Macro code</summary>

```html
{% macro responsive_img(path, alt="", sizes="100vw", priority="auto", class="") -%}
  {% set img_fmt = "avif" %}
  {% set img_qlt = 70 %}

  {% set meta = get_image_metadata(path=path) %}
  {% set w1 = meta.width %}
  {% set w2 = meta.width / 2 | int %}
  {% set w3 = meta.width / 4 | int %}
  {% set w4 = meta.width / 8 | int %}
  {% set w5 = meta.width / 16 | int %}
  {% set w6 = meta.width / 32 | int %}

  {% set i1 = resize_image(path=path, width=w1, op="fit_width", format=img_fmt, quality=img_qlt) %}
  {% set i2 = resize_image(path=path, width=w2, op="fit_width", format=img_fmt, quality=img_qlt) %}
  {% set i3 = resize_image(path=path, width=w3, op="fit_width", format=img_fmt, quality=img_qlt) %}
  {% set i4 = resize_image(path=path, width=w4, op="fit_width", format=img_fmt, quality=img_qlt) %}
  {% set i5 = resize_image(path=path, width=w5, op="fit_width", format=img_fmt, quality=img_qlt) %}
  {% set i6 = resize_image(path=path, width=w6, op="fit_width", format=img_fmt, quality=img_qlt) %}

  <img
    class = "{{ class }}"
    src="{{ i6.url }}"
    srcset="
      {{ i1.url }} {{ w1 }}w,
      {{ i2.url }} {{ w2 }}w,
      {{ i3.url }} {{ w3 }}w,
      {{ i4.url }} {{ w4 }}w,
      {{ i5.url }} {{ w5 }}w,
      {{ i6.url }} {{ w6 }}w,
    "
    sizes="{{ sizes }}"
    alt="{{ alt }}"
    loading="lazy"
    fetchpriority="{{ priority }}"
  />
{%- endmacro %}
```

</details>

With the above macro and Zola v0.20.0, the following image is output:
![DSC00819 14678d46ab9ae7d2](https://github.com/user-attachments/assets/d765b64b-950b-48a5-b29e-5a4a195a02b4)

With this PR, the output is as expected:
![DSC00819 854761b8da61362d](https://github.com/user-attachments/assets/7958dff3-70da-468d-92e6-b59935bc2c5d)

I initially wrote this to swap only the dimensions in the `read_image_metadata` default match arm. This fixed the issue for `get_image_metadata` but did not fix the issue for `resize_image`, which would still result in the same "before" image regardless of whether I gave `get_image_metadata`'s width or height to the width parameter. This was because it parsed its own copy of `ImageMeta` without correcting the rotation values. Because of this, and to avoid placing rotation corrections all over the codebase, I only applied it in `ImageMeta.read`, which covers both of my use cases, and potentially others that may otherwise have been missed. This doesn't affect the rotation handling in `ImageOp.perform` since it reads the image file directly, without the use of `ImageMeta`.

I haven't updated the documentation since I didn't see any mentions of rotation handling there. With this PR, it should be as expected, so I don't believe a mention is necessary, although I'll gladly write something up if requested.

This is my first time contributing to Zola, so please let me know if I should've done anything differently! I also haven't been working with Zola for too long, so I can't be certain this doesn't have any adverse effects, but everything appeared to be functioning fine on my site, and all tests are passing, so it would seem everything is good. A thorough review and testing should be done prior to merging, though, just to be safe.

Closes #2818

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



