### PR TITLE
Switch to sublime-jinja2 fork that doesn't break on Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = https://github.com/skozlovf/Sublime-GenericConfig.git
 [submodule "sublime/syntaxes/sublime-jinja2"]
 	path = components/config/sublime/syntaxes/extra/sublime-jinja2
-	url = https://github.com/Martin819/sublime-jinja2.git
+	url = https://github.com/senekor/sublime-jinja2.git
 [submodule "sublime/syntaxes/Julia-sublime"]
 	path = components/config/sublime/syntaxes/extra/Julia-sublime
 	url = https://github.com/JuliaEditorSupport/Julia-sublime.git


### PR DESCRIPTION
Fixes #2892 (hopefully)

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

As discussed on #2892. 

Switches from https://github.com/Martin819/sublime-jinja2 to https://github.com/senekor/sublime-jinja2, a fork which has one extra fix to stop using `:` in a Preferences path. 

This is my first attempt at a Zola PR and my first encounter with Git submodules, so I'm not at all sure I'm doing it right. In particular I haven't done the 

```ps
cargo run --example generate_sublime synpack ../../sublime/syntaxes ../../sublime/syntaxes/newlines.packdump
```

step described in `CONTRIBUTING.md` for new syntaxes, partly because this isn't a new syntax but mostly because it failed when I tried:

```ps
     Running `C:\Users\mikec\Code\rust\zola\target\debug\examples\generate_sublime.exe synpack ../../sublime/syntaxes ../../sublime/syntaxes/newlines.packdump`
Loading error: WalkDir(Error { depth: 0, inner: Io { path: Some("../../sublime/syntaxes\\Packages"), err: Os { code: 3, kind: NotFound, message: "The system cannot find the path specified." } } })
Loading error: WalkDir(Error { depth: 0, inner: Io { path: Some("../../sublime/syntaxes\\extra"), err: Os { code: 3, kind: NotFound, message: "The system cannot find the path specified." } } })
```

This doesn't look related to my change - maybe a mixed Unix/Window path separator issue? - but what do I know.