### PR TITLE
add taxonomy_root configuration option

### DIFF
--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -66,6 +66,9 @@ pub struct Config {
     /// If set, files from static/ will be hardlinked instead of copied to the output dir.
     pub hard_link_static: bool,
     pub taxonomies: Vec<taxonomies::TaxonomyConfig>,
+    /// Optional base path for all taxonomies. If set, all taxonomy paths will be relative to this path.
+    /// For example, if taxonomy_root is "blog" and taxonomy is "tags", the path will be /blog/tags/
+    pub taxonomy_root: Option<String>,
     /// The default author for pages.
     pub author: Option<String>,
 
@@ -410,6 +413,7 @@ impl Default for Config {
             feed_filenames: vec!["atom.xml".to_string()],
             hard_link_static: false,
             taxonomies: Vec::new(),
+            taxonomy_root: None,
             author: None,
             compile_sass: false,
             minify_html: false,

--- a/components/content/src/taxonomies.rs
+++ b/components/content/src/taxonomies.rs
@@ -67,9 +67,17 @@ impl TaxonomyTerm {
     ) -> Self {
         let item_slug = slugify_paths(name, config.slugify.taxonomies);
         let path = if lang != config.default_language {
-            format!("/{}/{}/{}/", lang, taxo_slug, item_slug)
+            if let Some(ref taxonomy_root) = config.taxonomy_root {
+                format!("/{}/{}/{}/{}/", lang, taxonomy_root, taxo_slug, item_slug)
+            } else {
+                format!("/{}/{}/{}/", lang, taxo_slug, item_slug)
+            }
         } else {
-            format!("/{}/{}/", taxo_slug, item_slug)
+            if let Some(ref taxonomy_root) = config.taxonomy_root {
+                format!("/{}/{}/{}/", taxonomy_root, taxo_slug, item_slug)
+            } else {
+                format!("/{}/{}/", taxo_slug, item_slug)
+            }
         };
         let permalink = config.make_permalink(&path);
 
@@ -166,9 +174,17 @@ impl Taxonomy {
             }
         });
         let path = if tax_found.lang != config.default_language {
-            format!("/{}/{}/", tax_found.lang, slug)
+            if let Some(ref taxonomy_root) = config.taxonomy_root {
+                format!("/{}/{}/{}/", tax_found.lang, taxonomy_root, slug)
+            } else {
+                format!("/{}/{}/", tax_found.lang, slug)
+            }
         } else {
-            format!("/{}/", slug)
+            if let Some(ref taxonomy_root) = config.taxonomy_root {
+                format!("/{}/{}/", taxonomy_root, slug)
+            } else {
+                format!("/{}/", slug)
+            }
         };
         let permalink = config.make_permalink(&path);
 
@@ -296,5 +312,42 @@ mod tests {
 
         let path = format!("{}{}", conf.base_url, "/tags/rust/");
         assert_eq!(ctx.get("current_url").and_then(|x| x.as_str()), Some(path.as_str()));
+    }
+
+    #[test]
+    fn taxonomy_path_with_taxonomy_root() {
+        let mut conf = Config::default_for_test();
+        conf.taxonomy_root = Some("blog".to_string());
+        let tax_conf = TaxonomyConfig::default();
+        let tax_found = TaxonomyFound::new("tags".into(), &conf.default_language, &tax_conf);
+        let tax = Taxonomy::new(tax_found, &conf);
+        let pages = &[];
+        let term = TaxonomyTerm::new("rust", &conf.default_language, "tags", pages, &conf);
+
+        // Verify taxonomy list path
+        assert_eq!(tax.path, "/blog/tags/");
+        assert_eq!(tax.permalink, format!("{}/blog/tags/", conf.base_url));
+
+        // Verify taxonomy term path
+        assert_eq!(term.path, "/blog/tags/rust/");
+        assert_eq!(term.permalink, format!("{}/blog/tags/rust/", conf.base_url));
+    }
+
+    #[test]
+    fn taxonomy_path_without_taxonomy_root() {
+        let conf = Config::default_for_test();
+        let tax_conf = TaxonomyConfig::default();
+        let tax_found = TaxonomyFound::new("tags".into(), &conf.default_language, &tax_conf);
+        let tax = Taxonomy::new(tax_found, &conf);
+        let pages = &[];
+        let term = TaxonomyTerm::new("rust", &conf.default_language, "tags", pages, &conf);
+
+        // Verify taxonomy list path
+        assert_eq!(tax.path, "/tags/");
+        assert_eq!(tax.permalink, format!("{}/tags/", conf.base_url));
+
+        // Verify taxonomy term path
+        assert_eq!(term.path, "/tags/rust/");
+        assert_eq!(term.permalink, format!("{}/tags/rust/", conf.base_url));
     }
 }

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -952,6 +952,10 @@ impl Site {
             components.push(taxonomy.lang.as_ref());
         }
 
