### PR TITLE
fix: multi-language search index configuration mismatch

### DIFF
--- a/components/search/src/elasticlunr.rs
+++ b/components/search/src/elasticlunr.rs
@@ -86,7 +86,7 @@ pub fn build_index(lang: &str, library: &Library, config: &Config) -> Result<Str
     let items = collect_index_items(lang, library);
 
     for item in items {
-        index.add_doc(item.url, fill_index(&config.search, item));
+        index.add_doc(item.url, fill_index(&language_options.search, item));
     }
 
     Ok(index.to_json())

--- a/test_site_i18n/config.toml
+++ b/test_site_i18n/config.toml
@@ -16,6 +16,12 @@ taxonomies = [
     {name = "tags"},
 ]
 
+[search]
+include_title = true
+include_description = true
+include_path = true
+include_content = true
+
 [languages.fr]
 generate_feeds = true
 taxonomies = [


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

If the change is a new feature or adding to/changing an existing one:

* [x] Have you created/updated the relevant documentation page(s)? *(N/A - bug fix only, no behavior change)*

---

## Description

Resolves #3098.

Currently, latest Zola (0.22.1) causes a panic when building search indexes for multi-language sites with more than 2 indexed fields.

`build_index()` uses `language_options.search` to build the index structure but `config.search` to fill it with data, causing a field count mismatch that triggers an "index out of bounds" panic in elasticlunr-rs.

## Changes

- Ensures both `build_fields()` and `fill_index()` use the same config, restoring v0.22.0 behavior.
- In `test_site_i18n/config.toml`, added `[search]` section with 4 fields to make the existing `can_build_multilingual_site()` test catch this regression.