### PR TITLE
Provide original markdown title in TOC

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rustup_toolchain }}
 
+      - name: Cargo fmt
+        run: cargo fmt --check
+
       - name: Cargo build (Native TLS)
         run: |
           cargo build --all --no-default-features --features=native-tls
@@ -54,6 +57,3 @@ jobs:
 
       - name: Cargo test
         run: cargo test --all
-
-      - name: Cargo fmt
-        run: cargo fmt --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Zig and cargo-zigbuild
         run: |
           curl -sSfL https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz | tar -xJf -
-          export PATH=$PWD/zig-linux-x86_64-0.14.0:$PATH
+          echo "$PWD/zig-linux-x86_64-0.14.0" >> $GITHUB_PATH
           cargo install --locked cargo-zigbuild
         if: ${{ endsWith(matrix.target, 'linux-musl') }}
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = https://github.com/skozlovf/Sublime-GenericConfig.git
 [submodule "sublime/syntaxes/sublime-jinja2"]
 	path = components/config/sublime/syntaxes/extra/sublime-jinja2
-	url = https://github.com/Martin819/sublime-jinja2.git
+	url = https://github.com/senekor/sublime-jinja2.git
 [submodule "sublime/syntaxes/Julia-sublime"]
 	path = components/config/sublime/syntaxes/extra/Julia-sublime
 	url = https://github.com/JuliaEditorSupport/Julia-sublime.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.22.0 (unreleased)
+
 ## 0.21.0 (2025-07-14)
 
 - Allow `github_alerts` at config.toml level

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "atty",
  "avif-parse",
  "base64",
+ "chrono",
  "csv",
  "elasticlunr-rs",
  "filetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -134,22 +134,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -435,9 +435,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -469,9 +469,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "jobserver",
  "libc",
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive 4.5.41",
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -591,11 +591,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.55"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
+checksum = "67e4efcbb5da11a92e8a609233aa1e8a7d91e38de0be865f016d14700d45a7fd"
 dependencies = [
- "clap 4.5.41",
+ "clap 4.5.43",
 ]
 
 [[package]]
