### PR TITLE
feat: migrate serve WebSocket from ws crate to Axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -205,7 +205,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -278,7 +278,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
  "axum-core",
- "bytes 1.11.0",
+ "base64",
+ "bytes",
  "futures-util",
  "http",
  "http-body",
@@ -292,8 +293,10 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -305,7 +308,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "futures-core",
  "http",
  "http-body",
@@ -395,7 +398,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -421,32 +424,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "generic-array",
 ]
 
 [[package]]
@@ -488,12 +470,6 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 dependencies = [
  "allocator-api2",
 ]
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecheck"
@@ -543,16 +519,6 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
-name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
@@ -586,12 +552,6 @@ checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
 dependencies = [
  "smallvec",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -771,7 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
- "cfg-if 1.0.4",
+ "cfg-if",
  "itoa",
  "rustversion",
  "ryu",
@@ -924,7 +884,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -964,7 +924,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
 ]
 
@@ -1051,7 +1011,7 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1090,20 +1050,11 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
 ]
 
@@ -1321,12 +1272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fallible_collections"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,7 +1327,7 @@ version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "libredox",
  "windows-sys 0.60.2",
@@ -1442,22 +1387,6 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags 1.3.2",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
@@ -1536,15 +1465,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
@@ -1555,25 +1475,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.4",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1583,7 +1492,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
@@ -1685,7 +1594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1703,7 +1612,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "crunchy",
  "zerocopy",
 ]
@@ -1774,7 +1683,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "itoa",
 ]
 
@@ -1784,7 +1693,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "http",
 ]
 
@@ -1794,7 +1703,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "futures-core",
  "http",
  "http-body",
@@ -1835,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "h2",
@@ -1874,7 +1783,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1891,7 +1800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
- "bytes 1.11.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2175,15 +2084,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,16 +2199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,12 +2232,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128"
@@ -2748,7 +2632,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "rayon",
 ]
 
@@ -2835,57 +2719,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mio-extras"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
-dependencies = [
- "lazycell",
- "log",
- "mio 0.6.23",
- "slab",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
 ]
 
 [[package]]
@@ -2895,7 +2736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e0603425789b4a70fcc4ac4f5a46a566c116ee3e2a6b768dc623f7719c611de"
 dependencies = [
  "assert-json-diff",
- "bytes 1.11.0",
+ "bytes",
  "colored",
  "futures-core",
  "http",
@@ -2947,17 +2788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,7 +2800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.10.0",
- "cfg-if 1.0.4",
+ "cfg-if",
  "cfg_aliases",
  "libc",
 ]
@@ -3062,7 +2892,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio 1.1.1",
+ "mio",
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
@@ -3212,12 +3042,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,7 +3059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.10.0",
- "cfg-if 1.0.4",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -3318,7 +3142,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02105a875f3751a0b44b4c822b01177728dd9049ae6fb419e9b04887d730ed1"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "owo-colors",
  "oxc-miette-derive",
  "textwrap",
@@ -3686,7 +3510,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -4079,7 +3903,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
@@ -4099,7 +3923,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
@@ -4151,19 +3975,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -4181,16 +3992,6 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4215,15 +4016,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -4241,15 +4033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4263,7 +4046,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io",
  "built",
- "cfg-if 1.0.4",
+ "cfg-if",
  "interpolate_name",
  "itertools 0.14.0",
  "libc",
