### PR TITLE
Add "Zola Demo Site" to examples list

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -46,3 +46,4 @@
 | [Herman Schaaf's Blog](https://hermanschaaf.com)                   | https://github.com/hermanschaaf/zola-blog                |
 | [Nizzlay](https://nizzlay.com)                                     | https://github.com/Nizzlay/nizzlay.com                   |
 | [Lysator](https://www.lysator.liu.se)                              | https://git.lysator.liu.se/www/hemsida                   |
+| [Zola Demo Site](https://tandiljuan.github.io/zola-demo/)          | https://github.com/tandiljuan/zola-demo                  |


### PR DESCRIPTION
Add a demonstration site built with Zola. On the main page, you can find a link to the blog posts that explain, step by step, how it was made.
