### PR TITLE
Configurable file watcher debounce duration in live-reload mode

### DIFF
--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -102,8 +102,10 @@ fail to see your change or get an error, try restarting `zola serve`.
 
 By default, the live reload will be debounced by one full second so as to more
 gracefully handle multiple changes to your input files in rapid succession. You
-have control over that debouncing duration with the debounce flag. You may use
-`-d0` to disable it altogether.
+have control over that debouncing duration with the `--debounce <duration_ms>`
+flag.  
+You may use `-d1` to (virtually) disable it altogether: for technical reasons
+(and keeping things simple), a "debounce" of 0 is not supported.
 
 You can also point to a config file other than `config.toml` like so (note that the position of the `config` option is important):
 

--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -100,6 +100,11 @@ a hard refresh if possible. If you are using WSL2 on Windows, make sure to store
 Some changes cannot be handled automatically and thus live reload may not always work. If you
 fail to see your change or get an error, try restarting `zola serve`.
 
+By default, the live reload will be debounced by one full second so as to more
+gracefully handle multiple changes to your input files in rapid succession. You
+have control over that debouncing duration with the debounce flag. You may use
+`-d0` to disable it altogether.
+
 You can also point to a config file other than `config.toml` like so (note that the position of the `config` option is important):
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,8 +102,8 @@ pub enum Command {
         #[clap(long)]
         extra_watch_path: Vec<String>,
 
-        /// Debounce time in milliseconds for the file watcher
-        #[clap(short = 'd', long, default_value_t = 1000)]
+        /// Debounce time in milliseconds for the file watcher (at least 1ms)
+        #[clap(short = 'd', long, default_value_t = 1000, value_parser = clap::value_parser!(u64).range(1..))]
         debounce: u64,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,10 @@ pub enum Command {
         /// Extra path to watch for changes, relative to the project root.
         #[clap(long)]
         extra_watch_path: Vec<String>,
+
+        /// Debounce time in milliseconds for the file watcher
+        #[clap(short = 'd', long, default_value_t = 1000)]
+        debounce: u64,
     },
 
     /// Try to build the project without rendering it. Checks links

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -429,6 +429,7 @@ pub fn serve(
     no_port_append: bool,
     utc_offset: UtcOffset,
     extra_watch_paths: Vec<String>,
+    debounce: u64,
 ) -> Result<()> {
     let start = Instant::now();
     let (mut site, bind_address, constructed_base_url) = create_new_site(
@@ -481,7 +482,7 @@ pub fn serve(
 
     // Setup watchers
     let (tx, rx) = channel();
-    let mut debouncer = new_debouncer(Duration::from_secs(1), /*tick_rate=*/ None, tx).unwrap();
+    let mut debouncer = new_debouncer(Duration::from_millis(debounce), /*tick_rate=*/ None, tx).unwrap();
 
     // We watch for changes on the filesystem for every entry in watch_this
     // Will fail if either:

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -482,7 +482,7 @@ pub fn serve(
 
     // Setup watchers
     let (tx, rx) = channel();
-    let mut debouncer = new_debouncer(Duration::from_millis(debounce), /*tick_rate=*/ None, tx).unwrap();
+    let mut debouncer = new_debouncer(Duration::from_millis(debounce), None, tx).unwrap();
 
     // We watch for changes on the filesystem for every entry in watch_this
     // Will fail if either:

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ fn main() {
             fast,
             no_port_append,
             extra_watch_path,
+            debounce,
         } => {
             if port != 1111 && !port_is_available(interface, port) {
                 console::error("The requested port is not available");
@@ -119,6 +120,7 @@ fn main() {
                 no_port_append,
                 UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC),
                 extra_watch_path,
+                debounce,
             ) {
                 messages::unravel_errors("Failed to serve the site", &e);
                 std::process::exit(1);


### PR DESCRIPTION
- Introduce `-d` `--debounce <VALUE>` flag for `serve`
- Document `serve`'s `--debounce` flag in `cli-usage.md`

Let the file watcher use a configurable debounce value.

This commit preserves the (until now hard-coded) 1-second debounce value
as the default, but adds a new flag for the `serve` command, which lets
the user configure a debounce duration for consecutive rebuilds in watch
mode.

Closes #2937.