### PR TITLE
Clarify instructions on deployment on github pages

### DIFF
--- a/docs/content/documentation/deployment/github-pages.md
+++ b/docs/content/documentation/deployment/github-pages.md
@@ -32,7 +32,9 @@ Using *Github Actions* for the deployment of your Zola-Page on Github-Pages is p
 
 Let's start with the token. Remember, if you are publishing the site on the same repo, you do not need to follow that step. But you will still need to pass in the automatic `GITHUB_TOKEN` as explained [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-1-passing-the-github_token-as-an-input).
 
-For creating the token either click on [here](https://github.com/settings/tokens/new?scopes=public_repo) or go to Settings > Developer Settings > Personal access tokens. Under the *Select Scopes* section, give it *public_repo* permissions and click *Generate token*. Then copy the token, navigate to your repository and add in the Settings tab the *Secret* `TOKEN` and paste your token in it.
+For creating the token either click on [here](https://github.com/settings/tokens/new?scopes=public_repo) or go to Settings > Developer Settings > Personal access tokens. Under the *Select Scopes* section, give it *public_repo* permissions and click *Generate token*.
+
+Then copy the token, in your repository, go to Settings > Secrets and variables > Actions, and under the Secrets tab, add a new *repository secret* named `TOKEN` and paste your token in it.
 
 Next we need to create the *Github Action*. Here we can make use of the [zola-deploy-action](https://github.com/shalzz/zola-deploy-action). Go to the *Actions* tab of your repository, click on *set up a workflow yourself* to get a blank workflow file. Copy the following script into it and commit it afterwards; note that you may need to change the `github.ref` branch from `main` to `master` or similar, as the action will only run for the branch you choose.
 If you get a permissions denied error, you may need to change the workflow permissions to read and write in Settings > Actions > Workflow permissions.
@@ -73,19 +75,6 @@ posts), adapt the following `.github/workflows/main.yml` (making sure to update 
 ```yaml
 on: push
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
-    steps:
-      - name: 'checkout'
-        uses: actions/checkout@v4
-      - name: 'build'
-        uses: shalzz/zola-deploy-action@master
-        env:
-          PAGES_BRANCH: gh-pages
-          BUILD_DIR: .
-          TOKEN: ${{ secrets.TOKEN }}
-          # BUILD_ONLY: true
   build_and_deploy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
@@ -97,7 +86,7 @@ jobs:
         env:
           PAGES_BRANCH: master
           BUILD_DIR: .
-          TOKEN: ${{ secrets.PUBLIC_TOKEN }}
+          TOKEN: ${{ secrets.TOKEN }}
           REPOSITORY: username/username.github.io
 ```
 by substituting your username or organization.


### PR DESCRIPTION
# Documentation improvement

Some of the steps on how to deploy were not clear and could benefit from a little more clarity

If you agree I would actually split the github actions section in two clearly separated scenarios:
 - build and deploy on the same repository
 - build and deploy on a separate repository

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

