### PR TITLE
Update Vercel guide

### DIFF
--- a/docs/content/documentation/deployment/vercel.md
+++ b/docs/content/documentation/deployment/vercel.md
@@ -7,7 +7,7 @@ Vercel (previously Zeit) is similar to Netlify, making the deployment of your si
 The sites are hosted by Vercel and automatically deployed whenever we push a commit to our
 selected production branch (e.g, master).
 
-If you don't have an account with Vercel, you can sign up [here](https://vercel.com/signup).
+If you don't have an account with Vercel, you can sign up [here.](https://vercel.com/signup)
 
 ## Automatic deploys
 
@@ -15,7 +15,8 @@ Once you sign up you can import your site from a Git provider (Github, GitLab or
 When you import your repository, Vercel will try to find out what framework your site is using.
 
 If it doesn't default to Zola:
-- Set Framework Preset as **Zola**.
+
+- Set "Framework Preset" as **Zola**.
 
 By default, Vercel chooses output directory as `public`. If you use a different directory, then
 specify output directory under the "Build and Output Settings" dropdown.
@@ -31,9 +32,22 @@ release tag, for example `0.17.2`.
 
 ### `GLIBC_X.XX` not found
 
-This is because Vercel's build images comes with an older glibc version whereas Zola 
-depends on a newer glibc. However, Vercel provides a newer build image which can be used in
-deployments by setting Node.js version to "20.x", allowing Zola to work properly.
+This is because Vercel's build images doesn't come with a `glibc` version that Zola requires. 
+Vercel provides [different build images](https://vercel.com/docs/builds/build-image) for
+different Node.js versions, so even though Zola has no relation with Node.js at all, you can
+bump your Node.js version from project settings to make Vercel to use a newer build
+environment, allowing Zola to work properly.
+
+If your project was created before when the default Node.js version was `20.x`, bumping
+Node.js version to `22.x` (which is the new default) should work for Zola versions up to
+`0.19.2` (inclusive) without further configuration.
+
+Since Vercel does not provide a even newer image, subsequent versions of Zola will not work
+again when using the built-in Zola framework preset. However, starting with Zola version
+`0.21.0`, a statically linked `musl` binary being released, which provides the highest
+compatibility among systems where glibc is insufficient - like Vercel's build images. To use
+the `musl`-compiled binary, you must ensure that Vercel
+[does not use its built-in Zola preset and instead provide the binary yourself.](#using-a-custom-zola-binary)
 
 ## Additional options
 
@@ -60,8 +74,8 @@ To enable that, create a file in the root of your git repository named `vercel.j
 ### Prefer clean URLs
 
 When enabled, all HTML files will be served without their file extension. For example
-if you have an `about.md` file, Zola will generate a `about/index.html` file, but Vercel
-will serve the file as `/about`, without its `index.html` suffix.
+if you have an `about.md` file, Zola will generate a `about/index.html` file, but you may
+prefer to have Vercel to serve the file as `/about` without its `index.html` suffix.
 
 To enable that, create a file in the root of your git repository named `vercel.json`
 (if it doesn't exists already), and set this option:
@@ -74,32 +88,43 @@ To enable that, create a file in the root of your git repository named `vercel.j
 
 ### Using a custom Zola binary
 
-If you want to use your own Zola binary that published on GitHub, or if you want to
-always use the latest version of Zola, you can run a shell command to grab the
-latest release from GitHub.
-
-To do that, set "Framework Preset" to "Other", and override "Install Command" to:
+If you want to provide Zola binary on your own for full control instead of having Vercel
+to use their controlled Zola preset, set the "Framework Preset" to "Other". This will make
+Vercel to not get use of `ZOLA_VERSION` variable anymore automatically.
+Then, set "Install Command" to:
 
 ```bash
-REPO="getzola/zola"; curl -fsS https://api.github.com/repos/${REPO}/releases/latest | grep -oP '"browser_download_url": ?"\K(.+linux-gnu.tar.gz)' | xargs -n 1 curl -fsSL -o zola.tar.gz && tar -xzvf zola.tar.gz
+echo "${ZOLA_VERSION:-"latest"}" | sed '/^latest$/!s/\(.*\)/tags\/v\1/' | xargs -I% curl -fsSL "https://api.github.com/repos/getzola/zola/releases/%" | grep -oP "\"browser_download_url\": ?\"\\K(.+linux-${ZOLA_LIBC:-"musl"}\\.tar\\.gz)" | xargs curl -fsSL | tar -xz
 ```
 
-This command will fetch the latest release from GitHub, download the archive and extract it.
+This command will download Zola from the file URL obtained from GitHub API and extract it.
+This way we can continue using same `ZOLA_VERSION` environment variable name to pin to a
+specific Zola version (same as how Vercel does) - or set it to `latest` to always pull the
+latest version whenever an deployment is initiated on Vercel.
 
-Then, set "Build Command" to `./zola build`. Now Vercel will use the downloaded Zola 
-binary to build the documentation instead of using the built-in one.
+We also pull `musl` binaries by default in the command, so we no longer have to worry
+about Vercel's build images. But if you would like to use older versions (below of
+`0.21.0` where there isn't a `musl` binary provided), you need to create a new environment
+variable named `ZOLA_LIBC` and set it to `gnu`.
 
-If you prefer to use `vercel.json` instead, (which overrides the options set in the dashboard)
-you can use this configuration.
+Along with setting "Install Command" to above, you will also need to set "Build Command"
+to `./zola build`, so we can have our site built with the locally downloaded Zola binary
+previously.
+
+If you prefer to use `vercel.json` instead,
+(which overrides the options set in the dashboard) you can use this configuration:
 
 ```json
 {
     "framework": null,
-    "installCommand": "REPO=\"getzola/zola\"; curl -fsS https://api.github.com/repos/${REPO}/releases/latest | grep -oP '\"browser_download_url\": ?\"\\K(.+linux-gnu.tar.gz)' | xargs -n 1 curl -fsSL -o zola.tar.gz && tar -xzvf zola.tar.gz",
+    "installCommand": "echo \"${ZOLA_VERSION:-\"latest\"}\" | sed '/^latest$/!s/\\(.*\\)/tags\\/v\\1/' | xargs -I% curl -fsSL \"https://api.github.com/repos/getzola/zola/releases/%\" | grep -oP \"\\\"browser_download_url\\\": ?\\\"\\K(.+linux-${ZOLA_LIBC:-\"musl\"}\\\\.tar\\\\.gz)\" | xargs curl -fsSL | tar -xz",
     "buildCommand": "./zola build",
     "outputDirectory": "public"
 }
 ```
+
+You can modify the commands as your wish if you would like to use your own fork and use
+binaries released there.
 
 ## See also
 


### PR DESCRIPTION
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

---

Updated Vercel guide to recommend using a custom command for obtaining musl binary of Zola, since Vercel's own Zola preset always gets glibc version even when it couldn't run on its own due to lacking glibc version in the system image.

```bash
echo "${ZOLA_VERSION:-"latest"}" | sed '/^latest$/!s/\(.*\)/tags\/v\1/' | \
    xargs -I% curl -fsSL "https://api.github.com/repos/getzola/zola/releases/%" | \
    grep -oP "\"browser_download_url\": ?\"\\K(.+linux-${ZOLA_LIBC:-"musl"}\\.tar\\.gz)" | \
    xargs curl -fsSL | tar -xz
```

Feels hacky than ever but I couldn't get to simplify than this.

Just for the reference, Vercel has [acknowledged the issue and said working on a fix](https://community.vercel.com/t/cant-build-site-with-zola-0-21-0/20782/15) to use musl binaries onwards but I'd prefer having the command on the Zola docs anyway.