+        if let Some(ref taxonomy_root) = self.config.taxonomy_root {
+            components.push(taxonomy_root.as_ref());
+        }
+
         components.push(taxonomy.slug.as_ref());
 
         let list_output =
@@ -987,9 +991,26 @@ impl Site {
 
                 if taxonomy.kind.feed {
                     let tax_path = if taxonomy.lang == self.config.default_language {
-                        PathBuf::from(format!("{}/{}", taxonomy.slug, item.slug))
+                        if let Some(ref taxonomy_root) = self.config.taxonomy_root {
+                            PathBuf::from(format!(
+                                "{}/{}/{}",
+                                taxonomy_root, taxonomy.slug, item.slug
+                            ))
+                        } else {
+                            PathBuf::from(format!("{}/{}", taxonomy.slug, item.slug))
+                        }
                     } else {
-                        PathBuf::from(format!("{}/{}/{}", taxonomy.lang, taxonomy.slug, item.slug))
+                        if let Some(ref taxonomy_root) = self.config.taxonomy_root {
+                            PathBuf::from(format!(
+                                "{}/{}/{}/{}",
+                                taxonomy.lang, taxonomy_root, taxonomy.slug, item.slug
+                            ))
+                        } else {
+                            PathBuf::from(format!(
+                                "{}/{}/{}",
+                                taxonomy.lang, taxonomy.slug, item.slug
+                            ))
+                        }
                     };
                     self.render_feeds(
                         item.pages.iter().map(|p| library.pages.get(p).unwrap()).collect(),

--- a/docs/content/documentation/content/taxonomies.md
+++ b/docs/content/documentation/content/taxonomies.md
@@ -137,4 +137,16 @@ The taxonomy pages are then available at the following paths:
 $BASE_URL/$NAME/ (taxonomy)
 $BASE_URL/$NAME/$SLUG (taxonomy entry)
 ```
+
+If you have set the `taxonomy_root` configuration option, all taxonomy paths will be prefixed with that root path:
+
+```txt
+$BASE_URL/$TAXONOMY_ROOT/$NAME/ (taxonomy)
+$BASE_URL/$TAXONOMY_ROOT/$NAME/$SLUG (taxonomy entry)
+```
+
+For example, with `taxonomy_root = "blog"` and a taxonomy named `tags` with a term `rust`:
+- Taxonomy list page: `$BASE_URL/blog/tags/`
+- Taxonomy term page: `$BASE_URL/blog/tags/rust/`
+
 Note that taxonomies are case insensitive so terms that have the same slug will get merged, e.g. sections and pages containing the tag "example" will be shown in the same taxonomy page as ones containing "Example" 

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -99,6 +99,10 @@ author =
 #
 taxonomies = []
 
+# Optional base path for all taxonomies. If set, all taxonomy paths will be relative to this path.
+# For example, if taxonomy_root is "blog" and taxonomy is "tags", the path will be /blog/tags/
+# taxonomy_root = "blog"
+
 # When set to "true", a search index is built from the pages and section
 # content for `default_language`.
 build_search_index = false


### PR DESCRIPTION
Taxonomy functionality generates pages entirely for you. It makes sense to be able to home these in specific directory outside of the rest of the content. Here we do that with the new option `taxonomy_root`.

This is lead up to the functionality requested in here. https://zola.discourse.group/t/custom-path-for-taxonomy-pages/82

----

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [ x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x ] Have you created/updated the relevant documentation page(s)?