@@ -4382,7 +4165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
 dependencies = [
  "base64",
- "bytes 1.11.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4431,7 +4214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "getrandom 0.2.16",
  "libc",
  "untrusted",
@@ -4446,7 +4229,7 @@ checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
  "bitvec",
  "bytecheck",
- "bytes 1.11.0",
+ "bytes",
  "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
@@ -4745,15 +4528,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.8.2"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4762,9 +4544,9 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -5107,7 +4889,7 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -5255,9 +5037,9 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "libc",
- "mio 1.1.1",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "socket2",
@@ -5297,12 +5079,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
- "bytes 1.11.0",
+ "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -5379,7 +5173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
- "bytes 1.11.0",
+ "bytes",
  "futures-util",
  "http",
  "http-body",
@@ -5426,6 +5220,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"
@@ -5631,12 +5442,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -5656,7 +5461,7 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -5669,7 +5474,7 @@ version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -5767,12 +5572,6 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -5780,12 +5579,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -6060,34 +5853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
-name = "ws"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fe90c75f236a0a00247d5900226aea4f2d7b05ccc34da9e7a8880ff59b5848"
-dependencies = [
- "byteorder",
- "bytes 0.4.12",
- "httparse",
- "log",
- "mio 0.6.23",
- "mio-extras",
- "rand 0.7.3",
- "sha-1",
- "slab",
- "url",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6253,7 +6018,6 @@ dependencies = [
  "url",
  "utils",
  "winres",
- "ws",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,9 @@ name = "zola"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 # Below is for the serve cmd
-axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
-tokio = { version = "1.0.1", default-features = false, features = ["rt", "fs", "time", "net"] }
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "ws"] }
+tokio = { version = "1.0.1", default-features = false, features = ["rt", "fs", "time", "net", "sync"] }
 notify-debouncer-full = "0.6"
-ws = "0.9"
 ctrlc = "3"
 open = "5"
 # For mimetype detection in serve mode

--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -195,10 +195,6 @@ $ docker run -u "$(id -u):$(id -g)" -v $PWD:/app --workdir /app -p 8080:8080 ghc
 
 You can now browse http://localhost:8080.
 
-> To enable live browser reload, you may have to bind to port 1024. Zola searches for an open
-> port between 1024 and 9000 for live reload. The new docker command would be
-> `$ docker run -u "$(id -u):$(id -g)" -v $PWD:/app --workdir /app -p 8080:8080 -p 1024:1024 ghcr.io/getzola/zola:v0.19.1 serve --interface 0.0.0.0 --port 8080 --base-url localhost`
-
 #### Multi-stage build
 
 Since there is no shell in the Zola docker image, if you want to use it from inside a Dockerfile, you have to use the

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -25,25 +25,34 @@ use std::cell::Cell;
 use std::ffi::OsStr;
 use std::net::{IpAddr, SocketAddr, TcpListener};
 use std::path::{MAIN_SEPARATOR, Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use axum::Router;
-use axum::body::Body;
-use axum::extract::{Request, State};
-use axum::http::{HeaderValue, Method, StatusCode, header};
-use axum::response::Response;
+use axum::{
+    Router,
+    body::Body,
+    extract::{
+        State, WebSocketUpgrade,
+        ws::{Message, WebSocket},
+    },
+    http::{HeaderValue, Method, StatusCode, header},
+    middleware,
+    response::{IntoResponse, Response},
+    routing::get,
+};
 use mime_guess::from_path as mimetype_from_path;
 use time::macros::format_description;
 use time::{OffsetDateTime, UtcOffset};
+use tokio::sync::broadcast;
 
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode};
 use relative_path::{RelativePath, RelativePathBuf};
-use ws::{Message, Sender, WebSocket};
 
 use errors::{Context, Error, Result, anyhow};
+use serde_json::json;
 use site::sass::compile_sass;
 use site::{BuildMode, SITE_CONTENT, Site};
 use utils::fs::{clean_site_output_folder, copy_file, create_directory};
@@ -66,10 +75,10 @@ const LIVE_RELOAD: &str = include_str!("livereload.js");
 
 static SERVE_ERROR: Mutex<Cell<Option<(&'static str, Error)>>> = Mutex::new(Cell::new(None));
 
-#[derive(Clone)]
 struct AppState {
     static_root: PathBuf,
     base_path: String,
+    reload_tx: broadcast::Sender<String>,
 }
 
 fn clear_serve_error() {
@@ -82,7 +91,23 @@ fn set_serve_error(msg: &'static str, e: Error) {
     }
 }
 
-async fn handle_request(State(state): State<AppState>, req: Request) -> Response {
+/// Creates a LiveReload protocol reload message for the given path.
+fn make_reload_message(path: &str) -> String {
+    json!({
+        "command": "reload",
+        "path": path,
+        "originalPath": "",
+        "liveCSS": true,
+        "liveImg": true,
+        "protocol": ["http://livereload.com/protocols/official-7"]
+    })
+    .to_string()
+}
+
+async fn handle_request(
+    State(state): State<Arc<AppState>>,
+    req: axum::extract::Request,
+) -> Response {
     let path_str = req.uri().path();
     let base_path = &state.base_path;
     let mut root = state.static_root.clone();
@@ -110,15 +135,6 @@ async fn handle_request(State(state): State<AppState>, req: Request) -> Response
 
     for c in decoded_path.split('/') {
         path.push(c);
-    }
-
-    // livereload.js is served using the LIVE_RELOAD str, not a file
-    if path == "livereload.js" {
-        if req.method() == Method::GET {
-            return livereload_js();
-        } else {
-            return method_not_allowed();
-        }
     }
 
     if let Some(content) = SITE_CONTENT.read().unwrap().get(&path) {
@@ -180,24 +196,100 @@ async fn handle_request(State(state): State<AppState>, req: Request) -> Response
         .unwrap()
 }
 
+/// WebSocket handler for live reload
+async fn ws_handler(ws: WebSocketUpgrade, State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let reload_tx = state.reload_tx.clone();
+    ws.on_upgrade(move |socket| handle_websocket(socket, reload_tx))
+}
+
+/// Handle WebSocket connection for live reload
+async fn handle_websocket(mut socket: WebSocket, reload_tx: broadcast::Sender<String>) {
+    let mut rx = reload_tx.subscribe();
+    let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
+
+    loop {
+        tokio::select! {
+            // Periodic ping to keep connection alive
+            _ = ping_interval.tick() => {
+                if socket.send(Message::Ping(vec![].into())).await.is_err() {
+                    break;
+                }
+            }
+            // Send reload messages to client
+            Ok(msg) = rx.recv() => {
+                if socket.send(Message::Text(msg.into())).await.is_err() {
+                    break;
+                }
+            }
+            // Handle incoming messages (livereload protocol)
+            msg_result = socket.recv() => {
+                match msg_result {
+                    Some(Ok(Message::Text(text))) => {
+                        // Handle "hello" message from client
+                        if text.contains("\"hello\"") {
+                            let hello_response = json!({
+                                "command": "hello",
+                                "protocols": ["http://livereload.com/protocols/official-7"],
+                                "serverName": "Zola"
+                            })
+                            .to_string();
+
+                            if socket.send(Message::Text(hello_response.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) => break,
+                    Some(Ok(Message::Pong(_))) => continue,
+                    Some(Ok(_)) => {} // Ignore other message types
+                    Some(Err(e)) => {
+                        console::error(&format!("WebSocket error: {e}"));
+                        break;
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+}
+
+/// Serve livereload.js
+async fn serve_livereload_js() -> impl IntoResponse {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "text/javascript")
+        .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .status(StatusCode::OK)
+        .body(Body::from(LIVE_RELOAD))
+        .expect("Could not build livereload.js response")
+}
+
 /// Inserts build error message boxes into HTML responses when needed.
 /// Used as axum middleware via `map_response`.
 async fn error_injection_middleware(response: Response) -> Response {
     use axum::body::to_bytes;
 
-    // Return response as-is if not HTML or if there are no error messages.
+    // Return response as-is if there are no error messages.
+    let has_error = SERVE_ERROR.lock().unwrap().get_mut().is_some();
+    if !has_error {
+        return response;
+    }
+
+    // Only inject errors into HTML responses or 404 responses.
+    // Don't interfere with WebSocket upgrades (101) or other special responses.
     let is_html = response
         .headers()
         .get(header::CONTENT_TYPE)
         .map(|val| val == HeaderValue::from_static("text/html"))
         .unwrap_or(false);
+    let is_not_found = response.status() == StatusCode::NOT_FOUND;
 
-    if !is_html || SERVE_ERROR.lock().unwrap().get_mut().is_none() {
+    // Pass through non-HTML, non-404 responses unchanged (e.g., WebSocket upgrades)
+    if !is_html && !is_not_found {
         return response;
     }
 
     let (parts, body) = response.into_parts();
-    let mut bytes = match to_bytes(body, usize::MAX).await {
+    let bytes = match to_bytes(body, usize::MAX).await {
         Ok(b) => b.to_vec(),
         Err(_) => return Response::from_parts(parts, Body::empty()),
     };
@@ -218,25 +310,30 @@ async fn error_injection_middleware(response: Response) -> Response {
             cause = e.source();
         }
 
-        // Push the error message (wrapped in an HTML dialog box) to the end of the HTML body.
-        //
-        // The message will be outside of <html> and <body> but web browsers are flexible enough
-        // that they will move it to the end of <body> at page load.
         let html_error = format!(
             r#"<div style="all:revert;position:fixed;display:flex;align-items:center;justify-content:center;background-color:rgb(0,0,0,0.5);top:0;right:0;bottom:0;left:0;"><div style="background-color:white;padding:0.5rem;border-radius:0.375rem;filter:drop-shadow(0,25px,25px,rgb(0,0,0/0.15));overflow-x:auto;"><p style="font-weight:700;color:black;font-size:1.25rem;margin:0;margin-bottom:0.5rem;">Zola Build Error:</p><pre style="padding:0.5rem;margin:0;border-radius:0.375rem;background-color:#363636;color:#CE4A2F;font-weight:700;">{error_str}</pre></div></div>"#
         );
-        bytes.extend(html_error.as_bytes());
+
+        if is_html {
+            // Inject error dialog into existing HTML response
+            let mut new_bytes = bytes;
+            new_bytes.extend(html_error.as_bytes());
+            return Response::from_parts(parts, Body::from(new_bytes));
+        } else if is_not_found {
+            // Return a full HTML page with the error dialog for 404s
+            // Include livereload.js so the page can receive reload messages when the error is fixed
+            let html_page = format!(
+                r#"<!DOCTYPE html><html><head><title>Zola Build Error</title><script src="/livereload.js"></script></head><body>{html_error}</body></html>"#
+            );
+            return Response::builder()
+                .header(header::CONTENT_TYPE, "text/html")
+                .status(StatusCode::OK)
+                .body(Body::from(html_page))
+                .expect("Could not build error response");
+        }
     }
 
     Response::from_parts(parts, Body::from(bytes))
-}
-
-fn livereload_js() -> Response {
-    Response::builder()
-        .header(header::CONTENT_TYPE, "text/javascript")
-        .status(StatusCode::OK)
-        .body(Body::from(LIVE_RELOAD))
-        .expect("Could not build livereload.js response")
 }
 
 fn in_memory_content(path: &RelativePathBuf, content: &str) -> Response {
@@ -294,32 +391,24 @@ fn not_found() -> Response {
         .expect("Could not build Not Found response")
 }
 
-fn rebuild_done_handling(broadcaster: &Sender, res: Result<()>, reload_path: &str) {
+fn rebuild_done_handling(
+    broadcaster: &broadcast::Sender<String>,
+    res: Result<()>,
+    reload_path: &str,
+) {
     match res {
         Ok(_) => {
             clear_serve_error();
-            broadcaster
-                .send(format!(
-                    r#"
-                {{
-                    "command": "reload",
-                    "path": {},
-                    "originalPath": "",
-                    "liveCSS": true,
-                    "liveImg": true,
-                    "protocol": ["http://livereload.com/protocols/official-7"]
-                }}"#,
-                    serde_json::to_string(&reload_path).unwrap()
-                ))
-                .unwrap();
         }
         Err(e) => {
             let msg = "Failed to build the site";
-
             messages::unravel_errors(msg, &e);
             set_serve_error(msg, e);
         }
     }
+
+    // Always send reload so the client fetches the page (with error dialog if needed)
+    let _ = broadcaster.send(make_reload_message(reload_path));
 }
 
 fn construct_url(base_url: &str, no_port_append: bool, interface_port: u16) -> String {
@@ -363,7 +452,6 @@ fn create_new_site(
     include_drafts: bool,
     store_html: bool,
     mut no_port_append: bool,
-    ws_port: Option<u16>,
 ) -> Result<(Site, SocketAddr, String)> {
     SITE_CONTENT.write().unwrap().clear();
 
@@ -400,11 +488,8 @@ fn create_new_site(
         site.include_drafts();
     }
     site.load()?;
-    if let Some(p) = ws_port {
-        site.enable_live_reload_with_port(p);
-    } else {
-        site.enable_live_reload(interface, interface_port);
-    }
+    // With Axum, WebSocket runs on the same server as HTTP
+    site.enable_live_reload_with_port(interface_port);
     messages::notify_site_size(&site);
     messages::warn_about_ignored_pages(&site);
     site.build()?;
@@ -441,7 +526,6 @@ pub fn serve(
         include_drafts,
         store_html,
         no_port_append,
-        None,
     )?;
     let base_path = match constructed_base_url.splitn(4, '/').nth(3) {
         Some(path) => format!("/{path}"),
@@ -503,82 +587,63 @@ pub fn serve(
         }
     }
 
-    let ws_port = site.live_reload;
-    let ws_address = format!("{}:{}", interface, ws_port.unwrap());
     let output_path = site.output_path.clone();
     create_directory(&output_path)?;
 
     // static_root needs to be canonicalized because we do the same for the http server.
     let static_root = std::fs::canonicalize(&output_path).unwrap();
 
-    let broadcaster = {
-        thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Could not build tokio runtime");
+    // Create broadcast channel for WebSocket live reload
+    let (reload_tx, _) = broadcast::channel::<String>(100);
+    let broadcaster = reload_tx.clone();
 
-            rt.block_on(async {
-                use axum::middleware;
+    // Shutdown signal for graceful termination
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    let shutdown_flag_server = shutdown_flag.clone();
 
-                let state = AppState { static_root, base_path };
+    // Start Axum server in a separate thread
+    thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Could not build tokio runtime");
 
-                let app = Router::new()
-                    .fallback(handle_request)
-                    .layer(middleware::map_response(error_injection_middleware))
-                    .with_state(state);
+        rt.block_on(async {
+            let state = Arc::new(AppState { static_root, base_path, reload_tx });
 
-                let listener = tokio::net::TcpListener::bind(&bind_address)
-                    .await
-                    .expect("Could not bind to address");
+            let app = Router::new()
+                .route("/livereload.js", get(serve_livereload_js))
+                .route("/livereload", get(ws_handler))
+                .fallback(handle_request)
+                .layer(middleware::map_response(error_injection_middleware))
+                .with_state(state);
 
-                let local_addr = listener.local_addr().unwrap();
+            let listener = tokio::net::TcpListener::bind(&bind_address)
+                .await
+                .expect("Could not bind to address");
 
-                println!(
-                    "Web server is available at {} (bound to {})\n",
-                    &constructed_base_url
-                        .replace(&bind_address.to_string(), &local_addr.to_string()),
-                    &local_addr
-                );
-                if open && let Err(err) = open::that(&constructed_base_url) {
-                    eprintln!("Failed to open URL in your browser: {err}");
-                }
+            let local_addr = listener.local_addr().unwrap();
 
-                axum::serve(listener, app).await.expect("Could not start web server");
-            });
-        });
-
-        // The websocket for livereload
-        let ws_server = WebSocket::new(|output: Sender| {
-            move |msg: Message| {
-                if msg.into_text().unwrap().contains("\"hello\"") {
-                    return output.send(Message::text(
-                        r#"
-                        {
-                            "command": "hello",
-                            "protocols": [ "http://livereload.com/protocols/official-7" ],
-                            "serverName": "Zola"
-                        }
-                    "#,
-                    ));
-                }
-                Ok(())
+            println!(
+                "Web server is available at {} (bound to {})\n",
+                &constructed_base_url.replace(&bind_address.to_string(), &local_addr.to_string()),
+                &local_addr
+            );
+            if open && let Err(err) = open::that(&constructed_base_url) {
+                eprintln!("Failed to open URL in your browser: {err}");
             }
-        })
-        .unwrap();
 
-        let broadcaster = ws_server.broadcaster();
-
-        let ws_server = ws_server
-            .bind(&*ws_address)
-            .map_err(|_| anyhow!("Cannot bind to address {} for the websocket server. Maybe the port is already in use?", &ws_address))?;
-
-        thread::spawn(move || {
-            ws_server.run().unwrap();
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    // Poll the shutdown flag
+                    while !shutdown_flag_server.load(Ordering::Relaxed) {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                })
+                .await
+                .expect("Could not start web server");
         });
-
-        broadcaster
-    };
+    });
 
     // We watch for changes in the config by monitoring its parent directory, but we ignore all
     // ordinary peer files. Map the parent directory back to the config file name to not confuse
@@ -597,6 +662,14 @@ pub fn serve(
     println!("Press Ctrl+C to stop\n");
     // Clean the output folder on ctrl+C
     ctrlc::set_handler(move || {
+        println!("\nShutting down...");
+
+        // Signal the server to stop accepting new connections
+        shutdown_flag.store(true, Ordering::Relaxed);
+
+        // Give in-flight requests time to complete (up to 2 seconds)
+        thread::sleep(Duration::from_secs(2));
+
         match clean_site_output_folder(&output_path, preserve_dotfiles_in_output) {
             Ok(()) => (),
             Err(e) => println!("Errored while cleaning output folder: {e}"),
@@ -670,7 +743,6 @@ pub fn serve(
         include_drafts,
         store_html,
         no_port_append,
-        ws_port,
     ) {
         Ok((s, _, _)) => {
             clear_serve_error();
@@ -683,6 +755,9 @@ pub fn serve(
 
             messages::unravel_errors(msg, &e);
             set_serve_error(msg, e);
+
+            // Send reload so the client fetches the page with the error dialog
+            let _ = broadcaster.send(make_reload_message("/x.js"));
 
             None
         }
@@ -893,7 +968,6 @@ mod tests {
         output_dir: Option<&Path>,
         base_url: Option<&str>,
         no_port_append: bool,
-        ws_port: Option<u16>,
         expected_base_url: String,
     ) {
         let cli_dir = Path::new("./test_site").canonicalize().unwrap();
@@ -917,7 +991,6 @@ mod tests {
             include_drafts,
             false,
             no_port_append,
-            ws_port,
         )
         .unwrap();
 
@@ -926,8 +999,8 @@ mod tests {
         assert!(site.base_path.exists());
         assert_eq!(site.base_path, root_dir);
         assert_eq!(site.config.base_url, constructed_base_url);
-        assert_ne!(site.live_reload, None);
-        assert_ne!(site.live_reload, Some(1111));
+        // With Axum, WebSocket runs on the same port as HTTP
+        assert_eq!(site.live_reload, Some(interface_port));
         assert_eq!(site.output_path, root_dir.join(&site.config.output_dir));
         assert_eq!(site.static_path, root_dir.join("static"));
 
@@ -952,7 +1025,6 @@ mod tests {
         let output_dir: Option<PathBuf> = None;
         let base_url: Option<String> = None;
         let no_port_append = false;
-        let ws_port: Option<u16> = None;
         let expected_base_url = String::from("http://127.0.0.1:1111");
 
         create_and_verify_new_site(
@@ -961,7 +1033,6 @@ mod tests {
             output_dir.as_deref(),
             base_url.as_deref(),
             no_port_append,
-            ws_port,
             expected_base_url,
         );
     }
@@ -974,7 +1045,6 @@ mod tests {
         let output_dir: Option<PathBuf> = None;
         let base_url: Option<String> = Some(String::from("localhost/path/to/site"));
         let no_port_append = false;
-        let ws_port: Option<u16> = None;
         let expected_base_url = String::from("http://localhost:1111/path/to/site");
 
         create_and_verify_new_site(
@@ -983,7 +1053,6 @@ mod tests {
             output_dir.as_deref(),
             base_url.as_deref(),
             no_port_append,
-            ws_port,
             expected_base_url,
         );
     }
@@ -996,7 +1065,6 @@ mod tests {
         let output_dir: Option<PathBuf> = None;
         let base_url: Option<String> = Some(String::from("example.com"));
         let no_port_append = true;
-        let ws_port: Option<u16> = None;
         let expected_base_url = String::from("http://example.com");
 
         // Note that no_port_append only works if we define a base_url
@@ -1007,7 +1075,6 @@ mod tests {
             output_dir.as_deref(),
             base_url.as_deref(),
             no_port_append,
-            ws_port,
             expected_base_url,
         );
     }
@@ -1020,7 +1087,6 @@ mod tests {
         let output_dir: Option<PathBuf> = None;
         let base_url: Option<String> = Some(String::from("https://example.com"));
         let no_port_append = true;
-        let ws_port: Option<u16> = None;
         let expected_base_url = String::from("https://example.com");
 
         // Note that no_port_append only works if we define a base_url
@@ -1031,7 +1097,6 @@ mod tests {
             output_dir.as_deref(),
             base_url.as_deref(),
             no_port_append,
-            ws_port,
             expected_base_url,
         );
     }
@@ -1043,7 +1108,6 @@ mod tests {
         let output_dir: Option<PathBuf> = None;
         let base_url: Option<String> = Some(String::from("https://example.com/path/to/site"));
         let no_port_append = true;
-        let ws_port: Option<u16> = None;
         let expected_base_url = String::from("https://example.com/path/to/site");
 
         // Note that no_port_append only works if we define a base_url
@@ -1054,7 +1118,6 @@ mod tests {
             output_dir.as_deref(),
             base_url.as_deref(),
             no_port_append,
-            ws_port,
             expected_base_url,
         );
     }
@@ -1067,7 +1130,6 @@ mod tests {
         let output_dir: Option<PathBuf> = None;
         let base_url: Option<String> = Some(String::from("https://example.com/path/to/site"));
         let no_port_append = false;
-        let ws_port: Option<u16> = None;
         let expected_base_url = String::from("https://example.com:1111/path/to/site");
 
         // Note that no_port_append only works if we define a base_url
@@ -1078,7 +1140,6 @@ mod tests {
             output_dir.as_deref(),
             base_url.as_deref(),
             no_port_append,
-            ws_port,
             expected_base_url,
         );
     }


### PR DESCRIPTION
Migrates the live reload WebSocket server from the standalone `ws` crate to native Axum WebSocket support:

- Replace ws::WebSocket with axum's built-in WebSocket extractor
- Use tokio::sync::broadcast for message broadcasting to clients
- Integrate WebSocket endpoint into main Axum router at /livereload
- Serve livereload.js via dedicated route instead of fallback handler
- Remove separate WebSocket server thread (now runs on same port as HTTP)

Also fixes build error notification via WebSocket:

- Send reload message on build errors so browser auto-refreshes
- Handle 404 responses in error_injection_middleware for error display
- Include livereload.js in error page so it can reload when fixed
- Don't interfere with WebSocket upgrades (101) in middleware

Additional improvements:

- Add WebSocket ping/pong keepalive (30s interval) for connection health
- Add graceful shutdown support via with_graceful_shutdown()
- Handle Message::Close and Message::Pong explicitly in WebSocket handler
- Remove vestigial ws_port variable (WebSocket now on same port as HTTP)
- Remove unnecessary #[derive(Clone)] from AppState (already Arc-wrapped)

Dependencies:

- Add "ws" feature to axum for WebSocket support
- Add "sync" feature to tokio for broadcast channels
- Remove ws, tower, tower-http, tracing, tracing-subscriber crates

**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



