### PR TITLE
Serve robots.txt as text/plain

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -247,6 +247,7 @@ fn in_memory_content(path: &RelativePathBuf, content: &str) -> Response<Body> {
         Some(ext) => match ext {
             "xml" => "text/xml",
             "json" => "application/json",
+            "txt" => "text/plain",
             _ => "text/html",
         },
         None => "text/html",


### PR DESCRIPTION
* [x] Are you doing the PR on the `next` branch?

Discussed at https://zola.discourse.group/t/serve-robots-txt-as-text-plain/2642 a while back - this looks like a straightforward oversight.