### PR TITLE
Update cloudflare-pages.md

### DIFF
--- a/docs/content/documentation/deployment/cloudflare-pages.md
+++ b/docs/content/documentation/deployment/cloudflare-pages.md
@@ -71,5 +71,5 @@ From within the workers & pages dash, do the following:
 And add an environment variable `UNSTABLE_PRE_BUILD`, with the following value and save.
 
 ```sh
-asdf plugin add zola https://github.com/salasrod/asdf-zola && asdf install zola 0.18.0 && asdf global zola 0.18.0
+asdf plugin add zola https://github.com/salasrod/asdf-zola && asdf install zola 0.21.0 && asdf global zola 0.21.0
 ```

--- a/docs/content/documentation/deployment/cloudflare-pages.md
+++ b/docs/content/documentation/deployment/cloudflare-pages.md
@@ -71,6 +71,6 @@ From within the workers & pages dash, do the following:
 And add an environment variable `UNSTABLE_PRE_BUILD`, with the following value and save.
 
 ```sh
-# Use zola latest binary version
-asdf plugin add zola https://github.com/salasrod/asdf-zola && asdf install zola <latest-version> && asdf global zola <latest-version>
+# Replace by the current latest version of Zola
+asdf plugin add zola https://github.com/salasrod/asdf-zola && asdf install zola <zola-latest-version> && asdf global zola <zola-latest-version>
 ```

--- a/docs/content/documentation/deployment/cloudflare-pages.md
+++ b/docs/content/documentation/deployment/cloudflare-pages.md
@@ -71,5 +71,6 @@ From within the workers & pages dash, do the following:
 And add an environment variable `UNSTABLE_PRE_BUILD`, with the following value and save.
 
 ```sh
-asdf plugin add zola https://github.com/salasrod/asdf-zola && asdf install zola 0.21.0 && asdf global zola 0.21.0
+# Use zola latest binary version
+asdf plugin add zola https://github.com/salasrod/asdf-zola && asdf install zola <latest-version> && asdf global zola <latest-version>
 ```


### PR DESCRIPTION
`atom.xml` not being generated in this version of binary. Updating the documentation so it uses the most recent version of zola in CF pages deployment with `asdf` command. See [issue](https://github.com/getzola/zola/issues/2997).


