### PR TITLE
Fix license in metainfo

### DIFF
--- a/zola.metainfo.xml
+++ b/zola.metainfo.xml
@@ -10,7 +10,7 @@
   </developer>
 
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>EUPL 1.2</project_license>
+  <project_license>EUPL-1.2</project_license>
 
   <description>
     <p>


### PR DESCRIPTION
- Use SPDX license name

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)?



