### PR TITLE
feat(content): use language-specific reading speeds for reading_time

### DIFF
--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -100,7 +100,7 @@ impl Page {
             page.file.find_language(&config.default_language, &config.other_languages_codes())?;
 
         page.raw_content = content.to_string();
-        let (word_count, reading_time) = get_reading_analytics(&page.raw_content);
+        let (word_count, reading_time) = get_reading_analytics(&page.raw_content, &page.lang);
         page.word_count = Some(word_count);
         page.reading_time = Some(reading_time);
 

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -79,7 +79,7 @@ impl Section {
             .file
             .find_language(&config.default_language, &config.other_languages_codes())?;
         section.raw_content = content.to_string();
-        let (word_count, reading_time) = get_reading_analytics(&section.raw_content);
+        let (word_count, reading_time) = get_reading_analytics(&section.raw_content, &section.lang);
         section.word_count = Some(word_count);
         section.reading_time = Some(reading_time);
 

--- a/components/content/src/utils.rs
+++ b/components/content/src/utils.rs
@@ -56,16 +56,61 @@ pub fn find_related_assets(path: &Path, config: &Config, recursive: bool) -> Vec
     assets
 }
 
-/// Get word count and estimated reading time
-pub fn get_reading_analytics(content: &str) -> (usize, usize) {
+/// Get word count and estimated reading time.
+///
+/// Rates are silent-reading speeds of young adults for non-fiction text,
+/// sourced from each language's ophthalmology, education, or media research
+/// society journals.
+///
+/// `zh`/`ja` use character counts (cpm); other languages use word counts via
+/// `unicode_words()`. Unlisted languages fall back to 200 wpm.
+///
+/// Per-language reading rates:
+///
+/// - en (238 wpm) — Brysbaert (2019)
+///   "How many words do we read per minute? A review and meta-analysis of reading rate"
+///   J. of Memory and Language.
+///   https://doi.org/10.1016/j.jml.2019.104047
+///
+/// - ko (202 wpm) — 송지호・김재형・형성민 (2016)
+///   「한국어 읽기 속도 측정 애플리케이션의 유효성 및 정상인의 읽기 속도에 대한 사전 연구」
+///   대한안과학회지 57(4), 642-649.
+///   https://www.kci.go.kr/kciportal/ci/sereArticleSearch/ciSereArtiView.kci?sereArticleSearchBean.artiId=ART002099342
+///
+/// - zh (439 cpm) — 王影超・李赛男・宋子明・闫国利 (2024)
+///   《不同阅读方式对汉语句子阅读中词频效应的影响》
+///   心理与行为研究 22(2), 183-188.
+///   https://psybeh.tjnu.edu.cn/CN/10.12139/j.1672-0628.2024.02.005
+///
+/// - ja (653 cpm) — 小林潤平・川嶋稔夫 (2018)
+///   「日本語文章の読み速度の個人差をもたらす眼球運動」
+///   映像情報メディア学会誌.
+///   https://doi.org/10.3169/itej.72.J154
+pub fn get_reading_analytics(content: &str, lang: &str) -> (usize, usize) {
     // code fences "toggle" the state from non-code to code and back, so anything inbetween the
     // first fence and the next can be ignored
-    let split = content.split("```");
-    let word_count = split.step_by(2).map(|section| section.unicode_words().count()).sum();
+    let stripped = content.split("```").step_by(2);
+    let primary = lang.split('-').next().unwrap_or(lang);
 
-    // https://help.medium.com/hc/en-us/articles/214991667-Read-time
-    // 275 seems a bit too high though
-    (word_count, word_count.div_ceil(200))
+    let (count, per_minute): (usize, usize) = match primary {
+        "zh" => (stripped.map(count_cjk_chars).sum(), 439),
+        "ja" => (stripped.map(count_cjk_chars).sum(), 653),
+        _ => {
+            let count = stripped.map(|s| s.unicode_words().count()).sum();
+            let wpm = match primary {
+                "en" => 238,
+                "ko" => 202,
+                _ => 200,
+            };
+            (count, wpm)
+        }
+    };
+
+    (count, count.div_ceil(per_minute))
+}
+
+fn count_cjk_chars(s: &str) -> usize {
+    s.chars().filter(|c| c.is_alphabetic()).count()
 }
 
 #[cfg(test)]
@@ -220,14 +265,14 @@ mod tests {
 
     #[test]
     fn reading_analytics_empty_text() {
-        let (word_count, reading_time) = get_reading_analytics("  ");
+        let (word_count, reading_time) = get_reading_analytics("  ", "en");
         assert_eq!(word_count, 0);
         assert_eq!(reading_time, 0);
     }
 
     #[test]
     fn reading_analytics_short_text() {
-        let (word_count, reading_time) = get_reading_analytics("Hello World");
+        let (word_count, reading_time) = get_reading_analytics("Hello World", "en");
         assert_eq!(word_count, 2);
         assert_eq!(reading_time, 1);
     }
@@ -238,22 +283,54 @@ mod tests {
         for _ in 0..1000 {
             content.push_str(" Hello world");
         }
-        let (word_count, reading_time) = get_reading_analytics(&content);
+        let (word_count, reading_time) = get_reading_analytics(&content, "en");
         assert_eq!(word_count, 2000);
-        assert_eq!(reading_time, 10);
+        assert_eq!(reading_time, 9);
     }
 
     #[test]
     fn reading_analytics_no_code() {
         let (word_count, reading_time) =
-            get_reading_analytics("hello world ``` code goes here ``` goodbye world");
+            get_reading_analytics("hello world ``` code goes here ``` goodbye world", "en");
         assert_eq!(word_count, 4);
         assert_eq!(reading_time, 1);
 
         let (word_count, reading_time) = get_reading_analytics(
             "hello world ``` code goes here ``` goodbye world ``` dangling fence",
+            "en",
         );
         assert_eq!(word_count, 4);
         assert_eq!(reading_time, 1);
+    }
+
+    #[test]
+    fn reading_analytics_chinese_counts_chars() {
+        let (count, time) = get_reading_analytics("你好世界，这是中文测试。", "zh");
+        assert_eq!(count, 10);
+        assert_eq!(time, 1);
+    }
+
+    #[test]
+    fn reading_analytics_japanese_counts_chars() {
+        let (count, time) = get_reading_analytics("こんにちは、世界。", "ja");
+        assert_eq!(count, 7);
+        assert_eq!(time, 1);
+    }
+
+    #[test]
+    fn reading_analytics_zh_variant_subtag() {
+        let (count, _) = get_reading_analytics("你好世界", "zh-Hant-TW");
+        assert_eq!(count, 4);
+    }
+
+    #[test]
+    fn reading_analytics_unknown_lang_falls_back() {
+        let mut content = String::new();
+        for _ in 0..1000 {
+            content.push_str(" Hello world");
+        }
+        let (word_count, reading_time) = get_reading_analytics(&content, "xx");
+        assert_eq!(word_count, 2000);
+        assert_eq!(reading_time, 10);
     }
 }

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -31,9 +31,9 @@ summary: String?;
 taxonomies: HashMap<String, Array<String>>;
 extra: HashMap<String, Any>;
 toc: Array<Header>,
-// Naive word count, will not work for languages without whitespace
+// Word count via unicode_words; for `zh` and `ja` this is a character count
 word_count: Number;
-// Based on https://help.medium.com/hc/en-us/articles/214991667-Read-time
+// Estimated reading time in minutes, using per-language silent-reading rates
 reading_time: Number;
 // earlier / lighter
 lower: Page?;
@@ -90,9 +90,9 @@ pages: Array<Page>;
 // the actual section object if you need it
 subsections: Array<String>;
 toc: Array<Header>,
-// Unicode word count
+// Word count via unicode_words; for `zh` and `ja` this is a character count
 word_count: Number;
-// Based on https://help.medium.com/hc/en-us/articles/214991667-Read-time
+// Estimated reading time in minutes, using per-language silent-reading rates
 reading_time: Number;
 // Paths of colocated assets, relative to the content directory
 assets: Array<String>;


### PR DESCRIPTION
## Summary

Closes https://github.com/getzola/zola/issues/3141

`reading_time` previously used a fixed 200 wpm rate via `unicode_words()`.
This works for whitespace-delimited languages but yields meaningless counts for Chinese and Japanese.

This PR adds per-language silent-reading rates, sources from each language's society journals (young adults, non-fiction)

  | Lang | Rate    | Source |
  |------|---------|--------|
  | en   | 238 wpm | [Brysbaert (2019), *Journal of Memory and Language*](https://doi.org/10.1016/j.jml.2019.104047) |
  | ko   | 202 wpm | [송지호 외 (2016), *대한안과학회지*](https://www.kci.go.kr/kciportal/ci/sereArticleSearch/ciSereArtiView.kci?sereArticleSearchBean.artiId=ART002099342) |
  | zh   | 439 cpm | [王影超 等 (2024), *心理与行为研究*](https://psybeh.tjnu.edu.cn/CN/10.12139/j.1672-0628.2024.02.005) |
  | ja   | 653 cpm | [小林・川嶋 (2018), *映像情報メディア学会誌*](https://doi.org/10.3169/itej.72.J154) |

`zh` (Chinese) and `ja` (Japanese) are character-counted, other languages use unicode words count.
Unlisted languages fall back to previous 200wpm. (I expect contributors from each country to add their languages)

Measures on the three translations of the article from #3141,
  | Lang | reading_time |
  |------|--------------|
  | ko   | 18 min |
  | en   | 20 min |
  | ja   | 19 min |

The same content now produces consistent reading times across all three languages.