### PR TITLE
Adding optional overflow scroll to codeblocks

### DIFF
--- a/components/markdown/src/codeblock/fence.rs
+++ b/components/markdown/src/codeblock/fence.rs
@@ -26,6 +26,7 @@ pub struct FenceSettings<'a> {
     pub hide_lines: Vec<RangeInclusive<usize>>,
     pub name: Option<&'a str>,
     pub enable_copy: bool,
+    pub overflow_scroll: bool,
 }
 
 impl<'a> FenceSettings<'a> {
@@ -38,6 +39,7 @@ impl<'a> FenceSettings<'a> {
             hide_lines: Vec::new(),
             name: None,
             enable_copy: false,
+            overflow_scroll: false,
         };
 
         for token in FenceIter::new(fence_info) {
@@ -49,6 +51,7 @@ impl<'a> FenceSettings<'a> {
                 FenceToken::HideLines(lines) => me.hide_lines.extend(lines),
                 FenceToken::Name(n) => me.name = Some(n),
                 FenceToken::EnableCopy => me.enable_copy = true,
+                FenceToken::OverflowScroll => me.overflow_scroll = true,
             }
         }
 
@@ -65,6 +68,7 @@ enum FenceToken<'a> {
     HideLines(Vec<RangeInclusive<usize>>),
     Name(&'a str),
     EnableCopy,
+    OverflowScroll,
 }
 
 struct FenceIter<'a> {
@@ -117,6 +121,7 @@ impl<'a> Iterator for FenceIter<'a> {
                     }
                 }
                 "copy" => return Some(FenceToken::EnableCopy),
+                "overflowscroll" => return Some(FenceToken::OverflowScroll),
                 lang => {
                     if tok_split.next().is_some() {
                         eprintln!("Warning: Unknown annotation {}", lang);

--- a/components/markdown/src/codeblock/mod.rs
+++ b/components/markdown/src/codeblock/mod.rs
@@ -18,6 +18,7 @@ fn opening_html(
     pre_class: Option<String>,
     line_numbers: bool,
     enable_copy: bool,
+    overflow_scroll: bool,
 ) -> String {
     let mut html = String::from("<pre");
     if line_numbers {
@@ -47,6 +48,9 @@ fn opening_html(
     if let Some(styles) = pre_style {
         html.push_str(" style=\"");
         html.push_str(styles.as_str());
+        if overflow_scroll {
+            html.push_str("overflow: scroll;");
+        }
         html.push('"');
     }
 
@@ -117,6 +121,7 @@ impl<'config> CodeBlock<'config> {
             highlighter.pre_class(),
             fence.line_numbers,
             fence.enable_copy,
+            fence.overflow_scroll,
         );
         Ok((
             Self {

--- a/components/markdown/tests/codeblocks.rs
+++ b/components/markdown/tests/codeblocks.rs
@@ -381,7 +381,7 @@ A quote
 fn can_highlight_overflow_scroll() {
     let body = render_codeblock(
         r#"
-```html,overflow_scroll
+```html,overflowscroll
 <p>Example of a very long line of source code in HTML, which will trigger a scrollbar to appear on the rendered codeblock instead of it overflowing</p>
 ```
     "#,

--- a/components/markdown/tests/codeblocks.rs
+++ b/components/markdown/tests/codeblocks.rs
@@ -378,6 +378,19 @@ A quote
 }
 
 #[test]
+fn can_highlight_overflow_scroll() {
+    let body = render_codeblock(
+        r#"
+```html,overflow_scroll
+<p>Example of a very long line of source code in HTML, which will trigger a scrollbar to appear on the rendered codeblock instead of it overflowing</p>
+```
+    "#,
+        HighlightMode::Inlined,
+    );
+    insta::assert_snapshot!(body);
+}
+
+#[test]
 fn can_highlight_unknown_lang() {
     let body = render_codeblock(
         r#"

--- a/components/markdown/tests/snapshots/codeblocks__can_highlight_overflow_scroll.snap
+++ b/components/markdown/tests/snapshots/codeblocks__can_highlight_overflow_scroll.snap
@@ -3,5 +3,5 @@ source: components/markdown/tests/codeblocks.rs
 assertion_line: 390
 expression: body
 ---
-<pre data-lang="overflow_scroll" style="background-color:#2b303b;color:#c0c5ce;" class="language-overflow_scroll "><code class="language-overflow_scroll" data-lang="overflow_scroll"><span>&lt;p&gt;Example of a very long line of source code in HTML, which will trigger a scrollbar to appear on the rendered codeblock instead of it overflowing&lt;/p&gt;
+<pre data-lang="html" style="background-color:#2b303b;color:#c0c5ce;overflow: scroll;" class="language-html "><code class="language-html" data-lang="html"><span>&lt;</span><span style="color:#bf616a;">p</span><span>&gt;Example of a very long line of source code in HTML, which will trigger a scrollbar to appear on the rendered codeblock instead of it overflowing&lt;/</span><span style="color:#bf616a;">p</span><span>&gt;
 </span></code></pre>

--- a/components/markdown/tests/snapshots/codeblocks__can_highlight_overflow_scroll.snap
+++ b/components/markdown/tests/snapshots/codeblocks__can_highlight_overflow_scroll.snap
@@ -1,0 +1,7 @@
+---
+source: components/markdown/tests/codeblocks.rs
+assertion_line: 390
+expression: body
+---
+<pre data-lang="overflow_scroll" style="background-color:#2b303b;color:#c0c5ce;" class="language-overflow_scroll "><code class="language-overflow_scroll" data-lang="overflow_scroll"><span>&lt;p&gt;Example of a very long line of source code in HTML, which will trigger a scrollbar to appear on the rendered codeblock instead of it overflowing&lt;/p&gt;
+</span></code></pre>

--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -321,6 +321,14 @@ highlight(code);
 ```
 ````
 
+- `overflowscroll` to add a scrollbar to the codeblock when the text doesn't fit the page.
+
+````
+```html,overflowscroll
+<p>Example of a very long line of source code in HTML, which will trigger a scrollbar to appear on the rendered codeblock instead of it overflowing</p>
+```
+````
+
 ## Styling codeblocks
 
 Depending on the annotations used, some codeblocks will be hard to read without any CSS. We recommend using the following


### PR DESCRIPTION
This PR implements the changes discussed in [this topic](https://zola.discourse.group/t/overflow-scroll-option-on-codeblocks/2636)

The changes allow the use of an `overflowscroll` annotation on codeblocks that will add a scrollbar to the bottom of the block if the lines are too long.

I decided to make it optional as some people might like to do it otherwise, e.g. using custom css for all `<pre>` tags

Note: this is my first time contributing to Zola, don't hesitate to comment under this PR if i have done something wrong!

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?
