### PR TITLE
Fix `now()` to return same time on each call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "atty",
  "avif-parse",
  "base64",
+ "chrono",
  "csv",
  "elasticlunr-rs",
  "filetime",

--- a/components/libs/Cargo.toml
+++ b/components/libs/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 ahash = "0.8"
 ammonia = "4"
 atty = "0.2.11"
+avif-parse = "1.3.2"
 base64 = "0.22"
+chrono = {version = "0.4.27", default-features = false, features = ["std", "clock"]}
 csv = "1"
 elasticlunr-rs = { version = "3.0.2", features = ["da", "no", "de", "du", "es", "fi", "fr", "hu", "it", "pt", "ro", "ru", "sv", "tr", "ko"] }
 filetime = "0.2"
@@ -44,7 +46,6 @@ unicode-segmentation = "1.2"
 url = "2"
 walkdir = "2"
 webp = "0.3"
-avif-parse = "1.3.2"
 
 [features]
 # TODO: fix me, it doesn't pick up the reqwuest feature if not set as default

--- a/components/libs/src/lib.rs
+++ b/components/libs/src/lib.rs
@@ -9,6 +9,7 @@ pub use ammonia;
 pub use atty;
 pub use avif_parse;
 pub use base64;
+pub use chrono;
 pub use csv;
 pub use elasticlunr;
 pub use filetime;

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -61,6 +61,11 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.output_path.clone(),
         ),
     );
+    {
+        let local = libs::chrono::Local::now();
+        let utc = local.to_utc();
+        site.tera.register_function("now", global_fns::Now::new(local, utc));
+    }
     site.tera.register_filter(
         "markdown",
         filters::MarkdownFilter::new(

--- a/components/templates/src/global_fns/build_info.rs
+++ b/components/templates/src/global_fns/build_info.rs
@@ -1,0 +1,103 @@
+use libs::tera::{from_value, to_value, Function as TeraFn, Result, Value};
+
+use libs::chrono::prelude::*;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Now {
+    local: DateTime<Local>,
+    utc: DateTime<Utc>,
+}
+
+impl Now {
+    pub fn new(local: DateTime<Local>, utc: DateTime<Utc>) -> Self {
+        Self { local, utc }
+    }
+}
+
+impl TeraFn for Now {
+    fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
+        let use_utc = match args.get("utc") {
+            Some(val) => match from_value::<bool>(val.clone()) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(format!(
+                        "Function `now` received utc={val} but `utc` can only be a boolean"
+                    )
+                    .into());
+                }
+            },
+            None => false,
+        };
+        let timestamp = match args.get("timestamp") {
+            Some(val) => match from_value::<bool>(val.clone()) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(format!(
+                            "Function `now` received timestamp={val} but `timestamp` can only be a boolean"
+                    )
+                    .into());
+                }
+            },
+            None => false,
+        };
+
+        if use_utc {
+            let datetime = self.utc;
+            if timestamp {
+                return Ok(to_value(datetime.timestamp()).unwrap());
+            }
+            Ok(to_value(datetime.to_rfc3339()).unwrap())
+        } else {
+            let datetime = self.local;
+            if timestamp {
+                return Ok(to_value(datetime.timestamp()).unwrap());
+            }
+            Ok(to_value(datetime.to_rfc3339()).unwrap())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_default() {
+        let local = Local::now();
+        let utc = local.to_utc();
+        let static_fn = Now::new(local, utc);
+        let args = HashMap::new();
+
+        let res = static_fn.call(&args).unwrap();
+        assert!(res.is_string());
+        assert!(res.as_str().unwrap().contains('T'));
+    }
+
+    #[test]
+    fn now_datetime_utc() {
+        let local = Local::now();
+        let utc = local.to_utc();
+        let static_fn = Now::new(local, utc);
+        let mut args = HashMap::new();
+        args.insert("utc".to_string(), to_value(true).unwrap());
+
+        let res = static_fn.call(&args).unwrap();
+        assert!(res.is_string());
+        let val = res.as_str().unwrap();
+        assert!(val.contains('T'));
+        assert!(val.contains("+00:00"));
+    }
+
+    #[test]
+    fn now_timestamp() {
+        let local = Local::now();
+        let utc = local.to_utc();
+        let static_fn = Now::new(local, utc);
+        let mut args = HashMap::new();
+        args.insert("timestamp".to_string(), to_value(true).unwrap());
+
+        let res = static_fn.call(&args).unwrap();
+        assert!(res.is_number());
+    }
+}

--- a/components/templates/src/global_fns/mod.rs
+++ b/components/templates/src/global_fns/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod macros;
 
+mod build_info;
 mod content;
 mod files;
 mod helpers;
@@ -8,6 +9,7 @@ mod i18n;
 mod images;
 mod load_data;
 
+pub use self::build_info::Now;
 pub use self::content::{GetPage, GetSection, GetTaxonomy, GetTaxonomyTerm, GetTaxonomyUrl};
 pub use self::files::{GetHash, GetUrl};
 pub use self::i18n::Trans;


### PR DESCRIPTION
This PR implements the same functionality as Tera, but with a single call to `chrono::Local::now()` at build time, instead of once per page. This change is non-breaking and 100% compatible with existing sites. No extra documentation should be needed if Zola's `now()` matches Tera's.
Fixes #2947.