### PR TITLE
build: Generate man pages at build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           mkdir -p artifacts
           cp -av target/${{ matrix.target }}/release/zola .
-          tar -czf ${{ github.event.repository.name }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz zola
+          cp -av "$(find target -path '*/zola-*/out' -type d)"/* artifacts
+          tar -czf ${{ github.event.repository.name }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz zola artifacts
         if: ${{ ! startsWith(matrix.os, 'windows') }}
 
       - name: Archive (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           mkdir -p artifacts
           cp -av target/${{ matrix.target }}/release/zola .
-          cp -av "$(find target -path '*/zola-*/out' -type d)"/* artifacts
+          OUTPUT_DIR="$(find target -path '*/zola-*/out' -type d)"
+          cp -av "$OUTPUT_DIR"/* artifacts
           tar -czf ${{ github.event.repository.name }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz zola artifacts
         if: ${{ ! startsWith(matrix.os, 'windows') }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ea63a92086df93893164221ad4f24142086d535b3a0957b9b9bea2dc86301"
+dependencies = [
+ "clap 4.5.43",
+ "roff",
+]
+
+[[package]]
 name = "codemap"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,6 +3996,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,6 +5734,7 @@ version = "0.21.0"
 dependencies = [
  "clap 4.5.43",
  "clap_complete",
+ "clap_mangen",
  "console 0.1.0",
  "ctrlc",
  "errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["static", "site", "generator", "blog"]
 include = ["src/**/*", "LICENSE", "README.md"]
 
 [build-dependencies]
+clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+clap_mangen = "0.2.31"
 winres = "0.1"
 time = "0.3"
 

--- a/build.rs
+++ b/build.rs
@@ -13,13 +13,24 @@ fn generate_pe_header() {
     res.compile().expect("Failed to compile Windows resources!");
 }
 
+include!("src/cli.rs");
+
+fn generate_man_pages() {
+    use clap::CommandFactory;
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let cmd = Cli::command();
+    clap_mangen::generate_to(cmd, out_dir).unwrap();
+}
+
 fn main() {
-    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows"
-        && std::env::var("PROFILE").unwrap() != "release"
-    {
+    if std::env::var("PROFILE").unwrap() != "release" {
         return;
     }
     if cfg!(windows) {
         generate_pe_header();
+    }
+    if cfg!(unix) {
+        generate_man_pages();
     }
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?

---

Generates man pages for the Zola CLI at the package compile time. These are generated when the target is `unix` and the profile is the `release`. man page is documentation for Unix-like operating systems, so the man pages are not generated when the target is `windows`.

Closes #3032