### PR TITLE
docs: Change config.toml to zola.toml

### DIFF
--- a/docs/content/documentation/_index.md
+++ b/docs/content/documentation/_index.md
@@ -7,7 +7,7 @@ Getting started
  - Installation
  - CLI usage
  - Directory structure
- - config.toml
+ - zola.toml
  
 Content
  - Organisation

--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -15,7 +15,7 @@ resize_image(path, width, height, op, format, quality, speed)
 ### Arguments
 
 - `path`: The path to the source image. The following directories will be searched, in this order:
-    - `/` (the root of the project; that is, the directory with your `config.toml`)
+    - `/` (the root of the project; that is, the directory with your `zola.toml`)
     - `/static`
     - `/content`
     - `/public`

--- a/docs/content/documentation/content/linking.md
+++ b/docs/content/documentation/content/linking.md
@@ -34,7 +34,7 @@ links working.
 It is possible to have Zola automatically insert anchor links next to the heading, as you can see on this documentation
 if you hover a title or covering the full heading text.
 
-This option is set in the global [`config.toml`](@/documentation/getting-started/configuration.md)'s `[markdown]` section and can be overridden at the section level with the `insert_anchor_links` variable on the
+This option is set in the global [`zola.toml`](@/documentation/getting-started/configuration.md)'s `[markdown]` section and can be overridden at the section level with the `insert_anchor_links` variable on the
 [section front matter page](@/documentation/content/section.md#front-matter).
 
 The default template is very basic and will need CSS tweaks in your project to look decent.
@@ -58,4 +58,4 @@ to link to. The path to the file starts from the `content` directory.
 For example, linking to a file located at `content/pages/about.md` would be `[my link](@/pages/about.md)`.
 You can still link to an anchor directly; `[my link](@/pages/about.md#example)` will work as expected.
 
-By default, broken internal links are treated as errors.  To treat them as warnings instead, visit the `[link_checker]` section of `config.toml` and set `internal_level = "warn"`.  Note: treating broken links as warnings allows the site to be built with broken links intact, so a link such as `[my link](@/pages/whoops.md)` will be rendered to HTML as `<a href="@/pages/whoops.md">`.
+By default, broken internal links are treated as errors.  To treat them as warnings instead, visit the `[link_checker]` section of `zola.toml` and set `internal_level = "warn"`.  Note: treating broken links as warnings allows the site to be built with broken links intact, so a link such as `[my link](@/pages/whoops.md)` will be rendered to HTML as `<a href="@/pages/whoops.md">`.

--- a/docs/content/documentation/content/multilingual.md
+++ b/docs/content/documentation/content/multilingual.md
@@ -7,7 +7,7 @@ Zola supports having a site in multiple languages.
 
 ## Configuration
 To get started, you will need to add the languages you want to support
-to your `config.toml`. For example:
+to your `zola.toml`. For example:
 
 ```toml
 [languages.fr]

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -144,7 +144,7 @@ in_search_index = true
 template = "page.html"
 
 # The taxonomies for this page. The keys need to be the same as the taxonomy
-# names configured in `config.toml` and the values are an array of String objects. For example,
+# names configured in `zola.toml` and the values are an array of String objects. For example,
 # tags = ["rust", "web"].
 [taxonomies]
 

--- a/docs/content/documentation/content/sass.md
+++ b/docs/content/documentation/content/sass.md
@@ -17,7 +17,7 @@ with dart-sass.
 ## Using Sass in Zola
 
 Zola always compiles Sass files in theme directories.
-However, for Zola to process files in the `sass` folder, you need to set `compile_sass = true` in your `config.toml`.
+However, for Zola to process files in the `sass` folder, you need to set `compile_sass = true` in your `zola.toml`.
 
 Zola processes any files with the `sass` or `scss` extension in the `sass`
 folder, and places the processed output into a `css` file with the same folder

--- a/docs/content/documentation/content/search.md
+++ b/docs/content/documentation/content/search.md
@@ -6,10 +6,10 @@ weight = 100
 Zola can build a search index from the sections and pages content to
 be used by a JavaScript library such as [elasticlunr](http://elasticlunr.com/) or [fuse](https://www.fusejs.io).
 
-To enable it, you only need to set `build_search_index = true` in your `config.toml` and Zola will
+To enable it, you only need to set `build_search_index = true` in your `zola.toml` and Zola will
 generate an index for the `default_language` set for all pages not excluded from the search index.
 
-It is very important to set the `default_language` in your `config.toml` if you are writing a site not in
+It is very important to set the `default_language` in your `zola.toml` if you are writing a site not in
 English; the index building pipelines are very different depending on the language.
 
 As each site will be different, Zola makes no assumptions about your search function and doesn't provide
@@ -28,7 +28,7 @@ to truncate the content in the [search configuration](@/documentation/getting-st
 Compatible with [elasticlunr](http://elasticlunr.com/). Also produces `elasticlunr.min.js`.
 
 ```toml
-# config.toml
+# zola.toml
 [search]
 index_format = "elasticlunr_javascript" # or "elasticlunr_json"
 ```
@@ -41,7 +41,7 @@ See <https://github.com/weixsong/lunr-languages#in-a-web-browser> for details.
 Compatible with [fuse.js](https://www.fusejs.io/) and [tinysearch](https://github.com/tinysearch/tinysearch).
 
 ```toml
-# config.toml
+# zola.toml
 [search]
 index_format = "fuse_javascript" # or "fuse_json"
 ```

--- a/docs/content/documentation/content/taxonomies.md
+++ b/docs/content/documentation/content/taxonomies.md
@@ -73,7 +73,7 @@ For example the default would be `page/1`.
 - `lang`: only set this if you are making a multilingual site and want to indicate which language this taxonomy is for
 - `render`: if set to `false`, pages will not be rendered for the taxonomy or for individual terms.
 
-Insert into the configuration file (`config.toml`):
+Insert into the configuration file (`zola.toml`):
 
 ⚠️ Place the taxonomies key in the main section and not in the `[extra]` section
 

--- a/docs/content/documentation/deployment/azure-static-webapps.md
+++ b/docs/content/documentation/deployment/azure-static-webapps.md
@@ -10,7 +10,7 @@ Follow the [official documentation](https://learn.microsoft.com/en-us/azure/stat
 
 Instead, for the`Build Details` section, set the App location as `./public` since that is where `zola build` will write the site content to by default. Leave the other boxes empty.
 
-After creating the web app, make note of the domain automatically created by Azure and update `base_url` in your repo's `config.toml` to that URL.
+After creating the web app, make note of the domain automatically created by Azure and update `base_url` in your repo's `zola.toml` to that URL.
 
 
 ### Configuring GitHub Actions

--- a/docs/content/documentation/deployment/cloudflare-pages.md
+++ b/docs/content/documentation/deployment/cloudflare-pages.md
@@ -23,7 +23,7 @@ You may find documentation and guides like [Getting started with Cloudflare Page
 
 ## Handling preview deployments
 
-When working with Cloudflare Pages, you'll often use preview deployments for testing changes before merging to your main branch. By default, these preview deployments use different URLs (like `https://your-branch-name.your-project.pages.dev`), which can cause issues with asset loading if your `base_url` is hardcoded in your `config.toml`.
+When working with Cloudflare Pages, you'll often use preview deployments for testing changes before merging to your main branch. By default, these preview deployments use different URLs (like `https://your-branch-name.your-project.pages.dev`), which can cause issues with asset loading if your `base_url` is hardcoded in your `zola.toml`.
 
 To fix this, modify your build command in the Cloudflare Pages configuration to dynamically set the base URL depending on the environment:
 
@@ -33,7 +33,7 @@ if [ "$CF_PAGES_BRANCH" = "main" ]; then zola build; else zola build --base-url 
 
 This command:
 
-- Uses your `config.toml` `base_url` when building from the main branch
+- Uses your `zola.toml` `base_url` when building from the main branch
 - Uses the preview deployment URL (automatically provided by Cloudflare Pages as `$CF_PAGES_URL`) for all other branches
 
 ## Troubleshooting

--- a/docs/content/documentation/deployment/flyio.md
+++ b/docs/content/documentation/deployment/flyio.md
@@ -25,7 +25,7 @@ You can now run `fly launch`. It will detect the `Dockerfile` and mostly auto-co
 
 Take note of the hostname assigned to your app.
 
-If you already have a Zola site you must now ensure that `base_url` in `config.toml` is set correctly using the hostname from your app (or whatever domain you have pointing to the app):
+If you already have a Zola site you must now ensure that `base_url` in `zola.toml` is set correctly using the hostname from your app (or whatever domain you have pointing to the app):
 
     base_url = "https://white-snow-9922.fly.dev"
 

--- a/docs/content/documentation/getting-started/cli-usage.md
+++ b/docs/content/documentation/getting-started/cli-usage.md
@@ -11,7 +11,7 @@ that for a specific command by running `zola <cmd> --help`.
 ## init
 
 Creates the directory structure used by Zola at the given directory after asking a few basic configuration questions.
-Any choices made during these prompts can be easily changed by modifying `config.toml`.
+Any choices made during these prompts can be easily changed by modifying `zola.toml`.
 
 ```bash
 $ zola init my_site
@@ -52,7 +52,7 @@ You can override the default output directory `public` by passing another value 
 $ zola build --output-dir $DOCUMENT_ROOT
 ```
 
-You can point to a config file other than `config.toml` like so (note that the position of the `config` option is important):
+You can point to a config file other than `zola.toml` like so (note that the position of the `config` option is important):
 
 ```bash
 $ zola --config config.staging.toml build
@@ -107,7 +107,7 @@ flag.
 You may use `-d1` to (virtually) disable it altogether: for technical reasons
 (and keeping things simple), a "debounce" of 0 is not supported.
 
-You can also point to a config file other than `config.toml` like so (note that the position of the `config` option is important):
+You can also point to a config file other than `zola.toml` like so (note that the position of the `config` option is important):
 
 ```bash
 $ zola --config config.staging.toml serve

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -6,12 +6,14 @@ weight = 40
 The default configuration is sufficient to get Zola running locally but not more than that.
 It follows the philosophy of paying for only what you need, almost everything is turned off by default.
 
-To change the configuration, edit the `config.toml` file.
+To change the configuration, edit the `zola.toml` file.
 If you are not familiar with TOML, have a look at [the TOML spec](https://github.com/toml-lang/toml).
 
-⚠️ If you add keys to your `config.toml`, you must pay attention to which TOML section it belongs to. A TOML section starts with a header, e.g. `[search]`, and ends at the next section or EOF.
+> The configuration file was previously named config.toml. Zola loads config.toml as a fallback if zola.toml does not exist. 
 
-Here are the current `config.toml` sections:
+⚠️ If you add keys to your `zola.toml`, you must pay attention to which TOML section it belongs to. A TOML section starts with a header, e.g. `[search]`, and ends at the next section or EOF.
+
+Here are the current `zola.toml` sections:
 1. main (unnamed)
 2. markdown
 3. link_checker

--- a/docs/content/documentation/getting-started/directory-structure.md
+++ b/docs/content/documentation/getting-started/directory-structure.md
@@ -8,7 +8,7 @@ After running `zola init`, you should see the following structure in your direct
 
 ```bash
 .
-├── config.toml
+├── zola.toml
 ├── content
 ├── sass
 ├── static
@@ -20,9 +20,9 @@ After running `zola init`, you should see the following structure in your direct
 
 You might also see a `public` directory if you are running the default `zola build/serve` commands which contains some output for the site: the full site for `zola build` and only the static assets for `zola serve`. This folder will be deleted/created automatically by `zola serve`.
 
-Here's a high-level overview of each of these directories and `config.toml`.
+Here's a high-level overview of each of these directories and `zola.toml`.
 
-## `config.toml`
+## `zola.toml`
 A mandatory Zola configuration file in TOML format.
 This file is explained in detail in the [configuration documentation](@/documentation/getting-started/configuration.md).
 

--- a/docs/content/documentation/getting-started/overview.md
+++ b/docs/content/documentation/getting-started/overview.md
@@ -39,7 +39,7 @@ You will be asked a few questions.
  For our blog, let's accept the default values (i.e., press Enter for each question). We now have a `myblog` directory with the following structure:
 
 ```
-├── config.toml
+├── zola.toml
 ├── content
 ├── sass
 ├── static
@@ -50,7 +50,7 @@ You will be asked a few questions.
 For reference, by the **end** of this overview, our `myblog` directory will have the following structure:
 
 ```
-├── config.toml
+├── zola.toml
 ├── content/
 │   └── blog/
 │       ├── _index.md
@@ -165,7 +165,7 @@ Done in 13ms.
 
 Web server is available at http://127.0.0.1:1111
 
-Listening for changes in .../myblog/{config.toml,content,sass,static,templates}
+Listening for changes in .../myblog/{zola.toml,content,sass,static,templates}
 Press Ctrl+C to stop
 ```
 

--- a/docs/content/documentation/templates/feeds/index.md
+++ b/docs/content/documentation/templates/feeds/index.md
@@ -4,9 +4,9 @@ weight = 50
 aliases = ["/documentation/templates/rss/"]
 +++
 
-If the site `config.toml` file sets `generate_feeds = true`, then Zola will
+If the site `zola.toml` file sets `generate_feeds = true`, then Zola will
 generate feed files for the site, named according to the `feed_filenames`
-setting in `config.toml`, which defaults to `atom.xml`. Given the feed filename
+setting in `zola.toml`, which defaults to `atom.xml`. Given the feed filename
 `atom.xml`, the generated file will live at `base_url/atom.xml`, based upon the
 `atom.xml` file in the `templates` directory, or the built-in Atom template.
 
@@ -55,7 +55,7 @@ Feeds for taxonomy terms get two more variables, using types from the
 
 You can also enable separate feeds for each section by setting the
 `generate_feeds` variable to true in the respective section's front matter.
-Section feeds will use the same template as indicated in the `config.toml` file.
+Section feeds will use the same template as indicated in the `zola.toml` file.
 Section feeds, in addition to the five feed template variables, get the
 `section` variable from the [section
 template](@/documentation/templates/pages-sections.md).

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -102,7 +102,7 @@ Format a number into its string representation.
 <!-- 1,000,000 -->
 ```
 
-By default this will format the number using the locale set by `config.default_language` in config.toml.
+By default this will format the number using the locale set by `config.default_language` in zola.toml.
 
 To format a number for a specific locale, you can use the `locale` argument and pass the name of the desired locale:
 
@@ -120,7 +120,7 @@ to make it easier to develop complex sites.
 For functions that are searching for a file on disk other than through `get_page` and `get_section`, the following
 logic applies.
 
-1. The base directory is the Zola root directory, where the `config.toml` is
+1. The base directory is the Zola root directory, where the `zola.toml` is
 2. For the given path: if it starts with `@/`, replace that with `content/` instead and trim any leading `/`
 3. Search in the following locations in this order, returning the first where the file exists:
    1. `$base_directory` + `$path`
@@ -188,7 +188,7 @@ Gets the permalink for the taxonomy item found.
 `name` will almost always come from a variable but in case you want to do it manually,
 the value should be the same as the one in the front matter, not the slugified version.
 
-`lang` (optional) default to `config.default_language` in config.toml
+`lang` (optional) default to `config.default_language` in zola.toml
 
 `required` (optional) if a taxonomy is defined but there isn't any content that uses it then throw an error. Defaults to true.
 
@@ -208,7 +208,7 @@ lang: String;
 permalink: String;
 ```
 
-`lang` (optional) default to `config.default_language` in config.toml
+`lang` (optional) default to `config.default_language` in zola.toml
 
 `required` (optional) if a taxonomy is defined but there isn't any content that uses it then throw an error. Defaults to true.
 
@@ -223,7 +223,7 @@ Gets a single term from a taxonomy of a specific kind.
 
 The type of the output is a single `TaxonomyTerm` item.
 
-`lang` (optional) default to `config.default_language` in config.toml
+`lang` (optional) default to `config.default_language` in zola.toml
 
 `include_pages` (optional) default to true. If false, the `pages` item in the `TaxonomyTerm` will be empty, regardless of what pages may actually exist for this term. `page_count` will correctly reflect the number of pages for this term in both cases.
 

--- a/docs/content/documentation/templates/pagination.md
+++ b/docs/content/documentation/templates/pagination.md
@@ -56,7 +56,7 @@ See the [taxonomies page](@/documentation/templates/taxonomies.md) for a detaile
 
 It is preferable to not include paginated pages in sitemap since they are non-canonical pages.
 To exclude paginated pages in sitemap, set the
-`exclude_paginated_pages_in_sitemap` as `all` in `config.toml`.
+`exclude_paginated_pages_in_sitemap` as `all` in `zola.toml`.
 
 ## Example
 

--- a/docs/content/documentation/themes/creating-a-theme.md
+++ b/docs/content/documentation/themes/creating-a-theme.md
@@ -25,7 +25,7 @@ min_version = "0.4.0"
 # An optional live demo URL
 demo = ""
 
-# Any variable there can be overridden in the end user `config.toml`
+# Any variable there can be overridden in the end user `zola.toml`
 # You don't need to prefix variables by the theme name but as this will
 # be merged with user data, some kind of prefix or nesting is preferable
 # Use snake_casing to be consistent with the rest of Zola

--- a/docs/content/documentation/themes/installing-and-using-themes.md
+++ b/docs/content/documentation/themes/installing-and-using-themes.md
@@ -56,7 +56,7 @@ Some custom data
 Most themes will also provide some variables that are meant to be overridden. This happens in the `extra` section
 of the [configuration file](@/documentation/getting-started/configuration.md).
 Let's say a theme uses a `show_twitter` variable and sets it to `false` by default. If you want to set it to `true`,
-you can update your `config.toml` like so:
+you can update your `zola.toml` like so:
 
 ```toml
 [extra]


### PR DESCRIPTION
This PR updates the documentation to use the zola.toml filename. References to config.toml in themes were not modified.
Issue: https://github.com/getzola/zola/issues/3103

I also put a note that mentions the name change and that config.toml is used if zola.toml doesn't exist.

<img width="1174" height="322" alt="image" src="https://github.com/user-attachments/assets/0a3ccb84-a20e-48be-9a75-8c6e7946a83f" />

---
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?