### PR TITLE
Correctly remove footnote-reference from summary

### DIFF
--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -531,7 +531,7 @@ Hello world
 
     #[test]
     fn strips_footnotes_in_summary() {
-        let config = Config::default_for_test();
+        let mut config = Config::default_for_test();
         let content = r#"
 +++
 +++
@@ -579,6 +579,44 @@ And here's another. [^3]
 <div class="footnote-definition" id="3"><sup class="footnote-definition-label">3</sup>
 <p>This is the third footnote.</p>
 </div>
+"##
+        );
+
+        let res = Page::parse(Path::new("hello.md"), &content, &config, &PathBuf::new());
+        assert!(res.is_ok());
+        config.markdown.bottom_footnotes = true;
+        page = res.unwrap();
+        page.render_markdown(
+            &HashMap::default(),
+            &ZOLA_TERA,
+            &config,
+            InsertAnchor::None,
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            page.summary,
+            Some("<p>This page use <sup>1.5</sup> and has footnotes, here's one. </p>\n<p>Here's another. </p>".to_string())
+        );
+        assert_eq!(
+            page.content,
+            r##"<p>This page use <sup>1.5</sup> and has footnotes, here's one. <sup class="footnote-reference" id="fr-1-1"><a href="#fn-1">1</a></sup></p>
+<p>Here's another. <sup class="footnote-reference" id="fr-2-1"><a href="#fn-2">2</a></sup></p>
+<span id="continue-reading"></span>
+<p>And here's another. <sup class="footnote-reference" id="fr-3-1"><a href="#fn-3">3</a></sup></p>
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn-1">
+<p>This is the first footnote. <a href="#fr-1-1">↩</a></p>
+</li>
+<li id="fn-2">
+<p>This is the second footnote. <a href="#fr-2-1">↩</a></p>
+</li>
+<li id="fn-3">
+<p>This is the third footnote. <a href="#fr-3-1">↩</a></p>
+</li>
+</ol>
+</section>
 "##
         );
     }

--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -38,7 +38,8 @@ static MORE_DIVIDER_RE: Lazy<Regex> = Lazy::new(|| {
 });
 
 static FOOTNOTES_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"<sup class="footnote-reference"><a href=\s*.*?>\s*.*?</a></sup>"#).unwrap()
+    Regex::new(r#"<sup class="footnote-reference"( id=\s*.*?)?><a href=\s*.*?>\s*.*?</a></sup>"#)
+        .unwrap()
 });
 
 /// Although there exists [a list of registered URI schemes][uri-schemes], a link may use arbitrary,


### PR DESCRIPTION
This commit updates and fixes the regular expression to find and delete footnote references in the pages' summaries.

fecc3cf introduces the desired behaviour.

6a2b890 broke the suppression of footnote-reference in the summary by adding an id parameter to the <sup> elements for back-reference.

Fixes #2961.

Ref: https://zola.discourse.group/t/drop-footnote-references-from-summary-if-bottom-footnotes-true/2841/2