### PR TITLE
Add option to attach `rel=external` to external links 

### DIFF
--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -240,7 +240,7 @@ impl Default for Markdown {
             external_links_target_blank: false,
             external_links_no_follow: false,
             external_links_no_referrer: false,
-            external_links_external: false,
+            external_links_external: true,
             smart_punctuation: false,
             definition_list: false,
             bottom_footnotes: false,

--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -46,6 +46,8 @@ pub struct Markdown {
     pub external_links_no_follow: bool,
     /// Whether to set rel="noreferrer" for all external links
     pub external_links_no_referrer: bool,
+    /// Whether to set rel="external" for all external links
+    pub external_links_external: bool,
     /// Whether smart punctuation is enabled (changing quotes, dashes, dots etc in their typographic form)
     pub smart_punctuation: bool,
     /// Whether parsing of definition lists is enabled
@@ -188,6 +190,7 @@ impl Markdown {
         self.external_links_target_blank
             || self.external_links_no_follow
             || self.external_links_no_referrer
+            || self.external_links_external
             || self.external_links_class.is_some()
     }
 
@@ -212,6 +215,9 @@ impl Markdown {
         if self.external_links_no_referrer {
             rel_opts.push("noreferrer");
         }
+        if self.external_links_external {
+            rel_opts.push("external");
+        }
         let rel = if rel_opts.is_empty() {
             "".to_owned()
         } else {
@@ -234,6 +240,7 @@ impl Default for Markdown {
             external_links_target_blank: false,
             external_links_no_follow: false,
             external_links_no_referrer: false,
+            external_links_external: false,
             smart_punctuation: false,
             definition_list: false,
             bottom_footnotes: false,

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -182,7 +182,7 @@ fn can_use_external_links_class() {
     config.markdown.external_links_class = None;
     config.markdown.external_links_target_blank = true;
     let body = common::render_with_config("<https://google.com>", config.clone()).unwrap().body;
-    insta::assert_snapshot!("external_link_target_blank", body);
+    insta::assert_snapshot!("external_link_no_class_and_target_blank", body);
 
     // both class and target blank
     config.markdown.external_links_class = Some("external".to_string());
@@ -194,11 +194,12 @@ fn can_use_external_links_class() {
 fn can_use_external_links_options() {
     let mut config = Config::default_for_test();
 
-    // no options
+    // default options (rel=external only)
     let body = common::render("<https://google.com>").unwrap().body;
-    insta::assert_snapshot!("external_link_no_options", body);
+    insta::assert_snapshot!("external_link_default_options", body);
 
     // target blank
+    config.markdown.external_links_external = false;
     config.markdown.external_links_target_blank = true;
     let body = common::render_with_config("<https://google.com>", config.clone()).unwrap().body;
     insta::assert_snapshot!("external_link_target_blank", body);

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -215,10 +215,17 @@ fn can_use_external_links_options() {
     let body = common::render_with_config("<https://google.com>", config.clone()).unwrap().body;
     insta::assert_snapshot!("external_link_no_referrer", body);
 
+    // external
+    config.markdown.external_links_no_referrer = false;
+    config.markdown.external_links_external = true;
+    let body = common::render_with_config("<https://google.com>", config.clone()).unwrap().body;
+    insta::assert_snapshot!("external_link_external", body);
+
     // all of them
     config.markdown.external_links_no_follow = true;
     config.markdown.external_links_target_blank = true;
     config.markdown.external_links_no_referrer = true;
+    config.markdown.external_links_external = true;
     let body = common::render_with_config("<https://google.com>", config).unwrap().body;
     insta::assert_snapshot!("external_link_all_options", body);
 }

--- a/components/markdown/tests/snapshots/img__can_add_lazy_loading_and_async_decoding.snap
+++ b/components/markdown/tests/snapshots/img__can_add_lazy_loading_and_async_decoding.snap
@@ -6,5 +6,4 @@ expression: body
 <img src="https://example.com/abc.jpg" alt="" loading="lazy" decoding="async" />
 <img src="https://example.com/abc.jpg" alt="ha&quot;h&gt;a" loading="lazy" decoding="async" />
 <img src="https://example.com/abc.jpg" alt="<strong>ha</strong><em>ha</em>" loading="lazy" decoding="async" />
-<img src="https://example.com/abc.jpg" alt="ha<a href="https://example.com">ha</a>" loading="lazy" decoding="async" /></p>
-
+<img src="https://example.com/abc.jpg" alt="ha<a rel="external" href="https://example.com">ha</a>" loading="lazy" decoding="async" /></p>

--- a/components/markdown/tests/snapshots/markdown__all_markdown_features_integration.snap
+++ b/components/markdown/tests/snapshots/markdown__all_markdown_features_integration.snap
@@ -105,8 +105,8 @@ console.log(foo(5));
 <tr><td style="text-align: right">ext</td><td style="text-align: right">extension to be used for dest files.</td></tr>
 </tbody></table>
 <h2 id="links">Links</h2>
-<p><a href="http://duckduckgo.com">link text</a></p>
-<p><a href="http://duckduckgo.com/" title="Duck duck go">link with title</a></p>
+<p><a rel="external" href="http://duckduckgo.com">link text</a></p>
+<p><a rel="external" title="Duck duck go" href="http://duckduckgo.com/">link with title</a></p>
 <h2 id="images">Images</h2>
 <p><img src="https://octodex.github.com/images/minion.png" alt="Minion" />
 <img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat" /></p>
@@ -126,4 +126,3 @@ and multiple paragraphs.</p>
 <div class="footnote-definition" id="second"><sup class="footnote-definition-label">2</sup>
 <p>Footnote text.</p>
 </div>
-

--- a/components/markdown/tests/snapshots/markdown__can_handle_heading_ids-2.snap
+++ b/components/markdown/tests/snapshots/markdown__can_handle_heading_ids-2.snap
@@ -13,7 +13,7 @@ expression: body
 <h1 id=""></h1>
 <h1 id="-1"></h1>
 <h1 id="About"><a href="https://getzola.org/about/">About</a></h1>
-<h1 id="Rust"><a href="https://rust-lang.org" title="Rust homepage">Rust</a></h1>
+<h1 id="Rust"><a rel="external" title="Rust homepage" href="https://rust-lang.org">Rust</a></h1>
 <h1 id="hi"><code>hi</code></h1>
 <h1 id="hi-1"><em>hi</em></h1>
 <h1 id="hi-2"><strong>hi</strong></h1>
@@ -22,4 +22,3 @@ expression: body
 <p>footnote</p>
 </div>
 <h1 id="classes" class="bold another">Classes</h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_handle_heading_ids.snap
+++ b/components/markdown/tests/snapshots/markdown__can_handle_heading_ids.snap
@@ -13,7 +13,7 @@ expression: body
 <h1 id=""></h1>
 <h1 id="-1"></h1>
 <h1 id="about"><a href="https://getzola.org/about/">About</a></h1>
-<h1 id="rust"><a href="https://rust-lang.org" title="Rust homepage">Rust</a></h1>
+<h1 id="rust"><a rel="external" title="Rust homepage" href="https://rust-lang.org">Rust</a></h1>
 <h1 id="hi"><code>hi</code></h1>
 <h1 id="hi-1"><em>hi</em></h1>
 <h1 id="hi-2"><strong>hi</strong></h1>
@@ -22,4 +22,3 @@ expression: body
 <p>footnote</p>
 </div>
 <h1 id="classes" class="bold another">Classes</h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_insert_anchors-2.snap
+++ b/components/markdown/tests/snapshots/markdown__can_insert_anchors-2.snap
@@ -1,12 +1,9 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 108
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <h1 id="hello">Hello<a class="zola-anchor" href="#hello" aria-label="Anchor link for: hello">🔗</a></h1>
 <h1 id="world">World<a class="zola-anchor" href="#world" aria-label="Anchor link for: world">🔗</a></h1>
 <h1 id="hello-1">Hello!<a class="zola-anchor" href="#hello-1" aria-label="Anchor link for: hello-1">🔗</a></h1>
-<h2 id="rust"><a href="https://rust-lang.org">Rust</a><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust">🔗</a></h2>
+<h2 id="rust"><a rel="external" href="https://rust-lang.org">Rust</a><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust">🔗</a></h2>
 <h1 id="hello-2">Hello*_()<a class="zola-anchor" href="#hello-2" aria-label="Anchor link for: hello-2">🔗</a></h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_insert_anchors-3.snap
+++ b/components/markdown/tests/snapshots/markdown__can_insert_anchors-3.snap
@@ -5,6 +5,5 @@ expression: body
 <h1 id="hello"><a class="zola-anchor" href="#hello" aria-label="Anchor link for: hello">Hello</a></h1>
 <h1 id="world"><a class="zola-anchor" href="#world" aria-label="Anchor link for: world">World</a></h1>
 <h1 id="hello-1"><a class="zola-anchor" href="#hello-1" aria-label="Anchor link for: hello-1">Hello!</a></h1>
-<h2 id="rust"><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust"><a href="https://rust-lang.org">Rust</a></a></h2>
+<h2 id="rust"><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust"><a rel="external" href="https://rust-lang.org">Rust</a></a></h2>
 <h1 id="hello-2"><a class="zola-anchor" href="#hello-2" aria-label="Anchor link for: hello-2">Hello*_()</a></h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_insert_anchors.snap
+++ b/components/markdown/tests/snapshots/markdown__can_insert_anchors.snap
@@ -1,12 +1,9 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 105
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <h1 id="hello"><a class="zola-anchor" href="#hello" aria-label="Anchor link for: hello">🔗</a>Hello</h1>
 <h1 id="world"><a class="zola-anchor" href="#world" aria-label="Anchor link for: world">🔗</a>World</h1>
 <h1 id="hello-1"><a class="zola-anchor" href="#hello-1" aria-label="Anchor link for: hello-1">🔗</a>Hello!</h1>
-<h2 id="rust"><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust">🔗</a><a href="https://rust-lang.org">Rust</a></h2>
+<h2 id="rust"><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust">🔗</a><a rel="external" href="https://rust-lang.org">Rust</a></h2>
 <h1 id="hello-2"><a class="zola-anchor" href="#hello-2" aria-label="Anchor link for: hello-2">🔗</a>Hello*_()</h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_make_zola_internal_links.snap
+++ b/components/markdown/tests/snapshots/markdown__can_make_zola_internal_links.snap
@@ -1,10 +1,7 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 43
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <p><a href="https://getzola.org/about/">rel link</a>
 <a href="https://getzola.org/about/#cv">rel link with anchor</a>
-<a href="https://getzola.org/about/">abs link</a></p>
-
+<a rel="external" href="https://getzola.org/about/">abs link</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_all_options.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_all_options.snap
@@ -3,4 +3,4 @@ source: components/markdown/tests/markdown.rs
 expression: body
 snapshot_kind: text
 ---
-<p><a rel="noopener nofollow noreferrer" target="_blank" href="https://google.com">https://google.com</a></p>
+<p><a rel="noopener nofollow noreferrer external" target="_blank" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_class.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_class.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
-<p><a class="external" href="https://google.com">https://google.com</a></p>
+<p><a class="external" rel="external" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_class_and_target_blank.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_class_and_target_blank.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
-<p><a class="external" rel="noopener" target="_blank" href="https://google.com">https://google.com</a></p>
+<p><a class="external" rel="noopener external" target="_blank" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_default_options.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_default_options.snap
@@ -1,0 +1,5 @@
+---
+source: components/markdown/tests/markdown.rs
+expression: body
+---
+<p><a rel="external" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_external.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_external.snap
@@ -1,0 +1,6 @@
+---
+source: components/markdown/tests/markdown.rs
+expression: body
+snapshot_kind: text
+---
+<p><a rel="external" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_no_class_and_target_blank.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_no_class_and_target_blank.snap
@@ -1,0 +1,5 @@
+---
+source: components/markdown/tests/markdown.rs
+expression: body
+---
+<p><a rel="noopener external" target="_blank" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_no_follow.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_no_follow.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
 <p><a rel="nofollow" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_no_options.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_no_options.snap
@@ -1,6 +1,0 @@
----
-source: components/markdown/tests/markdown.rs
-expression: body
-snapshot_kind: text
----
-<p><a href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_no_referrer.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_no_referrer.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
 <p><a rel="noreferrer" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_target_blank.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_target_blank.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
 <p><a rel="noopener" target="_blank" href="https://google.com">https://google.com</a></p>

--- a/components/templates/src/filters.rs
+++ b/components/templates/src/filters.rs
@@ -247,7 +247,7 @@ mod tests {
         let result = MarkdownFilter::new(config.clone(), HashMap::new(), Tera::default())
             .filter(&to_value(md).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value("<p>Hello <a rel=\"noopener\" target=\"_blank\" href=\"https://google.com\">https://google.com</a> 😄 …</p>\n").unwrap());
+        assert_eq!(result.unwrap(), to_value("<p>Hello <a rel=\"noopener external\" target=\"_blank\" href=\"https://google.com\">https://google.com</a> 😄 …</p>\n").unwrap());
 
         let md = "```py\ni=0\n```";
         let result = MarkdownFilter::new(config, HashMap::new(), Tera::default())

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -141,6 +141,9 @@ external_links_no_follow = false
 # Whether to set rel="noreferrer" for all external links
 external_links_no_referrer = false
 
+# Whether to set rel="external" for all external links
+external_links_external = false
+
 # Whether smart punctuation is enabled (changing quotes, dashes, dots in their typographic form)
 # For example, `...` into `…`, `"quote"` into `“curly”` etc
 smart_punctuation = false

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -142,7 +142,7 @@ external_links_no_follow = false
 external_links_no_referrer = false
 
 # Whether to set rel="external" for all external links
-external_links_external = false
+external_links_external = true
 
 # Whether smart punctuation is enabled (changing quotes, dashes, dots in their typographic form)
 # For example, `...` into `…`, `"quote"` into `“curly”` etc


### PR DESCRIPTION
Discussed in #2717.

It may be worth considering having it default to `true`... but I figured I would ask here, and let it be `false` at first, to avoid changing the current behaviour.

Though I would argue that this seems like a sensible default, and since we're gonna ship quite a few changes with the next release from `next`, it may be okay to introduce this "breaking" change. Just let me know!

Includes testing and documentation.

## Code changes

* [x] Are you doing the PR on the `next` branch?
* [x] Have you created/updated the relevant documentation page(s)?

