### PR TITLE
Add missing documentation for GitHub-flavored alerts

### DIFF
--- a/docs/content/documentation/getting-started/configuration/index.md
+++ b/docs/content/documentation/getting-started/configuration/index.md
@@ -156,6 +156,22 @@ lazy_async_image = false
 # Whether footnotes are rendered in the GitHub-style (at the bottom, with back references) or plain (in the place, where they are defined)
 bottom_footnotes = false
 
+# When set to "true", support for GitHub-style alerts, a.k.a. callouts or admonitions, is enabled in the Markdown parser.
+# For example, this Markdown syntax:
+#
+#     > [!NOTE]
+#     > alert note
+#
+# will result in the following generated HTML:
+#
+#     <blockquote class="markdown-alert-note">
+#     <p>alert note</p>
+#     </blockquote>
+#
+# where the CSS class name suffix may be `note`, `tip`, `important`, `warning`, or `caution`, depending on the alert type.
+# Visual appearance depends on theme-level support; refer to your theme's documentation for more information.
+github_alerts = false
+
 # This determines whether to insert a link for each header like the ones you can see on this site if you hover over
 # a header.
 # The default template can be overridden by creating an `anchor-link.html` file in the `templates` directory.


### PR DESCRIPTION
This feature was introduced in Zola [v0.21.0](https://github.com/getzola/zola/releases/tag/v0.21.0) via #2893, but lacks any form of official documentation. The bullet in the release notes was also accidentally removed at some point prior to release.

This commit attempts to document the basics of this feature in the <kbd>Getting Started</kbd> > <kbd>Configuration</kbd> section, but please let me know if you would like this info moved to a different location!

Related to #2817.
