### PR TITLE
Fix components/utils build

### DIFF
--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -13,7 +13,7 @@ percent-encoding = { workspace = true }
 regex = { workspace = true }
 slug = { workspace = true }
 tera = { workspace = true }
-time = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
 toml = { workspace = true }
 walkdir = { workspace = true }
 
@@ -21,4 +21,4 @@ errors = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
-time = { workspace = true, features = ["macros"] }
+time = { workspace = true, features = ["formatting", "macros"] }


### PR DESCRIPTION
Running `cargo build` from `components/utils` fails because `components/utils/src/de.rs` uses `time::format_description`. This module doesn't exist unless `time`'s `formatting` feature is enabled.

```
error[E0433]: failed to resolve: could not find `format_description` in `time`
   --> components/utils/src/de.rs:7:11
    |
  7 | use time::format_description::well_known::Rfc3339;
    |           ^^^^^^^^^^^^^^^^^^ could not find `format_description` in `time`
    |
note: found an item that was configured out
   --> /home/wcarv/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/time-0.3.44/src/lib.rs:101:9
    |
100 | #[cfg(any(feature = "formatting", feature = "parsing"))]
    |          --------------------------------------------- the item is gated here
101 | pub mod format_description;
    |         ^^^^^^^^^^^^^^^^^^

error[E0599]: no method named `format` found for struct `OffsetDateTime` in the current scope
  --> components/utils/src/de.rs:84:27
   |
84 |                 Ok(Some(d.format(&Rfc3339).unwrap()))
   |                           ^^^^^^ method not found in `OffsetDateTime`

Some errors have detailed explanations: E0433, E0599.
```

## Sanity check:

* ✔️  Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* ✔️ Are you doing the PR on the `next` branch?
* ➖ Have you created/updated the relevant documentation page(s)?