@@ -1186,11 +1186,11 @@ dependencies = [
 
 [[package]]
 name = "file-id"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes 1.10.1",
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -1697,7 +1697,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1713,7 +1713,7 @@ dependencies = [
  "bytes 1.10.1",
  "futures-channel",
  "futures-util",
- "h2 0.4.11",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1760,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64",
  "bytes 1.10.1",
@@ -1776,7 +1776,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1998,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -2046,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if 1.0.1",
@@ -2275,9 +2275,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2832,7 +2832,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2954,9 +2954,9 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.9.1",
  "fsevent-sys",
@@ -3401,7 +3401,7 @@ checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64",
  "indexmap 2.10.0",
- "quick-xml 0.38.0",
+ "quick-xml 0.38.1",
  "serde",
  "time",
 ]
@@ -3571,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
+checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
 dependencies = [
  "memchr",
 ]
@@ -3604,7 +3604,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -3620,7 +3620,7 @@ dependencies = [
  "bytes 1.10.1",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -3641,7 +3641,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3693,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3839,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4003,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4021,22 +4021,22 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring",
@@ -4165,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -4302,9 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slug"
@@ -4330,6 +4330,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4713,9 +4723,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes 1.10.1",
@@ -4725,8 +4735,8 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "slab",
- "socket2",
- "windows-sys 0.52.0",
+ "socket2 0.6.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4751,9 +4761,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes 1.10.1",
  "futures-core",
@@ -5232,9 +5242,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5371,7 +5381,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -5392,10 +5402,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -5681,9 +5692,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5705,7 +5716,7 @@ dependencies = [
 name = "zola"
 version = "0.21.0"
 dependencies = [
- "clap 4.5.41",
+ "clap 4.5.43",
  "clap_complete",
  "console 0.1.0",
  "ctrlc",
@@ -5743,9 +5754,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9e525af0a6a658e031e95f14b7f889976b74a11ba0eca5a5fc9ac8a1c43a6a"
+checksum = "fc1f7e205ce79eb2da3cd71c5f55f3589785cb7c79f6a03d1c8d1491bda5d089"
 dependencies = [
  "zune-core",
 ]

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "config"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 include = ["src/**/*"]
 
 [dependencies]
-serde = {version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use errors::{bail, Result};
+use errors::{Result, bail};
 use libs::unic_langid::LanguageIdentifier;
 use serde::{Deserialize, Serialize};
 
@@ -115,7 +115,10 @@ impl Default for LanguageOptions {
 /// We want to ensure the language codes are valid ones
 pub fn validate_code(code: &str) -> Result<()> {
     if LanguageIdentifier::from_bytes(code.as_bytes()).is_err() {
-        bail!("Language `{}` is not a valid Unicode Language Identifier (see http://unicode.org/reports/tr35/#Unicode_language_identifier)", code)
+        bail!(
+            "Language `{}` is not a valid Unicode Language Identifier (see http://unicode.org/reports/tr35/#Unicode_language_identifier)",
+            code
+        )
     }
 
     Ok(())

--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -7,7 +7,7 @@ use libs::syntect::{
 };
 use serde::{Deserialize, Serialize};
 
-use errors::{bail, Result};
+use errors::{Result, bail};
 use utils::types::InsertAnchor;
 
 use crate::highlighting::{CLASS_STYLE, THEME_SET};
@@ -72,10 +72,10 @@ pub struct Markdown {
 impl Markdown {
     pub fn validate_external_links_class(&self) -> Result<()> {
         // Validate external link class doesn't contain quotes which would break HTML and aren't valid in CSS
-        if let Some(class) = &self.external_links_class {
-            if class.contains('"') || class.contains('\'') {
-                bail!("External link class '{}' cannot contain quotes", class)
-            }
+        if let Some(class) = &self.external_links_class
+            && (class.contains('"') || class.contains('\''))
+        {
+            bail!("External link class '{}' cannot contain quotes", class)
         }
         Ok(())
     }
@@ -169,14 +169,14 @@ impl Markdown {
             let theme_name = &theme.theme;
             if !THEME_SET.themes.contains_key(theme_name) {
                 // Check extra themes
-                if let Some(extra) = &*self.extra_theme_set {
-                    if !extra.themes.contains_key(theme_name) {
-                        bail!(
-                            "Can't export highlight theme {}, as it does not exist.\n\
+                if let Some(extra) = &*self.extra_theme_set
+                    && !extra.themes.contains_key(theme_name)
+                {
+                    bail!(
+                        "Can't export highlight theme {}, as it does not exist.\n\
                         Make sure it's spelled correctly, or your custom .tmTheme' is defined properly.",
-                            theme_name
-                        )
-                    }
+                        theme_name
+                    )
                 }
             }
         }

--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -46,6 +46,8 @@ pub struct Markdown {
     pub external_links_no_follow: bool,
     /// Whether to set rel="noreferrer" for all external links
     pub external_links_no_referrer: bool,
+    /// Whether to set rel="external" for all external links
+    pub external_links_external: bool,
     /// Whether smart punctuation is enabled (changing quotes, dashes, dots etc in their typographic form)
     pub smart_punctuation: bool,
     /// Whether parsing of definition lists is enabled
@@ -188,6 +190,7 @@ impl Markdown {
         self.external_links_target_blank
             || self.external_links_no_follow
             || self.external_links_no_referrer
+            || self.external_links_external
             || self.external_links_class.is_some()
     }
 
@@ -212,6 +215,9 @@ impl Markdown {
         if self.external_links_no_referrer {
             rel_opts.push("noreferrer");
         }
+        if self.external_links_external {
+            rel_opts.push("external");
+        }
         let rel = if rel_opts.is_empty() {
             "".to_owned()
         } else {
@@ -234,6 +240,7 @@ impl Default for Markdown {
             external_links_target_blank: false,
             external_links_no_follow: false,
             external_links_no_referrer: false,
+            external_links_external: true,
             smart_punctuation: false,
             definition_list: false,
             bottom_footnotes: false,

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -66,6 +66,9 @@ pub struct Config {
     /// If set, files from static/ will be hardlinked instead of copied to the output dir.
     pub hard_link_static: bool,
     pub taxonomies: Vec<taxonomies::TaxonomyConfig>,
+    /// Optional base path for all taxonomies. If set, all taxonomy paths will be relative to this path.
+    /// For example, if taxonomy_root is "blog" and taxonomy is "tags", the path will be /blog/tags/
+    pub taxonomy_root: Option<String>,
     /// The default author for pages.
     pub author: Option<String>,
 
@@ -410,6 +413,7 @@ impl Default for Config {
             feed_filenames: vec!["atom.xml".to_string()],
             hard_link_static: false,
             taxonomies: Vec::new(),
+            taxonomy_root: None,
             author: None,
             compile_sass: false,
             minify_html: false,

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -13,7 +13,7 @@ use libs::toml::Value as Toml;
 use serde::{Deserialize, Serialize};
 
 use crate::theme::Theme;
-use errors::{anyhow, bail, Result};
+use errors::{Result, anyhow, bail};
 use utils::fs::read_file;
 use utils::globs::build_ignore_glob_set;
 use utils::slugs::slugify_paths;
@@ -245,8 +245,11 @@ impl Config {
             if base_language_options == languages::LanguageOptions::default() {
                 return Ok(());
             }
-            println!("Warning: config.toml contains both default language specific information at base and under section `[languages.{}]`, \
-                which may cause merge conflicts. Please use only one to specify language specific information", self.default_language);
+            println!(
+                "Warning: config.toml contains both default language specific information at base and under section `[languages.{}]`, \
+                which may cause merge conflicts. Please use only one to specify language specific information",
+                self.default_language
+            );
             base_language_options.merge(section_language_options)?;
         }
         self.languages.insert(self.default_language.clone(), base_language_options);
@@ -335,7 +338,7 @@ impl Config {
         }
     }
 
-    pub fn serialize(&self, lang: &str) -> SerializedConfig {
+    pub fn serialize(&self, lang: &str) -> SerializedConfig<'_> {
         let options = &self.languages[lang];
 
         SerializedConfig {
@@ -384,7 +387,11 @@ pub fn merge(into: &mut Toml, from: &Toml) -> Result<()> {
         }
         _ => {
             // Trying to merge a table with something else
-            Err(anyhow!("Cannot merge config.toml with theme.toml because the following values have incompatibles types:\n- {}\n - {}", into, from))
+            Err(anyhow!(
+                "Cannot merge config.toml with theme.toml because the following values have incompatibles types:\n- {}\n - {}",
+                into,
+                from
+            ))
         }
     }
 }

--- a/components/config/src/config/search.rs
+++ b/components/config/src/config/search.rs
@@ -62,7 +62,7 @@ impl Default for Search {
 }
 
 impl Search {
-    pub fn serialize(&self) -> SerializedSearch {
+    pub fn serialize(&self) -> SerializedSearch<'_> {
         SerializedSearch { index_format: &self.index_format }
     }
 }

--- a/components/config/src/highlighting.rs
+++ b/components/config/src/highlighting.rs
@@ -41,15 +41,15 @@ pub fn resolve_syntax_and_theme<'config>(
     let theme = config.markdown.get_highlight_theme();
 
     if let Some(ref lang) = language {
-        if let Some(ref extra_syntaxes) = config.markdown.extra_syntax_set {
-            if let Some(syntax) = extra_syntaxes.find_syntax_by_token(lang) {
-                return SyntaxAndTheme {
-                    syntax,
-                    syntax_set: extra_syntaxes,
-                    theme,
-                    source: HighlightSource::Extra,
-                };
-            }
+        if let Some(ref extra_syntaxes) = config.markdown.extra_syntax_set
+            && let Some(syntax) = extra_syntaxes.find_syntax_by_token(lang)
+        {
+            return SyntaxAndTheme {
+                syntax,
+                syntax_set: extra_syntaxes,
+                theme,
+                source: HighlightSource::Extra,
+            };
         }
         // The JS syntax hangs a lot... the TS syntax is probably better anyway.
         // https://github.com/getzola/zola/issues/1241

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -5,13 +5,13 @@ mod theme;
 use std::path::Path;
 
 pub use crate::config::{
+    Config,
     languages::LanguageOptions,
     link_checker::LinkChecker,
     link_checker::LinkCheckerLevel,
     search::{IndexFormat, Search},
     slugify::Slugify,
     taxonomies::TaxonomyConfig,
-    Config,
 };
 use errors::Result;
 

--- a/components/config/src/theme.rs
+++ b/components/config/src/theme.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use libs::toml::Value as Toml;
 use serde::{Deserialize, Serialize};
 
-use errors::{bail, Context, Result};
+use errors::{Context, Result, bail};
 use utils::fs::read_file;
 
 /// Holds the data from a `theme.toml` file.
@@ -26,10 +26,10 @@ impl Theme {
 
         let mut extra = HashMap::new();
         if let Some(theme_table) = theme.as_table() {
-            if let Some(ex) = theme_table.get("extra") {
-                if ex.is_table() {
-                    extra = ex.clone().try_into().unwrap();
-                }
+            if let Some(ex) = theme_table.get("extra")
+                && ex.is_table()
+            {
+                extra = ex.clone().try_into().unwrap();
             }
         } else {
             bail!("Expected the `theme.toml` to be a TOML table")

--- a/components/console/Cargo.toml
+++ b/components/console/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "console"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 errors = { path = "../errors" }

--- a/components/content/Cargo.toml
+++ b/components/content/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "content"
 version.workspace = true
-edition = "2021"
+edition = "2024"
 
 [dependencies]
-serde = {version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 time = { version = "0.3", features = ["macros"] }
 
 errors = { path = "../errors" }
@@ -16,6 +16,8 @@ config = { path = "../config" }
 markdown = { path = "../markdown" }
 
 [dev-dependencies]
-test-case = "3"  # TODO: can we solve that usecase in src/page.rs in a simpler way? A custom macro_rules! maybe
+# TODO: can we solve that usecase in src/page.rs in a simpler way? A custom macro_rules! maybe
+test-case = "3"
+
 tempfile = "3.3.0"
 templates = { path = "../templates" }

--- a/components/content/src/file_info.rs
+++ b/components/content/src/file_info.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use errors::{bail, Result};
+use errors::{Result, bail};
 
 /// Takes a full path to a file and returns only the components after the first `content` directory
 /// Will not return the filename as last component
@@ -152,7 +152,11 @@ impl FileInfo {
         // The language code is not present in the config: typo or the user forgot to add it to the
         // config
         if !other_languages.contains(&parts[1].as_ref()) {
-            bail!("File {:?} has a language code of {} which isn't present in the config.toml `languages`", self.path, parts[1]);
+            bail!(
+                "File {:?} has a language code of {} which isn't present in the config.toml `languages`",
+                self.path,
+                parts[1]
+            );
         }
 
         self.name = parts.swap_remove(0);
@@ -167,7 +171,7 @@ impl FileInfo {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::{find_content_components, FileInfo};
+    use super::{FileInfo, find_content_components};
 
     #[test]
     fn can_find_content_components() {

--- a/components/content/src/front_matter/page.rs
+++ b/components/content/src/front_matter/page.rs
@@ -6,7 +6,7 @@ use time::format_description::well_known::Rfc3339;
 use time::macros::{format_description, time};
 use time::{Date, OffsetDateTime, PrimitiveDateTime};
 
-use errors::{bail, Result};
+use errors::{Result, bail};
 use utils::de::{fix_toml_dates, from_unknown_datetime};
 
 use crate::front_matter::split::RawFrontMatter;
@@ -75,6 +75,7 @@ pub struct PageFrontMatter {
 /// 1. an offset datetime (plain RFC3339)
 /// 2. a local datetime (RFC3339 with timezone omitted)
 /// 3. a local date (YYYY-MM-DD).
+///
 /// This tries each in order.
 fn parse_datetime(d: &str) -> Option<OffsetDateTime> {
     OffsetDateTime::parse(d, &Rfc3339)
@@ -90,16 +91,16 @@ impl PageFrontMatter {
     pub fn parse(raw: &RawFrontMatter) -> Result<PageFrontMatter> {
         let mut f: PageFrontMatter = raw.deserialize()?;
 
-        if let Some(ref slug) = f.slug {
-            if slug.is_empty() {
-                bail!("`slug` can't be empty if present")
-            }
+        if let Some(ref slug) = f.slug
+            && slug.is_empty()
+        {
+            bail!("`slug` can't be empty if present")
         }
 
-        if let Some(ref path) = f.path {
-            if path.is_empty() {
-                bail!("`path` can't be empty if present")
-            }
+        if let Some(ref path) = f.path
+            && path.is_empty()
+        {
+            bail!("`path` can't be empty if present")
         }
 
         f.extra = match fix_toml_dates(f.extra) {
@@ -117,10 +118,10 @@ impl PageFrontMatter {
             }
         }
 
-        if let Some(ref date) = f.date {
-            if f.datetime.is_none() {
-                bail!("`date` could not be parsed: {}.", date);
-            }
+        if let Some(ref date) = f.date
+            && f.datetime.is_none()
+        {
+            bail!("`date` could not be parsed: {}.", date);
         }
 
         Ok(f)

--- a/components/content/src/front_matter/section.rs
+++ b/components/content/src/front_matter/section.rs
@@ -5,8 +5,8 @@ use errors::Result;
 use utils::de::fix_toml_dates;
 use utils::types::InsertAnchor;
 
-use crate::front_matter::split::RawFrontMatter;
 use crate::SortBy;
+use crate::front_matter::split::RawFrontMatter;
 
 const DEFAULT_PAGINATE_PATH: &str = "page";
 

--- a/components/content/src/front_matter/split.rs
+++ b/components/content/src/front_matter/split.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use errors::{bail, Context, Result};
+use errors::{Context, Result, bail};
 use libs::once_cell::sync::Lazy;
 use libs::regex::Regex;
 use libs::{serde_yaml, toml};

--- a/components/content/src/library.rs
+++ b/components/content/src/library.rs
@@ -594,9 +594,11 @@ mod tests {
             ]
         );
         assert_eq!(french_wiki.ignored_pages.len(), 0);
-        assert!(&library.pages[&PathBuf::from("content/wiki/recipes/chocolate-cake.fr.md")]
-            .higher
-            .is_none());
+        assert!(
+            &library.pages[&PathBuf::from("content/wiki/recipes/chocolate-cake.fr.md")]
+                .higher
+                .is_none()
+        );
         assert_eq!(
             &library.pages[&PathBuf::from("content/wiki/recipes/chocolate-cake.fr.md")].lower,
             &Some(PathBuf::from("content/wiki/recipes/rendang.fr.md"))

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -531,7 +531,7 @@ Hello world
 
     #[test]
     fn strips_footnotes_in_summary() {
-        let config = Config::default_for_test();
+        let mut config = Config::default_for_test();
         let content = r#"
 +++
 +++
@@ -579,6 +579,44 @@ And here's another. [^3]
 <div class="footnote-definition" id="3"><sup class="footnote-definition-label">3</sup>
 <p>This is the third footnote.</p>
 </div>
+"##
+        );
+
+        let res = Page::parse(Path::new("hello.md"), &content, &config, &PathBuf::new());
+        assert!(res.is_ok());
+        config.markdown.bottom_footnotes = true;
+        page = res.unwrap();
+        page.render_markdown(
+            &HashMap::default(),
+            &ZOLA_TERA,
+            &config,
+            InsertAnchor::None,
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            page.summary,
+            Some("<p>This page use <sup>1.5</sup> and has footnotes, here's one. </p>\n<p>Here's another. </p>".to_string())
+        );
+        assert_eq!(
+            page.content,
+            r##"<p>This page use <sup>1.5</sup> and has footnotes, here's one. <sup class="footnote-reference" id="fr-1-1"><a href="#fn-1">1</a></sup></p>
+<p>Here's another. <sup class="footnote-reference" id="fr-2-1"><a href="#fn-2">2</a></sup></p>
+<span id="continue-reading"></span>
+<p>And here's another. <sup class="footnote-reference" id="fr-3-1"><a href="#fn-3">3</a></sup></p>
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn-1">
+<p>This is the first footnote. <a href="#fr-1-1">↩</a></p>
+</li>
+<li id="fn-2">
+<p>This is the second footnote. <a href="#fr-2-1">↩</a></p>
+</li>
+<li id="fn-3">
+<p>This is the third footnote. <a href="#fr-3-1">↩</a></p>
+</li>
+</ol>
+</section>
 "##
         );
     }

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -8,14 +8,14 @@ use libs::tera::{Context as TeraContext, Tera};
 
 use config::Config;
 use errors::{Context, Result};
-use markdown::{render_content, RenderContext};
+use markdown::{RenderContext, render_content};
 use utils::slugs::slugify_paths;
 use utils::table_of_contents::Heading;
-use utils::templates::{render_template, ShortcodeDefinition};
+use utils::templates::{ShortcodeDefinition, render_template};
 use utils::types::InsertAnchor;
 
 use crate::file_info::FileInfo;
-use crate::front_matter::{split_page_content, PageFrontMatter};
+use crate::front_matter::{PageFrontMatter, split_page_content};
 use crate::library::Library;
 use crate::ser::SerializingPage;
 use crate::utils::get_reading_analytics;
@@ -146,11 +146,7 @@ impl Page {
         page.path = if let Some(ref p) = page.meta.path {
             let path = p.trim();
 
-            if path.starts_with('/') {
-                path.into()
-            } else {
-                format!("/{}", path)
-            }
+            if path.starts_with('/') { path.into() } else { format!("/{}", path) }
         } else {
             let mut path = if page.file.components.is_empty() {
                 if page.file.name == "index" && page.file.colocated_path.is_none() {
@@ -269,7 +265,7 @@ impl Page {
                 path.pop();
                 path.push(filename);
                 path = path
-                    .strip_prefix(&base_path.join("content"))
+                    .strip_prefix(base_path.join("content"))
                     .expect("Should be able to stripe prefix")
                     .to_path_buf();
                 path
@@ -298,7 +294,7 @@ impl Page {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::fs::{create_dir, File};
+    use std::fs::{File, create_dir};
     use std::io::Write;
     use std::path::{Path, PathBuf};
 

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -27,7 +27,7 @@ use utils::fs::read_file;
 // A regex parsing RFC3339 date followed by {_,-} and some characters
 static RFC3339_DATE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r"^(?P<datetime>(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)([01][0-9]|2[0-3]):([0-5][0-9])))?)\s?(_|-)(?P<slug>.+$)"
+        r"^(?P<datetime>(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)([01][0-9]|2[0-3]):([0-5][0-9])))?)(\s?(_|-)(?P<slug>.+$))?"
     ).unwrap()
 });
 
@@ -124,8 +124,11 @@ impl Page {
         };
 
         if let Some(ref caps) = RFC3339_DATE.captures(&file_path_for_slug) {
-            if !config.slugify.paths_keep_dates {
-                slug_from_dated_filename = Some(caps.name("slug").unwrap().as_str().to_string());
+            if caps.name("slug").is_some() {
+                if !config.slugify.paths_keep_dates {
+                    slug_from_dated_filename =
+                        Some(caps.name("slug").unwrap().as_str().to_string());
+                }
             }
             if page.meta.date.is_none() {
                 page.meta.date = Some(caps.name("datetime").unwrap().as_str().to_string());

--- a/components/content/src/pagination.rs
+++ b/components/content/src/pagination.rs
@@ -5,13 +5,13 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use errors::{Context as ErrorContext, Result};
-use libs::tera::{to_value, Context, Tera, Value};
+use libs::tera::{Context, Tera, Value, to_value};
 use utils::templates::{check_template_fallbacks, render_template};
 
+use crate::Section;
 use crate::library::Library;
 use crate::ser::{SectionSerMode, SerializingPage, SerializingSection};
 use crate::taxonomies::{Taxonomy, TaxonomyTerm};
-use crate::Section;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum PaginationRoot<'a> {

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -5,14 +5,14 @@ use libs::tera::{Context as TeraContext, Tera};
 
 use config::Config;
 use errors::{Context, Result};
-use markdown::{render_content, RenderContext};
+use markdown::{RenderContext, render_content};
 use utils::fs::read_file;
 use utils::net::is_external_link;
 use utils::table_of_contents::Heading;
-use utils::templates::{render_template, ShortcodeDefinition};
+use utils::templates::{ShortcodeDefinition, render_template};
 
 use crate::file_info::FileInfo;
-use crate::front_matter::{split_section_content, SectionFrontMatter};
+use crate::front_matter::{SectionFrontMatter, split_section_content};
 use crate::library::Library;
 use crate::ser::{SectionSerMode, SerializingSection};
 use crate::utils::{find_related_assets, get_reading_analytics, has_anchor};
@@ -171,10 +171,10 @@ impl Section {
         self.toc = res.toc;
 
         self.external_links = res.external_links;
-        if let Some(ref redirect_to) = self.meta.redirect_to {
-            if is_external_link(redirect_to) {
-                self.external_links.push(redirect_to.to_owned());
-            }
+        if let Some(ref redirect_to) = self.meta.redirect_to
+            && is_external_link(redirect_to)
+        {
+            self.external_links.push(redirect_to.to_owned());
         }
 
         self.internal_links = res.internal_links;
@@ -237,7 +237,7 @@ impl Section {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{create_dir, create_dir_all, File};
+    use std::fs::{File, create_dir, create_dir_all};
     use std::io::Write;
     use std::path::{Path, PathBuf};
 

--- a/components/content/src/sorting.rs
+++ b/components/content/src/sorting.rs
@@ -39,11 +39,7 @@ pub fn sort_pages(pages: &[&Page], sort_by: SortBy) -> (Vec<PathBuf>, Vec<PathBu
             SortBy::None => unreachable!(),
         };
 
-        if ord == Ordering::Equal {
-            a.permalink.cmp(&b.permalink)
-        } else {
-            ord
-        }
+        if ord == Ordering::Equal { a.permalink.cmp(&b.permalink) } else { ord }
     });
 
     (

--- a/components/content/src/taxonomies.rs
+++ b/components/content/src/taxonomies.rs
@@ -67,9 +67,17 @@ impl TaxonomyTerm {
     ) -> Self {
         let item_slug = slugify_paths(name, config.slugify.taxonomies);
         let path = if lang != config.default_language {
-            format!("/{}/{}/{}/", lang, taxo_slug, item_slug)
+            if let Some(ref taxonomy_root) = config.taxonomy_root {
+                format!("/{}/{}/{}/{}/", lang, taxonomy_root, taxo_slug, item_slug)
+            } else {
+                format!("/{}/{}/{}/", lang, taxo_slug, item_slug)
+            }
         } else {
-            format!("/{}/{}/", taxo_slug, item_slug)
+            if let Some(ref taxonomy_root) = config.taxonomy_root {
+                format!("/{}/{}/{}/", taxonomy_root, taxo_slug, item_slug)
+            } else {
+                format!("/{}/{}/", taxo_slug, item_slug)
+            }
         };
         let permalink = config.make_permalink(&path);
 
@@ -166,9 +174,17 @@ impl Taxonomy {
             }
         });
         let path = if tax_found.lang != config.default_language {
-            format!("/{}/{}/", tax_found.lang, slug)
+            if let Some(ref taxonomy_root) = config.taxonomy_root {
+                format!("/{}/{}/{}/", tax_found.lang, taxonomy_root, slug)
+            } else {
+                format!("/{}/{}/", tax_found.lang, slug)
+            }
         } else {
-            format!("/{}/", slug)
+            if let Some(ref taxonomy_root) = config.taxonomy_root {
+                format!("/{}/{}/", taxonomy_root, slug)
+            } else {
+                format!("/{}/", slug)
+            }
         };
         let permalink = config.make_permalink(&path);
 
@@ -296,5 +312,42 @@ mod tests {
 
         let path = format!("{}{}", conf.base_url, "/tags/rust/");
         assert_eq!(ctx.get("current_url").and_then(|x| x.as_str()), Some(path.as_str()));
+    }
+
+    #[test]
+    fn taxonomy_path_with_taxonomy_root() {
+        let mut conf = Config::default_for_test();
+        conf.taxonomy_root = Some("blog".to_string());
+        let tax_conf = TaxonomyConfig::default();
+        let tax_found = TaxonomyFound::new("tags".into(), &conf.default_language, &tax_conf);
+        let tax = Taxonomy::new(tax_found, &conf);
+        let pages = &[];
+        let term = TaxonomyTerm::new("rust", &conf.default_language, "tags", pages, &conf);
+
+        // Verify taxonomy list path
+        assert_eq!(tax.path, "/blog/tags/");
+        assert_eq!(tax.permalink, format!("{}/blog/tags/", conf.base_url));
+
+        // Verify taxonomy term path
+        assert_eq!(term.path, "/blog/tags/rust/");
+        assert_eq!(term.permalink, format!("{}/blog/tags/rust/", conf.base_url));
+    }
+
+    #[test]
+    fn taxonomy_path_without_taxonomy_root() {
+        let conf = Config::default_for_test();
+        let tax_conf = TaxonomyConfig::default();
+        let tax_found = TaxonomyFound::new("tags".into(), &conf.default_language, &tax_conf);
+        let tax = Taxonomy::new(tax_found, &conf);
+        let pages = &[];
+        let term = TaxonomyTerm::new("rust", &conf.default_language, "tags", pages, &conf);
+
+        // Verify taxonomy list path
+        assert_eq!(tax.path, "/tags/");
+        assert_eq!(tax.permalink, format!("{}/tags/", conf.base_url));
+
+        // Verify taxonomy term path
+        assert_eq!(term.path, "/tags/rust/");
+        assert_eq!(term.permalink, format!("{}/tags/rust/", conf.base_url));
     }
 }

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -67,13 +67,13 @@ pub fn get_reading_analytics(content: &str) -> (usize, usize) {
 
     // https://help.medium.com/hc/en-us/articles/214991667-Read-time
     // 275 seems a bit too high though
-    (word_count, ((word_count + 199) / 200))
+    (word_count, word_count.div_ceil(200))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::{create_dir, File};
+    use std::fs::{File, create_dir};
 
     use config::Config;
     use tempfile::tempdir;

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -157,6 +157,7 @@ mod tests {
                 id: "1".to_string(),
                 permalink: String::new(),
                 title: String::new(),
+                title_raw: String::new(),
                 children: vec![],
             },
             Heading {
@@ -164,6 +165,7 @@ mod tests {
                 id: "1-1".to_string(),
                 permalink: String::new(),
                 title: String::new(),
+                title_raw: String::new(),
                 children: vec![],
             },
             Heading {
@@ -171,6 +173,7 @@ mod tests {
                 id: "1-1-1".to_string(),
                 permalink: String::new(),
                 title: String::new(),
+                title_raw: String::new(),
                 children: vec![],
             },
             Heading {
@@ -178,6 +181,7 @@ mod tests {
                 id: "1-2".to_string(),
                 permalink: String::new(),
                 title: String::new(),
+                title_raw: String::new(),
                 children: vec![],
             },
         ];
@@ -192,12 +196,14 @@ mod tests {
             id: "1".to_string(),
             permalink: String::new(),
             title: String::new(),
+            title_raw: String::new(),
             children: vec![
                 Heading {
                     level: 2,
                     id: "1-1".to_string(),
                     permalink: String::new(),
                     title: String::new(),
+                    title_raw: String::new(),
                     children: vec![],
                 },
                 Heading {
@@ -205,6 +211,7 @@ mod tests {
                     id: "1-1-1".to_string(),
                     permalink: String::new(),
                     title: String::new(),
+                    title_raw: String::new(),
                     children: vec![],
                 },
                 Heading {
@@ -212,6 +219,7 @@ mod tests {
                     id: "1-2".to_string(),
                     permalink: String::new(),
                     title: String::new(),
+                    title_raw: String::new(),
                     children: vec![],
                 },
             ],

--- a/components/errors/Cargo.toml
+++ b/components/errors/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "errors"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.56"

--- a/components/imageproc/Cargo.toml
+++ b/components/imageproc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imageproc"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/components/imageproc/src/format.rs
+++ b/components/imageproc/src/format.rs
@@ -1,4 +1,4 @@
-use errors::{anyhow, Result};
+use errors::{Result, anyhow};
 use std::hash::{Hash, Hasher};
 
 const QUALITY_MIN_JPEG: u8 = 1;

--- a/components/imageproc/src/helpers.rs
+++ b/components/imageproc/src/helpers.rs
@@ -3,8 +3,8 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
 
-use crate::format::Format;
 use crate::ResizeOperation;
+use crate::format::Format;
 use libs::image::DynamicImage;
 
 /// Apply image rotation based on EXIF data
@@ -31,7 +31,7 @@ pub fn fix_orientation(img: &DynamicImage, raw_metadata: Option<Vec<u8>>) -> Opt
 pub fn get_rotated_size(w: u32, h: u32, raw_metadata: Option<Vec<u8>>) -> Option<(u32, u32)> {
     // See fix_orientation for the meaning of these values.
     match get_orientation(raw_metadata)? {
-        5 | 6 | 7 | 8 => Some((h, w)),
+        5..=8 => Some((h, w)),
         _ => None,
     }
 }

--- a/components/imageproc/src/lib.rs
+++ b/components/imageproc/src/lib.rs
@@ -5,6 +5,6 @@ mod ops;
 mod processor;
 
 pub use helpers::{fix_orientation, get_rotated_size};
-pub use meta::{read_image_metadata, ImageMeta, ImageMetaResponse};
+pub use meta::{ImageMeta, ImageMetaResponse, read_image_metadata};
 pub use ops::{ResizeInstructions, ResizeOperation};
 pub use processor::{EnqueueResponse, Processor, RESIZED_SUBDIR};

--- a/components/imageproc/src/meta.rs
+++ b/components/imageproc/src/meta.rs
@@ -1,4 +1,4 @@
-use errors::{anyhow, Context, Result};
+use errors::{Context, Result, anyhow};
 use libs::avif_parse::read_avif;
 use libs::image::{ImageDecoder, ImageReader};
 use libs::image::{ImageFormat, ImageResult};
@@ -94,10 +94,7 @@ pub fn read_image_metadata<P: AsRef<Path>>(path: P) -> Result<ImageMetaResponse>
             let avif_data =
                 read_avif(&mut BufReader::new(File::open(path)?)).with_context(err_context)?;
             let meta = avif_data.primary_item_metadata()?;
-            return Ok(ImageMetaResponse::new_avif(
-                meta.max_frame_width.get(),
-                meta.max_frame_height.get(),
-            ));
+            Ok(ImageMetaResponse::new_avif(meta.max_frame_width.get(), meta.max_frame_height.get()))
         }
         _ => ImageMeta::read(path).map(ImageMetaResponse::from).with_context(err_context),
     }

--- a/components/imageproc/src/ops.rs
+++ b/components/imageproc/src/ops.rs
@@ -1,4 +1,4 @@
-use errors::{anyhow, Result};
+use errors::{Result, anyhow};
 
 /// De-serialized & sanitized arguments of `resize_image`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/components/imageproc/src/processor.rs
+++ b/components/imageproc/src/processor.rs
@@ -3,7 +3,7 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use config::Config;
-use errors::{anyhow, Context, Result};
+use errors::{Context, Result, anyhow};
 use libs::ahash::{HashMap, HashSet};
 use libs::image::codecs::avif::AvifEncoder;
 use libs::image::codecs::jpeg::JpegEncoder;
@@ -18,7 +18,7 @@ use utils::fs as ufs;
 
 use crate::format::Format;
 use crate::helpers::get_processed_filename;
-use crate::{fix_orientation, ImageMeta, ResizeInstructions, ResizeOperation};
+use crate::{ImageMeta, ResizeInstructions, ResizeOperation, fix_orientation};
 
 pub const RESIZED_SUBDIR: &str = "processed_images";
 
@@ -89,12 +89,12 @@ impl ImageOp {
                 let mut avif: Vec<u8> = Vec::new();
                 let encoder = AvifEncoder::new_with_speed_quality(&mut avif, speed, quality);
                 encoder.write_image(
-                    &img.as_bytes(),
+                    img.as_bytes(),
                     img.dimensions().0,
                     img.dimensions().1,
                     img.color().into(),
                 )?;
-                tmp_output_writer.write_all(&avif.as_bytes())?;
+                tmp_output_writer.write_all(avif.as_bytes())?;
             }
         };
 

--- a/components/libs/Cargo.toml
+++ b/components/libs/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 ahash = "0.8"
 ammonia = "4"
 atty = "0.2.11"
+avif-parse = "1.3.2"
 base64 = "0.22"
+chrono = {version = "0.4.27", default-features = false, features = ["std", "clock"]}
 csv = "1"
 elasticlunr-rs = { version = "3.0.2", features = ["da", "no", "de", "du", "es", "fi", "fr", "hu", "it", "pt", "ro", "ru", "sv", "tr", "ko"] }
 filetime = "0.2"
@@ -44,7 +46,6 @@ unicode-segmentation = "1.2"
 url = "2"
 walkdir = "2"
 webp = "0.3"
-avif-parse = "1.3.2"
 
 [features]
 # TODO: fix me, it doesn't pick up the reqwuest feature if not set as default

--- a/components/libs/Cargo.toml
+++ b/components/libs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libs"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 ahash = "0.8"
@@ -11,26 +11,47 @@ avif-parse = "1.3.2"
 base64 = "0.22"
 chrono = {version = "0.4.27", default-features = false, features = ["std", "clock"]}
 csv = "1"
-elasticlunr-rs = { version = "3.0.2", features = ["da", "no", "de", "du", "es", "fi", "fr", "hu", "it", "pt", "ro", "ru", "sv", "tr", "ko"] }
+elasticlunr-rs = { version = "3.0.2", features = [
+    "da",
+    "no",
+    "de",
+    "du",
+    "es",
+    "fi",
+    "fr",
+    "hu",
+    "it",
+    "pt",
+    "ro",
+    "ru",
+    "sv",
+    "tr",
+    "ko",
+] }
 filetime = "0.2"
 gh-emoji = "1"
 glob = "0.3"
 globset = "0.4"
-image = {version = "0.25", default-features = true, features = ["avif"]}
+image = { version = "0.25", default-features = true, features = ["avif"] }
 lexical-sort = "0.3"
 minify-html = "0.16"
 nom-bibtex = "0.5"
 num-format = "0.4"
 once_cell = "1"
 percent-encoding = "2"
-pulldown-cmark = { version = "0.13", default-features = false, features = ["html", "simd"] }
+pulldown-cmark = { version = "0.13", default-features = false, features = [
+    "html",
+    "simd",
+] }
 pulldown-cmark-escape = { version = "0.11", default-features = false }
 quickxml_to_serde = "0.6"
 rayon = "1"
 regex = "1"
 relative-path = "2"
-reqwest = { version = "0.12", default-features = false, features = ["blocking"] }
-grass = {version = "0.13", default-features = false, features = ["random"]}
+reqwest = { version = "0.12", default-features = false, features = [
+    "blocking",
+] }
+grass = { version = "0.13", default-features = false, features = ["random"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"

--- a/components/libs/src/lib.rs
+++ b/components/libs/src/lib.rs
@@ -9,6 +9,7 @@ pub use ammonia;
 pub use atty;
 pub use avif_parse;
 pub use base64;
+pub use chrono;
 pub use csv;
 pub use elasticlunr;
 pub use filetime;

--- a/components/link_checker/Cargo.toml
+++ b/components/link_checker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "link_checker"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 config = { path = "../config" }

--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -59,7 +59,7 @@ pub fn check_url(url: &str, config: &LinkChecker) -> Result {
         Ok(ref mut response) if check_anchor && has_anchor(url) => {
             let body = {
                 let mut buf: Vec<u8> = vec![];
-                response.copy_to(&mut buf).unwrap();
+                response.copy_to(&mut buf).map_err(|e| e.to_string())?;
                 match String::from_utf8(buf) {
                     Ok(s) => s,
                     Err(_) => return Err("The page didn't return valid UTF-8".to_string()),

--- a/components/link_checker/src/lib.rs
+++ b/components/link_checker/src/lib.rs
@@ -3,8 +3,8 @@ use std::result;
 use std::sync::{Arc, RwLock};
 
 use libs::once_cell::sync::Lazy;
-use libs::reqwest::header::{HeaderMap, ACCEPT};
-use libs::reqwest::{blocking::Client, StatusCode};
+use libs::reqwest::header::{ACCEPT, HeaderMap};
+use libs::reqwest::{StatusCode, blocking::Client};
 
 use config::LinkChecker;
 use errors::anyhow;
@@ -15,15 +15,15 @@ pub type Result = result::Result<StatusCode, String>;
 
 pub fn is_valid(res: &Result) -> bool {
     match res {
-        Ok(ref code) => code.is_success() || *code == StatusCode::NOT_MODIFIED,
+        Ok(code) => code.is_success() || *code == StatusCode::NOT_MODIFIED,
         Err(_) => false,
     }
 }
 
 pub fn message(res: &Result) -> String {
     match res {
-        Ok(ref code) => format!("{}", code),
-        Err(ref error) => error.clone(),
+        Ok(code) => format!("{}", code),
+        Err(error) => error.clone(),
     }
 }
 
@@ -121,7 +121,7 @@ fn check_page_for_anchor(url: &str, body: String) -> errors::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        check_page_for_anchor, check_url, has_anchor, is_valid, message, LinkChecker, LINKS,
+        LINKS, LinkChecker, check_page_for_anchor, check_url, has_anchor, is_valid, message,
     };
     use libs::reqwest::StatusCode;
 
@@ -263,8 +263,10 @@ mod tests {
         let res = check_url("https://t6l5cn9lpm.lxizfnzckd", &LinkChecker::default());
         assert!(!is_valid(&res));
         assert!(res.is_err());
-        assert!(message(&res)
-            .starts_with("error sending request for url (https://t6l5cn9lpm.lxizfnzckd/)"));
+        assert!(
+            message(&res)
+                .starts_with("error sending request for url (https://t6l5cn9lpm.lxizfnzckd/)")
+        );
     }
 
     #[test]

--- a/components/markdown/Cargo.toml
+++ b/components/markdown/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "markdown"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 include = ["src/**/*"]
 
 [dependencies]

--- a/components/markdown/benches/all.rs
+++ b/components/markdown/benches/all.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use config::Config;
 use libs::tera::Tera;
-use markdown::{render_content, RenderContext};
+use markdown::{RenderContext, render_content};
 use utils::types::InsertAnchor;
 
 const CONTENT: &str = r#"

--- a/components/markdown/src/codeblock/highlight.rs
+++ b/components/markdown/src/codeblock/highlight.rs
@@ -1,13 +1,13 @@
 use std::fmt::Write;
 
-use config::highlighting::{SyntaxAndTheme, CLASS_STYLE};
+use config::highlighting::{CLASS_STYLE, SyntaxAndTheme};
 use libs::syntect::easy::HighlightLines;
 use libs::syntect::highlighting::{Color, Theme};
 use libs::syntect::html::{
-    line_tokens_to_classed_spans, styled_line_to_highlighted_html, ClassStyle, IncludeBackground,
+    ClassStyle, IncludeBackground, line_tokens_to_classed_spans, styled_line_to_highlighted_html,
 };
 use libs::syntect::parsing::{
-    ParseState, Scope, ScopeStack, SyntaxReference, SyntaxSet, SCOPE_REPO,
+    ParseState, SCOPE_REPO, Scope, ScopeStack, SyntaxReference, SyntaxSet,
 };
 use libs::tera::escape_html;
 
@@ -210,8 +210,8 @@ impl<'config> SyntaxHighlighter<'config> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use config::highlighting::resolve_syntax_and_theme;
     use config::Config;
+    use config::highlighting::resolve_syntax_and_theme;
     use libs::syntect::util::LinesWithEndings;
 
     #[test]

--- a/components/markdown/src/codeblock/mod.rs
+++ b/components/markdown/src/codeblock/mod.rs
@@ -3,12 +3,12 @@ mod highlight;
 
 use std::ops::RangeInclusive;
 
-use errors::{bail, Result};
+use errors::{Result, bail};
 use libs::syntect::util::LinesWithEndings;
 
 use crate::codeblock::highlight::SyntaxHighlighter;
-use config::highlighting::{resolve_syntax_and_theme, HighlightSource};
 use config::Config;
+use config::highlighting::{HighlightSource, resolve_syntax_and_theme};
 pub(crate) use fence::FenceSettings;
 
 fn opening_html(

--- a/components/markdown/src/lib.rs
+++ b/components/markdown/src/lib.rs
@@ -7,8 +7,8 @@ use shortcode::{extract_shortcodes, insert_md_shortcodes};
 
 use errors::Result;
 
-use crate::markdown::markdown_to_html;
 pub use crate::markdown::Rendered;
+use crate::markdown::markdown_to_html;
 pub use context::RenderContext;
 
 pub fn render_content(content: &str, context: &RenderContext) -> Result<markdown::Rendered> {

--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -734,6 +734,8 @@ pub fn markdown_to_html(
             let start_idx = heading_ref.start_idx;
             let end_idx = heading_ref.end_idx;
             let title = get_text(&events[start_idx + 1..end_idx]);
+            let mut title_raw = String::new();
+            cmark::html::push_html(&mut title_raw, events[start_idx + 1..end_idx].iter().cloned());
 
             if heading_ref.id.is_none() {
                 heading_ref.id = Some(find_anchor(
@@ -785,6 +787,7 @@ pub fn markdown_to_html(
                 id: id.to_owned(),
                 permalink,
                 title,
+                title_raw,
                 children: Vec::new(),
             };
             headings.push(h);

--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -38,7 +38,8 @@ static MORE_DIVIDER_RE: Lazy<Regex> = Lazy::new(|| {
 });
 
 static FOOTNOTES_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"<sup class="footnote-reference"><a href=\s*.*?>\s*.*?</a></sup>"#).unwrap()
+    Regex::new(r#"<sup class="footnote-reference"( id=\s*.*?)?><a href=\s*.*?>\s*.*?</a></sup>"#)
+        .unwrap()
 });
 
 /// Although there exists [a list of registered URI schemes][uri-schemes], a link may use arbitrary,

--- a/components/markdown/src/shortcode/mod.rs
+++ b/components/markdown/src/shortcode/mod.rs
@@ -6,7 +6,7 @@ use utils::templates::{ShortcodeDefinition, ShortcodeFileType, ShortcodeInvocati
 
 mod parser;
 
-pub(crate) use parser::{parse_for_shortcodes, Shortcode, SHORTCODE_PLACEHOLDER};
+pub(crate) use parser::{SHORTCODE_PLACEHOLDER, Shortcode, parse_for_shortcodes};
 
 /// Extracts the shortcodes present in the source, check if we know them and errors otherwise
 pub fn extract_shortcodes(

--- a/components/markdown/src/shortcode/parser.rs
+++ b/components/markdown/src/shortcode/parser.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, ops::Range};
 
-use errors::{bail, Context as ErrorContext, Result};
-use libs::tera::{to_value, Context, Map, Tera, Value};
-use pest::iterators::Pair;
+use errors::{Context as ErrorContext, Result, bail};
+use libs::tera::{Context, Map, Tera, Value, to_value};
 use pest::Parser;
+use pest::iterators::Pair;
 use pest_derive::Parser;
 use utils::templates::{ShortcodeDefinition, ShortcodeFileType, ShortcodeInvocationCounter};
 
@@ -33,7 +33,11 @@ impl Shortcode {
         if let Some(def) = definitions.get(&self.name) {
             self.tera_name = def.tera_name.clone();
         } else {
-            return Err(errors::anyhow!("Found usage of a shortcode named `{}` but we do not know about. Make sure it's not a typo and that a field name `{}.{{html,md}}` exists in the `templates/shortcodes` directory.", self.name, self.name));
+            return Err(errors::anyhow!(
+                "Found usage of a shortcode named `{}` but we do not know about. Make sure it's not a typo and that a field name `{}.{{html,md}}` exists in the `templates/shortcodes` directory.",
+                self.name,
+                self.name
+            ));
         }
         for inner_sc in self.inner.iter_mut() {
             inner_sc.fill_tera_name(definitions)?;
@@ -102,11 +106,7 @@ impl Shortcode {
         }
 
         let rendered_end = sc_span.start + rendered_length;
-        let delta = if sc_span.end < rendered_end {
-            rendered_end - sc_span.end
-        } else {
-            sc_span.end - rendered_end
-        };
+        let delta = rendered_end.abs_diff(sc_span.end);
 
         if sc_span.end < rendered_end {
             self.span = (self.span.start + delta)..(self.span.end + delta);

--- a/components/markdown/tests/common.rs
+++ b/components/markdown/tests/common.rs
@@ -6,7 +6,7 @@ use libs::tera::Tera;
 
 use config::Config;
 use errors::Result;
-use markdown::{render_content, RenderContext, Rendered};
+use markdown::{RenderContext, Rendered, render_content};
 use templates::ZOLA_TERA;
 use utils::types::InsertAnchor;
 

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -182,7 +182,7 @@ fn can_use_external_links_class() {
     config.markdown.external_links_class = None;
     config.markdown.external_links_target_blank = true;
     let body = common::render_with_config("<https://google.com>", config.clone()).unwrap().body;
-    insta::assert_snapshot!("external_link_target_blank", body);
+    insta::assert_snapshot!("external_link_no_class_and_target_blank", body);
 
     // both class and target blank
     config.markdown.external_links_class = Some("external".to_string());
@@ -194,11 +194,12 @@ fn can_use_external_links_class() {
 fn can_use_external_links_options() {
     let mut config = Config::default_for_test();
 
-    // no options
+    // default options (rel=external only)
     let body = common::render("<https://google.com>").unwrap().body;
-    insta::assert_snapshot!("external_link_no_options", body);
+    insta::assert_snapshot!("external_link_default_options", body);
 
     // target blank
+    config.markdown.external_links_external = false;
     config.markdown.external_links_target_blank = true;
     let body = common::render_with_config("<https://google.com>", config.clone()).unwrap().body;
     insta::assert_snapshot!("external_link_target_blank", body);
@@ -215,10 +216,17 @@ fn can_use_external_links_options() {
     let body = common::render_with_config("<https://google.com>", config.clone()).unwrap().body;
     insta::assert_snapshot!("external_link_no_referrer", body);
 
+    // external
+    config.markdown.external_links_no_referrer = false;
+    config.markdown.external_links_external = true;
+    let body = common::render_with_config("<https://google.com>", config.clone()).unwrap().body;
+    insta::assert_snapshot!("external_link_external", body);
+
     // all of them
     config.markdown.external_links_no_follow = true;
     config.markdown.external_links_target_blank = true;
     config.markdown.external_links_no_referrer = true;
+    config.markdown.external_links_external = true;
     let body = common::render_with_config("<https://google.com>", config).unwrap().body;
     insta::assert_snapshot!("external_link_all_options", body);
 }

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use libs::tera::Tera;
 
 use config::Config;
-use markdown::{render_content, RenderContext};
+use markdown::{RenderContext, render_content};
 use templates::ZOLA_TERA;
 use utils::slugs::SlugifyStrategy;
 use utils::types::InsertAnchor;

--- a/components/markdown/tests/snapshots/img__can_add_lazy_loading_and_async_decoding.snap
+++ b/components/markdown/tests/snapshots/img__can_add_lazy_loading_and_async_decoding.snap
@@ -6,5 +6,4 @@ expression: body
 <img src="https://example.com/abc.jpg" alt="" loading="lazy" decoding="async" />
 <img src="https://example.com/abc.jpg" alt="ha&quot;h&gt;a" loading="lazy" decoding="async" />
 <img src="https://example.com/abc.jpg" alt="<strong>ha</strong><em>ha</em>" loading="lazy" decoding="async" />
-<img src="https://example.com/abc.jpg" alt="ha<a href="https://example.com">ha</a>" loading="lazy" decoding="async" /></p>
-
+<img src="https://example.com/abc.jpg" alt="ha<a rel="external" href="https://example.com">ha</a>" loading="lazy" decoding="async" /></p>

--- a/components/markdown/tests/snapshots/markdown__all_markdown_features_integration.snap
+++ b/components/markdown/tests/snapshots/markdown__all_markdown_features_integration.snap
@@ -105,8 +105,8 @@ console.log(foo(5));
 <tr><td style="text-align: right">ext</td><td style="text-align: right">extension to be used for dest files.</td></tr>
 </tbody></table>
 <h2 id="links">Links</h2>
-<p><a href="http://duckduckgo.com">link text</a></p>
-<p><a href="http://duckduckgo.com/" title="Duck duck go">link with title</a></p>
+<p><a rel="external" href="http://duckduckgo.com">link text</a></p>
+<p><a rel="external" title="Duck duck go" href="http://duckduckgo.com/">link with title</a></p>
 <h2 id="images">Images</h2>
 <p><img src="https://octodex.github.com/images/minion.png" alt="Minion" />
 <img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat" /></p>
@@ -126,4 +126,3 @@ and multiple paragraphs.</p>
 <div class="footnote-definition" id="second"><sup class="footnote-definition-label">2</sup>
 <p>Footnote text.</p>
 </div>
-

--- a/components/markdown/tests/snapshots/markdown__can_handle_heading_ids-2.snap
+++ b/components/markdown/tests/snapshots/markdown__can_handle_heading_ids-2.snap
@@ -13,7 +13,7 @@ expression: body
 <h1 id=""></h1>
 <h1 id="-1"></h1>
 <h1 id="About"><a href="https://getzola.org/about/">About</a></h1>
-<h1 id="Rust"><a href="https://rust-lang.org" title="Rust homepage">Rust</a></h1>
+<h1 id="Rust"><a rel="external" title="Rust homepage" href="https://rust-lang.org">Rust</a></h1>
 <h1 id="hi"><code>hi</code></h1>
 <h1 id="hi-1"><em>hi</em></h1>
 <h1 id="hi-2"><strong>hi</strong></h1>
@@ -22,4 +22,3 @@ expression: body
 <p>footnote</p>
 </div>
 <h1 id="classes" class="bold another">Classes</h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_handle_heading_ids.snap
+++ b/components/markdown/tests/snapshots/markdown__can_handle_heading_ids.snap
@@ -13,7 +13,7 @@ expression: body
 <h1 id=""></h1>
 <h1 id="-1"></h1>
 <h1 id="about"><a href="https://getzola.org/about/">About</a></h1>
-<h1 id="rust"><a href="https://rust-lang.org" title="Rust homepage">Rust</a></h1>
+<h1 id="rust"><a rel="external" title="Rust homepage" href="https://rust-lang.org">Rust</a></h1>
 <h1 id="hi"><code>hi</code></h1>
 <h1 id="hi-1"><em>hi</em></h1>
 <h1 id="hi-2"><strong>hi</strong></h1>
@@ -22,4 +22,3 @@ expression: body
 <p>footnote</p>
 </div>
 <h1 id="classes" class="bold another">Classes</h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_insert_anchors-2.snap
+++ b/components/markdown/tests/snapshots/markdown__can_insert_anchors-2.snap
@@ -1,12 +1,9 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 108
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <h1 id="hello">Hello<a class="zola-anchor" href="#hello" aria-label="Anchor link for: hello">🔗</a></h1>
 <h1 id="world">World<a class="zola-anchor" href="#world" aria-label="Anchor link for: world">🔗</a></h1>
 <h1 id="hello-1">Hello!<a class="zola-anchor" href="#hello-1" aria-label="Anchor link for: hello-1">🔗</a></h1>
-<h2 id="rust"><a href="https://rust-lang.org">Rust</a><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust">🔗</a></h2>
+<h2 id="rust"><a rel="external" href="https://rust-lang.org">Rust</a><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust">🔗</a></h2>
 <h1 id="hello-2">Hello*_()<a class="zola-anchor" href="#hello-2" aria-label="Anchor link for: hello-2">🔗</a></h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_insert_anchors-3.snap
+++ b/components/markdown/tests/snapshots/markdown__can_insert_anchors-3.snap
@@ -5,6 +5,5 @@ expression: body
 <h1 id="hello"><a class="zola-anchor" href="#hello" aria-label="Anchor link for: hello">Hello</a></h1>
 <h1 id="world"><a class="zola-anchor" href="#world" aria-label="Anchor link for: world">World</a></h1>
 <h1 id="hello-1"><a class="zola-anchor" href="#hello-1" aria-label="Anchor link for: hello-1">Hello!</a></h1>
-<h2 id="rust"><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust"><a href="https://rust-lang.org">Rust</a></a></h2>
+<h2 id="rust"><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust"><a rel="external" href="https://rust-lang.org">Rust</a></a></h2>
 <h1 id="hello-2"><a class="zola-anchor" href="#hello-2" aria-label="Anchor link for: hello-2">Hello*_()</a></h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_insert_anchors.snap
+++ b/components/markdown/tests/snapshots/markdown__can_insert_anchors.snap
@@ -1,12 +1,9 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 105
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <h1 id="hello"><a class="zola-anchor" href="#hello" aria-label="Anchor link for: hello">🔗</a>Hello</h1>
 <h1 id="world"><a class="zola-anchor" href="#world" aria-label="Anchor link for: world">🔗</a>World</h1>
 <h1 id="hello-1"><a class="zola-anchor" href="#hello-1" aria-label="Anchor link for: hello-1">🔗</a>Hello!</h1>
-<h2 id="rust"><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust">🔗</a><a href="https://rust-lang.org">Rust</a></h2>
+<h2 id="rust"><a class="zola-anchor" href="#rust" aria-label="Anchor link for: rust">🔗</a><a rel="external" href="https://rust-lang.org">Rust</a></h2>
 <h1 id="hello-2"><a class="zola-anchor" href="#hello-2" aria-label="Anchor link for: hello-2">🔗</a>Hello*_()</h1>
-

--- a/components/markdown/tests/snapshots/markdown__can_make_zola_internal_links.snap
+++ b/components/markdown/tests/snapshots/markdown__can_make_zola_internal_links.snap
@@ -1,10 +1,7 @@
 ---
-source: components/rendering/tests/markdown.rs
-assertion_line: 43
+source: components/markdown/tests/markdown.rs
 expression: body
-
 ---
 <p><a href="https://getzola.org/about/">rel link</a>
 <a href="https://getzola.org/about/#cv">rel link with anchor</a>
-<a href="https://getzola.org/about/">abs link</a></p>
-
+<a rel="external" href="https://getzola.org/about/">abs link</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_all_options.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_all_options.snap
@@ -3,4 +3,4 @@ source: components/markdown/tests/markdown.rs
 expression: body
 snapshot_kind: text
 ---
-<p><a rel="noopener nofollow noreferrer" target="_blank" href="https://google.com">https://google.com</a></p>
+<p><a rel="noopener nofollow noreferrer external" target="_blank" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_class.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_class.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
-<p><a class="external" href="https://google.com">https://google.com</a></p>
+<p><a class="external" rel="external" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_class_and_target_blank.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_class_and_target_blank.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
-<p><a class="external" rel="noopener" target="_blank" href="https://google.com">https://google.com</a></p>
+<p><a class="external" rel="noopener external" target="_blank" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_default_options.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_default_options.snap
@@ -1,0 +1,5 @@
+---
+source: components/markdown/tests/markdown.rs
+expression: body
+---
+<p><a rel="external" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_external.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_external.snap
@@ -3,4 +3,4 @@ source: components/markdown/tests/markdown.rs
 expression: body
 snapshot_kind: text
 ---
-<p><a href="https://google.com">https://google.com</a></p>
+<p><a rel="external" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_no_class_and_target_blank.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_no_class_and_target_blank.snap
@@ -1,0 +1,5 @@
+---
+source: components/markdown/tests/markdown.rs
+expression: body
+---
+<p><a rel="noopener external" target="_blank" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_no_follow.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_no_follow.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
 <p><a rel="nofollow" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_no_referrer.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_no_referrer.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
 <p><a rel="noreferrer" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/snapshots/markdown__external_link_target_blank.snap
+++ b/components/markdown/tests/snapshots/markdown__external_link_target_blank.snap
@@ -1,6 +1,5 @@
 ---
 source: components/markdown/tests/markdown.rs
 expression: body
-snapshot_kind: text
 ---
 <p><a rel="noopener" target="_blank" href="https://google.com">https://google.com</a></p>

--- a/components/markdown/tests/toc.rs
+++ b/components/markdown/tests/toc.rs
@@ -48,6 +48,32 @@ fn can_ignore_tags_in_toc() {
 }
 
 #[test]
+fn can_provide_raw_content() {
+    let res = common::render(
+        r#"
+## heading with `code`
+
+## **bold** and *italics*
+
+## exploring the `<details>` tag
+    "#,
+    )
+    .unwrap();
+
+    let toc = res.toc;
+    assert_eq!(toc.len(), 3);
+
+    assert_eq!(toc[0].id, "heading-with-code");
+    assert_eq!(toc[0].title_raw, "heading with <code>code</code>");
+
+    assert_eq!(toc[1].id, "bold-and-italics");
+    assert_eq!(toc[1].title_raw, "<strong>bold</strong> and <em>italics</em>");
+
+    assert_eq!(toc[2].id, "exploring-the-details-tag");
+    assert_eq!(toc[2].title_raw, "exploring the <code>&lt;details&gt;</code> tag");
+}
+
+#[test]
 fn can_make_toc_all_levels() {
     let res = common::render(
         r#"

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "search"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 errors = { path = "../errors" }

--- a/components/search/src/elasticlunr.rs
+++ b/components/search/src/elasticlunr.rs
@@ -1,9 +1,9 @@
 use config::{Config, Search};
 use content::{Library, Section};
-use errors::{bail, Result};
-use libs::elasticlunr::{lang, Index, IndexBuilder};
-use libs::time::format_description::well_known::Rfc3339;
+use errors::{Result, bail};
+use libs::elasticlunr::{Index, IndexBuilder, lang};
 use libs::time::OffsetDateTime;
+use libs::time::format_description::well_known::Rfc3339;
 
 use crate::clean_and_truncate_body;
 
@@ -58,12 +58,11 @@ fn fill_index(
         row.push(description.clone().unwrap_or_default());
     }
 
-    if search_config.include_date {
-        if let Some(date) = datetime {
-            if let Ok(d) = date.format(&Rfc3339) {
-                row.push(d);
-            }
-        }
+    if search_config.include_date
+        && let Some(date) = datetime
+        && let Ok(d) = date.format(&Rfc3339)
+    {
+        row.push(d);
     }
 
     if search_config.include_path {
@@ -115,7 +114,7 @@ fn add_section_to_index(
     if section.meta.redirect_to.is_none() {
         index.add_doc(
             &section.permalink,
-            &fill_index(
+            fill_index(
                 search_config,
                 &section.meta.title,
                 &section.meta.description,
@@ -134,7 +133,7 @@ fn add_section_to_index(
 
         index.add_doc(
             &page.permalink,
-            &fill_index(
+            fill_index(
                 search_config,
                 &page.meta.title,
                 &page.meta.description,

--- a/components/search/src/fuse.rs
+++ b/components/search/src/fuse.rs
@@ -28,11 +28,11 @@ pub fn build_index(lang: &str, library: &Library, config: &Search) -> Result<Str
             items.push(Item {
                 url: &section.permalink,
                 title: match config.include_title {
-                    true => Some(&section.meta.title.as_deref().unwrap_or_default()),
+                    true => Some(section.meta.title.as_deref().unwrap_or_default()),
                     false => None,
                 },
                 description: match config.include_description {
-                    true => Some(&section.meta.description.as_deref().unwrap_or_default()),
+                    true => Some(section.meta.description.as_deref().unwrap_or_default()),
                     false => None,
                 },
                 body: match config.include_content {
@@ -53,11 +53,11 @@ pub fn build_index(lang: &str, library: &Library, config: &Search) -> Result<Str
                     items.push(Item {
                         url: &page.permalink,
                         title: match config.include_title {
-                            true => Some(&page.meta.title.as_deref().unwrap_or_default()),
+                            true => Some(page.meta.title.as_deref().unwrap_or_default()),
                             false => None,
                         },
                         description: match config.include_description {
-                            true => Some(&page.meta.description.as_deref().unwrap_or_default()),
+                            true => Some(page.meta.description.as_deref().unwrap_or_default()),
                             false => None,
                         },
                         body: match config.include_content {

--- a/components/search/src/lib.rs
+++ b/components/search/src/lib.rs
@@ -5,7 +5,7 @@ use libs::ammonia;
 use libs::once_cell::sync::Lazy;
 use std::collections::{HashMap, HashSet};
 
-pub use elasticlunr::{build_index as build_elasticlunr, ELASTICLUNR_JS};
+pub use elasticlunr::{ELASTICLUNR_JS, build_index as build_elasticlunr};
 pub use fuse::build_index as build_fuse;
 
 static AMMONIA: Lazy<ammonia::Builder<'static>> = Lazy::new(|| {

--- a/components/search/src/lib.rs
+++ b/components/search/src/lib.rs
@@ -24,9 +24,17 @@ static AMMONIA: Lazy<ammonia::Builder<'static>> = Lazy::new(|| {
     builder
 });
 
-/// uses ammonia to clean the body, and truncates it to `truncate_content_length`
+/// Uses ammonia to clean the body, and truncates it to `truncate_content_length`.
+/// Removes extra whitespace and blank lines.
 pub fn clean_and_truncate_body(truncate_content_length: Option<usize>, body: &str) -> String {
-    let mut clean = AMMONIA.clean(body).to_string();
+    let mut clean = AMMONIA
+        .clean(body)
+        .to_string()
+        .lines()
+        .map(|l| l.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
     if let Some(new_len) = truncate_content_length {
         clean.truncate(clean.char_indices().nth(new_len).map(|(i, _)| i).unwrap_or(clean.len()))
     }
@@ -39,10 +47,13 @@ fn clean_and_truncate_body_test() {
     assert_eq!(clean_and_truncate_body(None, "hello world"), "hello world");
     assert_eq!(
         clean_and_truncate_body(None, "hello <script>alert('xss')</script> world"),
-        "hello  world"
+        "hello world"
     );
     assert_eq!(clean_and_truncate_body(Some(100), "hello"), "hello");
     assert_eq!(clean_and_truncate_body(Some(2), "hello"), "he");
     assert_eq!(clean_and_truncate_body(Some(6), "hello \u{202E} world"), "hello ");
     assert_eq!(clean_and_truncate_body(Some(7), "hello \u{202E} world"), "hello \u{202e}");
+    assert_eq!(clean_and_truncate_body(None, "hello        world"), "hello world");
+    assert_eq!(clean_and_truncate_body(None, "hello    \n    world"), "hello\nworld");
+    assert_eq!(clean_and_truncate_body(None, "\n hello  \n \n \n   world\n   "), "hello\nworld");
 }

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -2,7 +2,7 @@
 name = "site"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
-edition = "2018"
+edition = "2024"
 include = ["src/**/*"]
 
 [dependencies]

--- a/components/site/src/feeds.rs
+++ b/components/site/src/feeds.rs
@@ -38,11 +38,7 @@ pub fn render_feeds(
 
     pages.par_sort_unstable_by(|a, b| {
         let ord = b.meta.datetime.unwrap().cmp(&a.meta.datetime.unwrap());
-        if ord == Ordering::Equal {
-            a.permalink.cmp(&b.permalink)
-        } else {
-            ord
-        }
+        if ord == Ordering::Equal { a.permalink.cmp(&b.permalink) } else { ord }
     });
 
     let mut context = Context::new();

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -952,6 +952,10 @@ impl Site {
             components.push(taxonomy.lang.as_ref());
         }
 
+        if let Some(ref taxonomy_root) = self.config.taxonomy_root {
+            components.push(taxonomy_root.as_ref());
+        }
+
         components.push(taxonomy.slug.as_ref());
 
         let list_output =
@@ -987,9 +991,26 @@ impl Site {
 
                 if taxonomy.kind.feed {
                     let tax_path = if taxonomy.lang == self.config.default_language {
-                        PathBuf::from(format!("{}/{}", taxonomy.slug, item.slug))
+                        if let Some(ref taxonomy_root) = self.config.taxonomy_root {
+                            PathBuf::from(format!(
+                                "{}/{}/{}",
+                                taxonomy_root, taxonomy.slug, item.slug
+                            ))
+                        } else {
+                            PathBuf::from(format!("{}/{}", taxonomy.slug, item.slug))
+                        }
                     } else {
-                        PathBuf::from(format!("{}/{}/{}", taxonomy.lang, taxonomy.slug, item.slug))
+                        if let Some(ref taxonomy_root) = self.config.taxonomy_root {
+                            PathBuf::from(format!(
+                                "{}/{}/{}/{}",
+                                taxonomy.lang, taxonomy_root, taxonomy.slug, item.slug
+                            ))
+                        } else {
+                            PathBuf::from(format!(
+                                "{}/{}/{}",
+                                taxonomy.lang, taxonomy.slug, item.slug
+                            ))
+                        }
                     };
                     self.render_feeds(
                         item.pages.iter().map(|p| library.pages.get(p).unwrap()).collect(),

--- a/components/site/src/link_checking.rs
+++ b/components/site/src/link_checking.rs
@@ -7,7 +7,7 @@ use libs::globset::GlobSet;
 use libs::rayon::prelude::*;
 
 use crate::Site;
-use errors::{bail, Result};
+use errors::{Result, bail};
 use libs::rayon;
 use libs::url::Url;
 use utils::anchors::is_special_anchor;
@@ -113,13 +113,13 @@ fn should_skip_by_file(file_path: &Path, glob_set: &GlobSet) -> bool {
 }
 
 fn get_link_domain(link: &str) -> Result<String> {
-    return match Url::parse(link) {
+    match Url::parse(link) {
         Ok(url) => match url.host_str().map(String::from) {
             Some(domain_str) => Ok(domain_str),
             None => bail!("could not parse domain `{}` from link", link),
         },
         Err(err) => bail!("could not parse domain `{}` from link: `{}`", link, err),
-    };
+    }
 }
 
 /// Checks all external links and returns all the errors that were encountered.

--- a/components/site/src/minify.rs
+++ b/components/site/src/minify.rs
@@ -1,5 +1,5 @@
-use errors::{bail, Result};
-use libs::minify_html::{minify, Cfg};
+use errors::{Result, bail};
+use libs::minify_html::{Cfg, minify};
 
 pub fn html(html: String) -> Result<String> {
     let mut cfg = Cfg::new();

--- a/components/site/src/sass.rs
+++ b/components/site/src/sass.rs
@@ -2,11 +2,11 @@ use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 
 use libs::globset::Glob;
-use libs::grass::{from_path as compile_file, Options, OutputStyle};
+use libs::grass::{Options, OutputStyle, from_path as compile_file};
 use libs::walkdir::{DirEntry, WalkDir};
 
 use crate::anyhow;
-use errors::{bail, Result};
+use errors::{Result, bail};
 use utils::fs::{create_directory, create_file};
 
 pub fn compile_sass(base_path: &Path, output_path: &Path) -> Result<()> {

--- a/components/site/src/sitemap.rs
+++ b/components/site/src/sitemap.rs
@@ -44,7 +44,7 @@ impl<'a> SitemapEntry<'a> {
 
 impl<'a> PartialOrd for SitemapEntry<'a> {
     fn partial_cmp(&self, other: &SitemapEntry) -> Option<Ordering> {
-        Some(self.permalink.as_ref().cmp(other.permalink.as_ref()))
+        Some(self.cmp(other))
     }
 }
 
@@ -82,13 +82,13 @@ pub fn find_entries<'a>(
             entries.insert(entry);
         }
 
-        if let Some(paginate_by) = s.paginate_by() {
-            if !config.should_exclude_paginated_pages_in_sitemap() {
-                let number_pagers = (s.pages.len() as f64 / paginate_by as f64).ceil() as isize;
-                for i in 1..=number_pagers {
-                    let permalink = format!("{}{}/{}/", s.permalink, s.meta.paginate_path, i);
-                    entries.insert(SitemapEntry::new(Cow::Owned(permalink), &None));
-                }
+        if let Some(paginate_by) = s.paginate_by()
+            && !config.should_exclude_paginated_pages_in_sitemap()
+        {
+            let number_pagers = (s.pages.len() as f64 / paginate_by as f64).ceil() as isize;
+            for i in 1..=number_pagers {
+                let permalink = format!("{}{}/{}/", s.permalink, s.meta.paginate_path, i);
+                entries.insert(SitemapEntry::new(Cow::Owned(permalink), &None));
             }
         }
     }

--- a/components/site/src/tpls.rs
+++ b/components/site/src/tpls.rs
@@ -61,6 +61,11 @@ pub fn register_early_global_fns(site: &mut Site) -> TeraResult<()> {
             site.output_path.clone(),
         ),
     );
+    {
+        let local = libs::chrono::Local::now();
+        let utc = local.to_utc();
+        site.tera.register_function("now", global_fns::Now::new(local, utc));
+    }
     site.tera.register_filter(
         "markdown",
         filters::MarkdownFilter::new(

--- a/components/site/tests/common.rs
+++ b/components/site/tests/common.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use path_slash::PathExt;
 use site::Site;
 use std::ffi::OsStr;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 
 // 2 helper macros to make all the build testing more bearable
 #[macro_export]
@@ -46,7 +46,7 @@ pub fn build_site(name: &str) -> (Site, TempDir, PathBuf) {
     site.load().unwrap();
     let tmp_dir = tempdir().expect("create temp dir");
     let public = &tmp_dir.path().join("public");
-    site.set_output_path(&public);
+    site.set_output_path(public);
     site.build().expect("Couldn't build the site");
     (site, tmp_dir, public.clone())
 }
@@ -66,7 +66,7 @@ where
     }
     let tmp_dir = tempdir().expect("create temp dir");
     let public = &tmp_dir.path().join("public");
-    site.set_output_path(&public);
+    site.set_output_path(public);
     site.build().expect("Couldn't build the site");
     (site, tmp_dir, public.clone())
 }
@@ -94,7 +94,7 @@ fn find_lang_for(entry: &Path, base_dir: &Path) -> Option<(String, Option<String
         let mut unified_path = no_ext.clone();
         unified_path.pop();
         // Readd stem with .md added
-        unified_path.push(&format!("{}.md", stem.unwrap().to_str().unwrap()));
+        unified_path.push(format!("{}.md", stem.unwrap().to_str().unwrap()));
         let unified_path_str = match unified_path.strip_prefix(base_dir) {
             Ok(path_without_prefix) => path_without_prefix.to_slash_lossy(),
             _ => unified_path.to_slash_lossy(),

--- a/components/site/tests/invalid.rs
+++ b/components/site/tests/invalid.rs
@@ -13,6 +13,9 @@ fn errors_on_index_md_page_in_section() {
     let res = site.load();
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert!(format!("{:?}", err)
-        .contains("We can't have a page called `index.md` in the same folder as an index section"));
+    assert!(
+        format!("{:?}", err).contains(
+            "We can't have a page called `index.md` in the same folder as an index section"
+        )
+    );
 }

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -8,8 +8,8 @@ use common::{build_site, build_site_with_setup};
 use config::TaxonomyConfig;
 use content::Page;
 use libs::ahash::AHashMap;
-use site::sitemap;
 use site::Site;
+use site::sitemap;
 use utils::types::InsertAnchor;
 
 #[test]
@@ -827,8 +827,11 @@ fn can_ignore_markdown_content() {
 #[test]
 fn can_cachebust_static_files() {
     let (_, _tmp_dir, public) = build_site("test_site");
-    assert!(file_contains!(public, "index.html",
-        "<link href=\"https://replace-this-with-your-url.com/site.css?h=83bd983e8899946ee33d\" rel=\"stylesheet\">"));
+    assert!(file_contains!(
+        public,
+        "index.html",
+        "<link href=\"https://replace-this-with-your-url.com/site.css?h=83bd983e8899946ee33d\" rel=\"stylesheet\">"
+    ));
 }
 
 #[test]
@@ -934,7 +937,7 @@ fn can_find_site_and_page_authors() {
 
     // Only the first page has had an author added.
     assert_eq!(1, p1.meta.authors.len());
-    assert_eq!("page@example.com (Page Author)", p1.meta.authors.get(0).unwrap());
+    assert_eq!("page@example.com (Page Author)", p1.meta.authors.first().unwrap());
     assert_eq!(0, p2.meta.authors.len());
 }
 

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "templates"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 errors = { path = "../errors" }

--- a/components/templates/src/filters.rs
+++ b/components/templates/src/filters.rs
@@ -247,7 +247,7 @@ mod tests {
         let result = MarkdownFilter::new(config.clone(), HashMap::new(), Tera::default())
             .filter(&to_value(md).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value("<p>Hello <a rel=\"noopener\" target=\"_blank\" href=\"https://google.com\">https://google.com</a> 😄 …</p>\n").unwrap());
+        assert_eq!(result.unwrap(), to_value("<p>Hello <a rel=\"noopener external\" target=\"_blank\" href=\"https://google.com\">https://google.com</a> 😄 …</p>\n").unwrap());
 
         let md = "```py\ni=0\n```";
         let result = MarkdownFilter::new(config, HashMap::new(), Tera::default())

--- a/components/templates/src/global_fns/build_info.rs
+++ b/components/templates/src/global_fns/build_info.rs
@@ -1,4 +1,4 @@
-use libs::tera::{from_value, to_value, Function as TeraFn, Result, Value};
+use libs::tera::{Function as TeraFn, Result, Value, from_value, to_value};
 
 use libs::chrono::prelude::*;
 use std::collections::HashMap;

--- a/components/templates/src/global_fns/build_info.rs
+++ b/components/templates/src/global_fns/build_info.rs
@@ -1,0 +1,103 @@
+use libs::tera::{from_value, to_value, Function as TeraFn, Result, Value};
+
+use libs::chrono::prelude::*;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Now {
+    local: DateTime<Local>,
+    utc: DateTime<Utc>,
+}
+
+impl Now {
+    pub fn new(local: DateTime<Local>, utc: DateTime<Utc>) -> Self {
+        Self { local, utc }
+    }
+}
+
+impl TeraFn for Now {
+    fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
+        let use_utc = match args.get("utc") {
+            Some(val) => match from_value::<bool>(val.clone()) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(format!(
+                        "Function `now` received utc={val} but `utc` can only be a boolean"
+                    )
+                    .into());
+                }
+            },
+            None => false,
+        };
+        let timestamp = match args.get("timestamp") {
+            Some(val) => match from_value::<bool>(val.clone()) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(format!(
+                            "Function `now` received timestamp={val} but `timestamp` can only be a boolean"
+                    )
+                    .into());
+                }
+            },
+            None => false,
+        };
+
+        if use_utc {
+            let datetime = self.utc;
+            if timestamp {
+                return Ok(to_value(datetime.timestamp()).unwrap());
+            }
+            Ok(to_value(datetime.to_rfc3339()).unwrap())
+        } else {
+            let datetime = self.local;
+            if timestamp {
+                return Ok(to_value(datetime.timestamp()).unwrap());
+            }
+            Ok(to_value(datetime.to_rfc3339()).unwrap())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_default() {
+        let local = Local::now();
+        let utc = local.to_utc();
+        let static_fn = Now::new(local, utc);
+        let args = HashMap::new();
+
+        let res = static_fn.call(&args).unwrap();
+        assert!(res.is_string());
+        assert!(res.as_str().unwrap().contains('T'));
+    }
+
+    #[test]
+    fn now_datetime_utc() {
+        let local = Local::now();
+        let utc = local.to_utc();
+        let static_fn = Now::new(local, utc);
+        let mut args = HashMap::new();
+        args.insert("utc".to_string(), to_value(true).unwrap());
+
+        let res = static_fn.call(&args).unwrap();
+        assert!(res.is_string());
+        let val = res.as_str().unwrap();
+        assert!(val.contains('T'));
+        assert!(val.contains("+00:00"));
+    }
+
+    #[test]
+    fn now_timestamp() {
+        let local = Local::now();
+        let utc = local.to_utc();
+        let static_fn = Now::new(local, utc);
+        let mut args = HashMap::new();
+        args.insert("timestamp".to_string(), to_value(true).unwrap());
+
+        let res = static_fn.call(&args).unwrap();
+        assert!(res.is_number());
+    }
+}

--- a/components/templates/src/global_fns/content.rs
+++ b/components/templates/src/global_fns/content.rs
@@ -1,10 +1,10 @@
 use content::{Library, Taxonomy, TaxonomyTerm};
-use libs::tera::{from_value, to_value, Function as TeraFn, Result, Value};
+use libs::tera::{Function as TeraFn, Result, Value, from_value, to_value};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
-use utils::slugs::{slugify_paths, SlugifyStrategy};
+use utils::slugs::{SlugifyStrategy, slugify_paths};
 
 #[derive(Debug)]
 pub struct GetTaxonomyUrl {
@@ -72,7 +72,7 @@ impl TeraFn for GetTaxonomyUrl {
     }
 }
 
-fn add_lang_to_path<'a>(path: &str, lang: &str) -> Result<Cow<'a, String>> {
+fn add_lang_to_path<'a>(path: &str, lang: &str) -> Result<Cow<'a, str>> {
     match path.rfind('.') {
         Some(period_offset) => {
             let prefix = path.get(0..period_offset);
@@ -88,15 +88,15 @@ fn add_lang_to_path<'a>(path: &str, lang: &str) -> Result<Cow<'a, String>> {
 }
 
 fn get_path_with_lang<'a>(
-    path: &'a String,
-    lang: &Option<String>,
+    path: &'a str,
+    lang: Option<&str>,
     default_lang: &str,
     supported_languages: &[String],
-) -> Result<Cow<'a, String>> {
+) -> Result<Cow<'a, str>> {
     if supported_languages.contains(&default_lang.to_string()) {
         lang.as_ref().map_or_else(
             || Ok(Cow::Borrowed(path)),
-            |lang_code| match default_lang == lang_code {
+            |&lang_code| match default_lang == lang_code {
                 true => Ok(Cow::Borrowed(path)),
                 false => add_lang_to_path(path, lang_code),
             },
@@ -139,8 +139,8 @@ impl TeraFn for GetPage {
         let lang =
             optional_arg!(String, args.get("lang"), "`get_section`: `lang` must be a string");
 
-        get_path_with_lang(&path, &lang, &self.default_lang, &self.supported_languages).and_then(
-            |path_with_lang| {
+        get_path_with_lang(&path, lang.as_deref(), &self.default_lang, &self.supported_languages)
+            .and_then(|path_with_lang| {
                 let full_path = self.base_path.join(path_with_lang.as_ref());
                 let library = self.library.read().unwrap();
 
@@ -154,8 +154,7 @@ impl TeraFn for GetPage {
                         None => Err(format!("Page `{}` not found.", path).into()),
                     },
                 }
-            },
-        )
+            })
     }
 }
 
@@ -191,34 +190,38 @@ impl TeraFn for GetSection {
 
         let metadata_only = args
             .get("metadata_only")
-            .map_or(false, |c| from_value::<bool>(c.clone()).unwrap_or(false));
+            .is_some_and(|c| from_value::<bool>(c.clone()).unwrap_or(false));
 
         let lang =
             optional_arg!(String, args.get("lang"), "`get_section`: `lang` must be a string");
 
-        get_path_with_lang(&path, &lang, self.default_lang.as_str(), &self.supported_languages)
-            .and_then(|path_with_lang| {
-                let full_path = self.base_path.join(path_with_lang.as_ref());
-                let library = self.library.read().unwrap();
+        get_path_with_lang(
+            &path,
+            lang.as_deref(),
+            self.default_lang.as_str(),
+            &self.supported_languages,
+        )
+        .and_then(|path_with_lang| {
+            let full_path = self.base_path.join(path_with_lang.as_ref());
+            let library = self.library.read().unwrap();
 
-                match library.sections.get(&full_path) {
-                    Some(s) => {
-                        if metadata_only {
-                            Ok(to_value(s.serialize_basic(&library)).unwrap())
-                        } else {
-                            Ok(to_value(s.serialize(&library)).unwrap())
-                        }
+            match library.sections.get(&full_path) {
+                Some(s) => {
+                    if metadata_only {
+                        Ok(to_value(s.serialize_basic(&library)).unwrap())
+                    } else {
+                        Ok(to_value(s.serialize(&library)).unwrap())
                     }
-                    None => match lang {
-                        Some(lang_code) => Err(format!(
-                            "Section `{}` not found for language `{}`.",
-                            path, lang_code
-                        )
-                        .into()),
-                        None => Err(format!("Section `{}` not found.", path).into()),
-                    },
                 }
-            })
+                None => match lang {
+                    Some(lang_code) => {
+                        Err(format!("Section `{}` not found for language `{}`.", path, lang_code)
+                            .into())
+                    }
+                    None => Err(format!("Section `{}` not found.", path).into()),
+                },
+            }
+        })
     }
 }
 
@@ -544,8 +547,7 @@ mod tests {
             Value::String("programming".to_string())
         );
         assert_eq!(
-            res_obj["items"].clone().as_array().unwrap()[0].clone().as_object().unwrap()
-                ["permalink"],
+            res_obj["items"].clone().as_array().unwrap()[0].clone().as_object().unwrap()["permalink"],
             Value::String("http://a-website.com/tags/programming/".to_string())
         );
         assert_eq!(

--- a/components/templates/src/global_fns/files.rs
+++ b/components/templates/src/global_fns/files.rs
@@ -6,15 +6,16 @@ use std::path::PathBuf;
 use crate::global_fns::helpers::search_for_file;
 use config::Config;
 
-use libs::base64::engine::{general_purpose::STANDARD as standard_b64, Engine};
-use libs::sha2::{digest, Sha256, Sha384, Sha512};
-use libs::tera::{from_value, to_value, Function as TeraFn, Result, Value};
+use libs::base64::engine::{Engine, general_purpose::STANDARD as standard_b64};
+use libs::sha2::{Sha256, Sha384, Sha512, digest};
+use libs::tera::{Function as TeraFn, Result, Value, from_value, to_value};
 use utils::site::resolve_internal_link;
 
-fn compute_hash<D: digest::Digest>(data: &[u8], as_base64: bool) -> String
+fn compute_hash<D>(data: &[u8], as_base64: bool) -> String
 where
-    digest::Output<D>: core::fmt::LowerHex,
     D: std::io::Write,
+    D: digest::Digest,
+    digest::Output<D>: core::fmt::LowerHex,
 {
     let mut hasher = D::new();
     hasher.update(data);
@@ -85,10 +86,7 @@ impl TeraFn for GetUrl {
 
         // if it starts with @/, resolve it as an internal link
         if path.starts_with("@/") {
-            let path_with_lang = match make_path_with_lang(path, &lang, &self.config) {
-                Ok(x) => x,
-                Err(e) => return Err(e),
-            };
+            let path_with_lang = make_path_with_lang(path, &lang, &self.config)?;
 
             match resolve_internal_link(&path_with_lang, &self.permalinks) {
                 Ok(resolved) => Ok(to_value(resolved.permalink).unwrap()),
@@ -140,7 +138,7 @@ impl TeraFn for GetUrl {
                             "`get_url`: Could not find or open file {}",
                             path_with_lang
                         )
-                        .into())
+                        .into());
                     }
                 };
             }
@@ -251,8 +249,8 @@ mod tests {
     use std::fs::{copy, create_dir};
     use std::path::PathBuf;
 
-    use libs::tera::{to_value, Function};
-    use tempfile::{tempdir, TempDir};
+    use libs::tera::{Function, to_value};
+    use tempfile::{TempDir, tempdir};
 
     use config::Config;
     use utils::fs::create_file;
@@ -526,7 +524,7 @@ title = "A title"
         assert_eq!(
             static_fn.call(&args).unwrap(),
             "141c09bd28899773b772bbe064d8b718fa1d6f2852b7eafd5ed6689d26b74883b79e2e814cd69d5b52ab476aa284c414"
-            );
+        );
     }
 
     #[test]
@@ -603,7 +601,7 @@ title = "A title"
         assert_eq!(
             static_fn.call(&args).unwrap(),
             "99514329186b2f6ae4a1329e7ee6c610a729636335174ac6b740f9028396fcc803d0e93863a7c3d90f86beee782f4f3f"
-            );
+        );
     }
 
     #[test]

--- a/components/templates/src/global_fns/helpers.rs
+++ b/components/templates/src/global_fns/helpers.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
-use errors::{bail, Result};
+use errors::{Result, bail};
 use utils::fs::is_path_in_directory;
 
 /// This is used by a few Tera functions to search for files on the filesystem.
@@ -11,6 +11,7 @@ use utils::fs::is_path_in_directory;
 /// 3. base_path + content + path
 /// 4. base_path + {output dir} + path
 /// 5. base_path + themes + {current_theme} + static + path
+///
 /// A path starting with @/ will replace it with `content/` and a path starting with `/` will have
 /// it removed.
 /// It also returns the unified path so it can be used as unique hash for a given file.
@@ -51,9 +52,5 @@ pub fn search_for_file(
         }
     }
 
-    if file_exists {
-        Ok(Some((file_path, actual_path.into_owned())))
-    } else {
-        Ok(None)
-    }
+    if file_exists { Ok(Some((file_path, actual_path.into_owned()))) } else { Ok(None) }
 }

--- a/components/templates/src/global_fns/i18n.rs
+++ b/components/templates/src/global_fns/i18n.rs
@@ -1,4 +1,4 @@
-use libs::tera::{from_value, to_value, Error, Function as TeraFn, Result, Value};
+use libs::tera::{Error, Function as TeraFn, Result, Value, from_value, to_value};
 
 use config::Config;
 use std::collections::HashMap;

--- a/components/templates/src/global_fns/images.rs
+++ b/components/templates/src/global_fns/images.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use libs::tera::{from_value, to_value, Function as TeraFn, Result, Value};
+use libs::tera::{Function as TeraFn, Result, Value, from_value, to_value};
 
 use crate::global_fns::helpers::search_for_file;
 
@@ -142,10 +142,10 @@ mod tests {
     use std::fs::{copy, create_dir_all};
 
     use config::Config;
-    use libs::tera::{to_value, Function};
+    use libs::tera::{Function, to_value};
     use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
 
     fn create_dir_with_image() -> TempDir {
         let dir = tempdir().unwrap();

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -1,15 +1,15 @@
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use libs::csv::Reader;
-use libs::reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
+use libs::reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use libs::reqwest::{blocking::Client, header};
 use libs::tera::{
-    from_value, to_value, Error, Error as TeraError, Function as TeraFn, Map, Result, Value,
+    Error, Error as TeraError, Function as TeraFn, Map, Result, Value, from_value, to_value,
 };
 use libs::url::Url;
 use libs::{nom_bibtex, serde_json, serde_yaml, toml};
@@ -267,10 +267,7 @@ impl TeraFn for LoadData {
         );
 
         let method = match method_arg {
-            Some(ref method_str) => match Method::from_str(method_str) {
-                Ok(m) => m,
-                Err(e) => return Err(e),
-            },
+            Some(ref method_str) => Method::from_str(method_str)?,
             _ => Method::Get,
         };
         let headers = optional_arg!(
@@ -578,7 +575,7 @@ mod tests {
 
     use crate::global_fns::load_data::Method;
     use libs::serde_json::json;
-    use libs::tera::{self, to_value, Function};
+    use libs::tera::{self, Function, to_value};
     use std::fs::{copy, create_dir_all};
     use tempfile::tempdir;
 
@@ -601,10 +598,12 @@ mod tests {
         args.insert("method".to_string(), to_value("illegalmethod").unwrap());
         let result = static_fn.call(&args);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("`load_data` method must either be POST or GET."));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("`load_data` method must either be POST or GET.")
+        );
     }
 
     #[test]

--- a/components/templates/src/global_fns/mod.rs
+++ b/components/templates/src/global_fns/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod macros;
 
+mod build_info;
 mod content;
 mod files;
 mod helpers;
@@ -8,6 +9,7 @@ mod i18n;
 mod images;
 mod load_data;
 
+pub use self::build_info::Now;
 pub use self::content::{GetPage, GetSection, GetTaxonomy, GetTaxonomyTerm, GetTaxonomyUrl};
 pub use self::files::{GetHash, GetUrl};
 pub use self::i18n::Trans;

--- a/components/templates/src/lib.rs
+++ b/components/templates/src/lib.rs
@@ -7,7 +7,7 @@ use config::Config;
 use libs::once_cell::sync::Lazy;
 use libs::tera::{Context, Tera};
 
-use errors::{bail, Context as ErrorContext, Result};
+use errors::{Context as ErrorContext, Result, bail};
 use utils::templates::rewrite_theme_paths;
 
 pub static ZOLA_TERA: Lazy<Tera> = Lazy::new(|| {

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "utils"
 version = "0.1.0"
 authors = ["Vincent Prouillet <prouillet.vincent@gmail.com>"]
-edition = "2018"
+edition = "2024"
 include = ["src/**/*"]
 
 [dependencies]

--- a/components/utils/src/anchors.rs
+++ b/components/utils/src/anchors.rs
@@ -1,5 +1,5 @@
-use libs::regex::escape;
 use libs::regex::Regex;
+use libs::regex::escape;
 
 pub fn has_anchor_id(content: &str, anchor: &str) -> bool {
     let checks = anchor_id_checks(anchor);

--- a/components/utils/src/de.rs
+++ b/components/utils/src/de.rs
@@ -1,5 +1,5 @@
 use core::convert::TryFrom;
-use errors::{anyhow, Result};
+use errors::{Result, anyhow};
 use libs::regex::Regex;
 use libs::tera::{Map, Value};
 use libs::time;
@@ -26,7 +26,7 @@ pub fn parse_yaml_datetime(date_string: &str) -> Result<time::OffsetDateTime> {
     let fraction_intermediate = fraction_raw.trim_end_matches("0");
     //
     // Prepare for eventual conversion into nanoseconds
-    let fraction = if fraction_intermediate.len() > 0 { fraction_intermediate } else { "0" };
+    let fraction = if !fraction_intermediate.is_empty() { fraction_intermediate } else { "0" };
     let maybe_timezone_hour = captures.name("offset_hour");
     let maybe_timezone_minute = captures.name("offset_minute");
 

--- a/components/utils/src/fs.rs
+++ b/components/utils/src/fs.rs
@@ -1,7 +1,7 @@
-use libs::filetime::{set_file_mtime, FileTime};
+use libs::filetime::{FileTime, set_file_mtime};
 use libs::globset::GlobSet;
 use libs::walkdir::WalkDir;
-use std::fs::{copy, create_dir_all, metadata, remove_dir_all, remove_file, File};
+use std::fs::{File, copy, create_dir_all, metadata, remove_dir_all, remove_file};
 use std::io::prelude::*;
 use std::path::Path;
 use std::time::SystemTime;
@@ -77,7 +77,7 @@ pub fn copy_file(src: &Path, dest: &Path, base_path: &Path, hard_link: bool) -> 
 /// 2. Its modification timestamp is identical to that of the src file.
 /// 3. Its filesize is identical to that of the src file.
 pub fn copy_file_if_needed(src: &Path, dest: &Path, hard_link: bool) -> Result<()> {
-    create_parent(&dest)?;
+    create_parent(dest)?;
 
     if hard_link {
         if dest.exists() {
@@ -120,10 +120,10 @@ pub fn copy_directory(
     {
         let relative_path = entry.path().strip_prefix(src).unwrap();
 
-        if let Some(gs) = ignore_globset {
-            if gs.is_match(relative_path) {
-                continue;
-            }
+        if let Some(gs) = ignore_globset
+            && gs.is_match(relative_path)
+        {
+            continue;
         }
 
         let target_path = dest.join(relative_path);
@@ -253,7 +253,7 @@ pub fn clean_site_output_folder(
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{metadata, read_to_string, File};
+    use std::fs::{File, metadata, read_to_string};
     use std::io::Write;
     use std::path::PathBuf;
     use std::str::FromStr;

--- a/components/utils/src/globs.rs
+++ b/components/utils/src/globs.rs
@@ -1,6 +1,6 @@
 use libs::globset::{Glob, GlobSet, GlobSetBuilder};
 
-use errors::{bail, Result};
+use errors::{Result, bail};
 
 pub fn build_ignore_glob_set(ignore: &Vec<String>, name: &str) -> Result<GlobSet> {
     // Convert the file glob strings into a compiled glob set matcher. We want to do this once,

--- a/components/utils/src/site.rs
+++ b/components/utils/src/site.rs
@@ -1,7 +1,7 @@
 use libs::percent_encoding::percent_decode;
 use std::collections::HashMap;
 
-use errors::{anyhow, Result};
+use errors::{Result, anyhow};
 
 /// Result of a successful resolution of an internal link.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/components/utils/src/slugs.rs
+++ b/components/utils/src/slugs.rs
@@ -23,7 +23,7 @@ fn strip_chars(s: &str, chars: &str) -> String {
 fn strip_invalid_paths_chars(s: &str) -> String {
     // NTFS forbidden characters : https://gist.github.com/doctaphred/d01d05291546186941e1b7ddc02034d3
     // Also we need to trim whitespaces and `.` from the end of filename
-    let trimmed = s.trim_end_matches(|c| c == ' ' || c == '.');
+    let trimmed = s.trim_end_matches([' ', '.']);
     strip_chars(trimmed, r#"<>:"/\|?*"#)
 }
 

--- a/components/utils/src/table_of_contents.rs
+++ b/components/utils/src/table_of_contents.rs
@@ -7,6 +7,7 @@ pub struct Heading {
     pub id: String,
     pub permalink: String,
     pub title: String,
+    pub title_raw: String,
     pub children: Vec<Heading>,
 }
 

--- a/components/utils/src/templates.rs
+++ b/components/utils/src/templates.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use libs::tera::{Context, Tera};
 
-use errors::{bail, Result};
+use errors::{Result, bail};
 
 const DEFAULT_TPL: &str = include_str!("default_tpl.html");
 
@@ -45,7 +45,7 @@ impl ShortcodeInvocationCounter {
     pub fn get(&mut self, str: &str) -> usize {
         let nth = self.amounts.entry(str.into()).or_insert(0);
         *nth += 1;
-        return *nth;
+        *nth
     }
     pub fn reset(&mut self) {
         self.amounts.clear();

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -17,9 +17,11 @@ If the file is given any name _other_ than `index.md` or `_index.md`, then it wi
 create a page with that name (without the `.md`). For example, naming a file in the root of your
 content directory `about.md` would create a page at `[base_url]/about`.
 
-Another exception to this rule is that a filename starting with a datetime (YYYY-mm-dd or [an RFC3339 datetime](https://www.ietf.org/rfc/rfc3339.txt)) followed by
-an underscore (`_`) or a dash (`-`) will use that date as the page date, unless already set
-in the front matter. The page name will be anything after `_`/`-`, so the file `2018-10-10-hello-world.md` will
+Another exception to this rule is that a filename starting with a datetime (YYYY-mm-dd or [an RFC3339 datetime](https://www.ietf.org/rfc/rfc3339.txt))
+will use that date as the page date, unless already set
+in the front matter. A datetime filename can optionally be followed by an underscore (`_`) or a dash (`-`), and slug.
+The page name will be either the datetime or anything after `_`/`-`,
+so the file `2018-10-10.md` will be available at `[base_url]/2018-10-10`, and `2018-10-10-hello-world.md` will
 be available at `[base_url]/hello-world`. Note that the full RFC3339 datetime contains colons, which is not a valid
 character in a filename on Windows.
 This behavior can be disabled by setting `slugify.paths_keep_dates` to `true` (the default is `false`). Note that a `_` separating the date would be slugified into a `-` with the default value for `slugify.paths` of `"on"`.

--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -170,6 +170,8 @@ If your site source is laid out as follows:
 
 you would set your `extra_syntaxes_and_themes` to `["syntaxes", "syntaxes/Sublime-Language1"]` to load `lang1.sublime-syntax` and `lang2.sublime-syntax`.
 
+Note that some newer syntax features, such as [inheritance](https://www.sublimetext.com/docs/syntax.html#inheritance), do not currently work. You may have to make modifications to any custom syntax files you choose to install. To find more information, including workarounds, search the project for [open issues](https://github.com/getzola/zola/issues).
+
 You can see the list of available themes on the [configuration page](@/documentation/getting-started/configuration.md#syntax-highlighting).
 
 

--- a/docs/content/documentation/content/table-of-contents.md
+++ b/docs/content/documentation/content/table-of-contents.md
@@ -16,12 +16,14 @@ Here is an example of using that field to render a two-level table of contents:
     <ul>
     {% for h1 in page.toc %}
         <li>
+            <!-- the "title" property strips the HTML tags from the original title -->
             <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
             {% if h1.children %}
                 <ul>
                     {% for h2 in h1.children %}
                         <li>
-                            <a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
+                            <!-- "title_raw" lets you access the title with its original HTML tags -->
+                            <a href="{{ h2.permalink | safe }}">{{ h2.title_raw | safe }}</a>
                         </li>
                     {% endfor %}
                 </ul>

--- a/docs/content/documentation/content/taxonomies.md
+++ b/docs/content/documentation/content/taxonomies.md
@@ -137,4 +137,16 @@ The taxonomy pages are then available at the following paths:
 $BASE_URL/$NAME/ (taxonomy)
 $BASE_URL/$NAME/$SLUG (taxonomy entry)
 ```
+
+If you have set the `taxonomy_root` configuration option, all taxonomy paths will be prefixed with that root path:
+
+```txt
+$BASE_URL/$TAXONOMY_ROOT/$NAME/ (taxonomy)
+$BASE_URL/$TAXONOMY_ROOT/$NAME/$SLUG (taxonomy entry)
+```
+
+For example, with `taxonomy_root = "blog"` and a taxonomy named `tags` with a term `rust`:
+- Taxonomy list page: `$BASE_URL/blog/tags/`
+- Taxonomy term page: `$BASE_URL/blog/tags/rust/`
+
 Note that taxonomies are case insensitive so terms that have the same slug will get merged, e.g. sections and pages containing the tag "example" will be shown in the same taxonomy page as ones containing "Example" 

--- a/docs/content/documentation/deployment/docker-image.md
+++ b/docs/content/documentation/deployment/docker-image.md
@@ -23,7 +23,7 @@ COPY --from=zola /project/public /public
 ```
 
 To build your website as a docker image, you then run:
-```shell
+```sh
 docker build -t my_website:latest .
 ```
 

--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -100,6 +100,13 @@ a hard refresh if possible. If you are using WSL2 on Windows, make sure to store
 Some changes cannot be handled automatically and thus live reload may not always work. If you
 fail to see your change or get an error, try restarting `zola serve`.
 
+By default, the live reload will be debounced by one full second so as to more
+gracefully handle multiple changes to your input files in rapid succession. You
+have control over that debouncing duration with the `--debounce <duration_ms>`
+flag.  
+You may use `-d1` to (virtually) disable it altogether: for technical reasons
+(and keeping things simple), a "debounce" of 0 is not supported.
+
 You can also point to a config file other than `config.toml` like so (note that the position of the `config` option is important):
 
 ```bash

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -141,6 +141,9 @@ external_links_no_follow = false
 # Whether to set rel="noreferrer" for all external links
 external_links_no_referrer = false
 
+# Whether to set rel="external" for all external links
+external_links_external = true
+
 # Whether smart punctuation is enabled (changing quotes, dashes, dots in their typographic form)
 # For example, `...` into `…`, `"quote"` into `“curly”` etc
 smart_punctuation = false

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -99,6 +99,10 @@ author =
 #
 taxonomies = []
 
+# Optional base path for all taxonomies. If set, all taxonomy paths will be relative to this path.
+# For example, if taxonomy_root is "blog" and taxonomy is "tags", the path will be /blog/tags/
+# taxonomy_root = "blog"
+
 # When set to "true", a search index is built from the pages and section
 # content for `default_language`.
 build_search_index = false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,10 @@ pub enum Command {
         /// Extra path to watch for changes, relative to the project root.
         #[clap(long)]
         extra_watch_path: Vec<String>,
+
+        /// Debounce time in milliseconds for the file watcher (at least 1ms)
+        #[clap(short = 'd', long, default_value_t = 1000, value_parser = clap::value_parser!(u64).range(1..))]
+        debounce: u64,
     },
 
     /// Try to build the project without rendering it. Checks links

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -430,6 +430,7 @@ pub fn serve(
     no_port_append: bool,
     utc_offset: UtcOffset,
     extra_watch_paths: Vec<String>,
+    debounce: u64,
 ) -> Result<()> {
     let start = Instant::now();
     let (mut site, bind_address, constructed_base_url) = create_new_site(
@@ -482,7 +483,7 @@ pub fn serve(
 
     // Setup watchers
     let (tx, rx) = channel();
-    let mut debouncer = new_debouncer(Duration::from_secs(1), /*tick_rate=*/ None, tx).unwrap();
+    let mut debouncer = new_debouncer(Duration::from_millis(debounce), None, tx).unwrap();
 
     // We watch for changes on the filesystem for every entry in watch_this
     // Will fail if either:

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -247,6 +247,7 @@ fn in_memory_content(path: &RelativePathBuf, content: &str) -> Response<Body> {
         Some(ext) => match ext {
             "xml" => "text/xml",
             "json" => "application/json",
+            "txt" => "text/plain",
             _ => "text/html",
         },
         None => "text/html",

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -499,7 +499,7 @@ pub fn serve(
         };
         if should_watch {
             debouncer
-                .watch(&root_dir.join(entry), recursive_mode)
+                .watch(root_dir.join(entry), recursive_mode)
                 .with_context(|| format!("Can't watch `{}` for changes in folder `{}`. Does it exist, and do you have correct permissions?", entry, root_dir.display()))?;
             watchers.push(entry.to_string());
         }
@@ -544,10 +544,8 @@ pub fn serve(
                         .replace(&bind_address.to_string(), &server.local_addr().to_string()),
                     &server.local_addr()
                 );
-                if open {
-                    if let Err(err) = open::that(&constructed_base_url) {
-                        eprintln!("Failed to open URL in your browser: {err}");
-                    }
+                if open && let Err(err) = open::that(&constructed_base_url) {
+                    eprintln!("Failed to open URL in your browser: {err}");
                 }
 
                 server.await.expect("Could not start web server");
@@ -633,10 +631,10 @@ pub fn serve(
 
     let copy_static = |site: &Site, path: &Path, partial_path: &Path| {
         // Do nothing if the file/dir is on the ignore list
-        if let Some(gs) = &site.config.ignored_static_globset {
-            if gs.is_match(partial_path) {
-                return;
-            }
+        if let Some(gs) = &site.config.ignored_static_globset
+            && gs.is_match(partial_path)
+        {
+            return;
         }
         // Do nothing if the file/dir was deleted
         if !path.exists() {
@@ -916,9 +914,9 @@ mod tests {
             &root_dir,
             interface,
             interface_port,
-            output_dir.as_deref(),
+            output_dir,
             force,
-            base_url.as_deref(),
+            base_url,
             &config_file,
             include_drafts,
             false,

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -183,7 +183,7 @@ mod tests {
     // event mapping and filtering don't cause us to accidentally ignore things we care about.
     #[test]
     fn test_get_relative_event_kind() {
-        let cases = vec![
+        let cases = [
             (EventKind::Create(CreateKind::File), Some(SimpleFileSystemEventKind::Create)),
             (EventKind::Create(CreateKind::Folder), Some(SimpleFileSystemEventKind::Create)),
             (EventKind::Modify(ModifyKind::Any), Some(SimpleFileSystemEventKind::Modify)),
@@ -223,7 +223,7 @@ mod tests {
             (EventKind::Remove(RemoveKind::Folder), Some(SimpleFileSystemEventKind::Remove)),
         ];
         for (case, expected) in cases.iter() {
-            let ek = get_relevant_event_kind(&case);
+            let ek = get_relevant_event_kind(case);
             assert_eq!(ek, *expected, "case: {case:?}");
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ fn main() {
             fast,
             no_port_append,
             extra_watch_path,
+            debounce,
         } => {
             if port != 1111 && !port_is_available(interface, port) {
                 console::error("The requested port is not available");
@@ -119,6 +120,7 @@ fn main() {
                 no_port_append,
                 UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC),
                 extra_watch_path,
+                debounce,
             ) {
                 messages::unravel_errors("Failed to serve the site", &e);
                 std::process::exit(1);

--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -5,7 +5,9 @@
 
   <name>Zola</name>
   <summary>A fast static site generator in a single binary with everything built-in</summary>
-  <developer_name>Vincent Prouillet and contributors</developer_name>
+  <developer>
+    <name>Vincent Prouillet and contributors</name>
+  </developer>
 
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
@@ -51,6 +53,9 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.21.0" date="2025-07-14">
+      <url>https://github.com/getzola/zola/releases/tag/v0.21.0</url>
+    </release>
     <release version="0.20.0" date="2025-02-15">
       <url>https://github.com/getzola/zola/releases/tag/v0.20.0</url>
     </release>

--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -5,7 +5,7 @@
 
   <name>Zola</name>
   <summary>A fast static site generator in a single binary with everything built-in</summary>
-  <developer>
+  <developer id="org.getzola">
     <name>Vincent Prouillet and contributors</name>
   </developer>
 


### PR DESCRIPTION
Provide original markdown title in TOC.

This commit introduces the "title_raw" property to the Heading struct,
so that the user may get adequately formatted entries in their table of
contents when the original title contains, for example, code highlight
content.

For example:

    ### The `<summary>` in the `<details>`

Would offer, in heading.title:

    The <summary> in the <details>

And in the newly introduced heading.title_raw:

    The <code>&lt;summary&gt;</code> in the <code>&lt;details&gt;</code>

Resolves #3023.

---

Sanity check:

* [x] Not already addressed by another ongoing PR
* [x] PR made against `next`?
* [x] Documentation updated?