### PR TITLE
Closes the paren on page count for themes

### DIFF
--- a/docs/templates/theme-tags/list.html
+++ b/docs/templates/theme-tags/list.html
@@ -11,7 +11,7 @@
 <p><a href="{{ get_url(path = "themes") }}">All themes ({{ section.pages | length }}</a></p>
 <ul style="list-style-type: none;">
 {% for t in terms %}
-<li><a href="{{ t.permalink }}">{{ t.name }}({{ t.page_count }}</a></li>
+<li><a href="{{ t.permalink }}">{{ t.name }}({{ t.page_count }})</a></li>
 {% endfor %}
 </ul>
 {% endblock content %}


### PR DESCRIPTION
This is a tiny change to the "search by tag" themes page. 

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [ ] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



