### PR TITLE
fix: reject unknown fields in highlighting config

### DIFF
--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -14,22 +14,20 @@ pub enum HighlightStyle {
     Class,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum HighlightConfig {
-    Single { theme: String },
-    Dual { light_theme: String, dark_theme: String },
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Highlighting {
     /// Emit an error for missing highlight languages. Defaults to false
     #[serde(default)]
     pub error_on_missing_language: bool,
     #[serde(default)]
     pub style: HighlightStyle,
-    #[serde(flatten)]
-    pub theme: HighlightConfig,
+    /// Single theme name. Mutually exclusive with light_theme/dark_theme.
+    pub theme: Option<String>,
+    /// Light theme for dual-theme mode.
+    pub light_theme: Option<String>,
+    /// Dark theme for dual-theme mode.
+    pub dark_theme: Option<String>,
     #[serde(default)]
     pub extra_grammars: Vec<String>,
     #[serde(default)]
@@ -54,20 +52,29 @@ impl Highlighting {
 
         registry.link_grammars();
 
-        match &self.theme {
-            HighlightConfig::Single { theme } => {
+        match (&self.theme, &self.light_theme, &self.dark_theme) {
+            (Some(theme), None, None) => {
                 if !registry.contains_theme(theme) {
                     bail!("Theme `{theme}` does not exist");
                 }
             }
-            HighlightConfig::Dual { light_theme, dark_theme } => {
+            (None, Some(light_theme), Some(dark_theme)) => {
                 if !registry.contains_theme(light_theme) {
                     bail!("Theme `{light_theme}` does not exist");
                 }
-
                 if !registry.contains_theme(dark_theme) {
                     bail!("Theme `{dark_theme}` does not exist");
                 }
+            }
+            (None, None, None) => {
+                bail!(
+                    "No theme specified in [markdown.highlighting]. Set either `theme` or both `light_theme` and `dark_theme`"
+                );
+            }
+            _ => {
+                bail!(
+                    "Invalid theme configuration: set either `theme` alone, or both `light_theme` and `dark_theme`"
+                );
             }
         }
 
@@ -87,38 +94,34 @@ impl Highlighting {
             return out;
         }
 
-        // we know themes are present so unwrap
-        match &self.theme {
-            HighlightConfig::Single { theme } => {
-                out.push((
-                    "giallo.css",
-                    self.registry.generate_css(theme, "z-").expect("theme to be present"),
-                ));
-            }
-            HighlightConfig::Dual { light_theme, dark_theme } => {
-                out.push((
-                    "giallo-light.css",
-                    self.registry.generate_css(light_theme, "z-").expect("theme to be present"),
-                ));
-                out.push((
-                    "giallo-dark.css",
-                    self.registry.generate_css(dark_theme, "z-").expect("theme to be present"),
-                ));
-            }
+        if let Some(theme) = &self.theme {
+            out.push((
+                "giallo.css",
+                self.registry.generate_css(theme, "z-").expect("theme to be present"),
+            ));
+        } else if let (Some(light_theme), Some(dark_theme)) = (&self.light_theme, &self.dark_theme)
+        {
+            out.push((
+                "giallo-light.css",
+                self.registry.generate_css(light_theme, "z-").expect("theme to be present"),
+            ));
+            out.push((
+                "giallo-dark.css",
+                self.registry.generate_css(dark_theme, "z-").expect("theme to be present"),
+            ));
         }
 
         out
     }
 
     pub fn highlight_options<'a>(&'a self, lang: &'a str) -> HighlightOptions {
-        let mut opt = match &self.theme {
-            HighlightConfig::Single { theme } => {
-                HighlightOptions::new(lang, ThemeVariant::Single(theme))
-            }
-            HighlightConfig::Dual { light_theme, dark_theme } => HighlightOptions::new(
-                lang,
-                ThemeVariant::Dual { light: light_theme, dark: dark_theme },
-            ),
+        let mut opt = if let Some(theme) = &self.theme {
+            HighlightOptions::new(lang, ThemeVariant::Single(theme))
+        } else {
+            // Validated in init(): light_theme and dark_theme are both present
+            let light = self.light_theme.as_deref().unwrap();
+            let dark = self.dark_theme.as_deref().unwrap();
+            HighlightOptions::new(lang, ThemeVariant::Dual { light, dark })
         };
 
         if !self.error_on_missing_language {

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::config::{
     languages::LanguageOptions,
     link_checker::LinkChecker,
     link_checker::LinkCheckerLevel,
-    markup::{HighlightConfig, HighlightStyle, Highlighting, Markdown},
+    markup::{HighlightStyle, Highlighting, Markdown},
     search::{IndexFormat, Search},
     slugify::Slugify,
     taxonomies::TaxonomyConfig,

--- a/components/markdown/benches/all.rs
+++ b/components/markdown/benches/all.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use config::{Config, HighlightConfig, Highlighting};
+use config::{Config, Highlighting};
 use criterion::{Criterion, criterion_group, criterion_main};
 use markdown::{MarkdownContext, render_content};
 use std::hint::black_box;
@@ -99,7 +99,9 @@ fn bench_with_highlighting(c: &mut Criterion) {
     let mut highlighting = Highlighting {
         error_on_missing_language: false,
         style: Default::default(),
-        theme: HighlightConfig::Single { theme: "github-dark".to_string() },
+        theme: Some("github-dark".to_string()),
+        light_theme: None,
+        dark_theme: None,
         extra_grammars: vec![],
         extra_themes: vec![],
         registry: Default::default(),

--- a/components/site/benches/load.rs
+++ b/components/site/benches/load.rs
@@ -1,7 +1,7 @@
 //! Benchmarking loading/markdown of generated sites of various sizes
 use std::env;
 
-use config::{HighlightConfig, Highlighting};
+use config::Highlighting;
 use criterion::{Criterion, criterion_group, criterion_main};
 use site::Site;
 
@@ -25,7 +25,9 @@ fn bench_loading_small_blog_with_syntax_highlighting(c: &mut Criterion) {
     let mut highlighting = Highlighting {
         error_on_missing_language: false,
         style: Default::default(),
-        theme: HighlightConfig::Single { theme: "github-dark".to_string() },
+        theme: Some("github-dark".to_string()),
+        light_theme: None,
+        dark_theme: None,
         extra_grammars: vec![],
         extra_themes: vec![],
         registry: Default::default(),
@@ -59,7 +61,9 @@ fn bench_loading_small_kb_with_syntax_highlighting(c: &mut Criterion) {
     let mut highlighting = Highlighting {
         error_on_missing_language: false,
         style: Default::default(),
-        theme: HighlightConfig::Single { theme: "github-dark".to_string() },
+        theme: Some("github-dark".to_string()),
+        light_theme: None,
+        dark_theme: None,
         extra_grammars: vec![],
         extra_themes: vec![],
         registry: Default::default(),

--- a/components/templates/src/filters/markdown.rs
+++ b/components/templates/src/filters/markdown.rs
@@ -81,7 +81,7 @@ impl Filter<&str, TeraResult<String>> for MarkdownFilter {
 mod tests {
     use std::collections::HashMap;
 
-    use config::{Config, HighlightConfig, HighlightStyle, Highlighting, Registry};
+    use config::{Config, HighlightStyle, Highlighting, Registry};
     use giallo::DataAttrPosition;
     use tera::{Context, Filter, Kwargs, State, Value};
 
@@ -148,7 +148,9 @@ mod tests {
         config.markdown.highlighting = Some(Highlighting {
             error_on_missing_language: false,
             style: HighlightStyle::Inline,
-            theme: HighlightConfig::Single { theme: "github-dark".to_string() },
+            theme: Some("github-dark".to_string()),
+            light_theme: None,
+            dark_theme: None,
             extra_grammars: vec![],
             extra_themes: vec![],
             data_attr_position: DataAttrPosition::default(),


### PR DESCRIPTION
Add `#[serde(deny_unknown_fields)]` to the `Highlighting` struct so that typos like `extra_grammar` (instead of `extra_grammars`) produce a clear deserialization error instead of being silently ignored.

The existing `#[serde(flatten)]` on `HighlightConfig` was incompatible with `deny_unknown_fields` (a known serde limitation), so the theme configuration is now represented as explicit `theme`, `light_theme`, and `dark_theme` fields with validation in `init()`.

Invalid combinations (e.g. specifying both `theme` and `light_theme`) are caught with a descriptive error message.

Closes #3127