### PR TITLE
Fix frontmatter detection

### DIFF
--- a/components/content/src/front_matter/split.rs
+++ b/components/content/src/front_matter/split.rs
@@ -9,13 +9,13 @@ use crate::front_matter::section::SectionFrontMatter;
 
 static TOML_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"^[[:space:]]*\+\+\+(\r?\n(?s).*?(?-s))\+\+\+[[:space:]]*(?:$|(?:\r?\n((?s).*(?-s))$))",
+        r"^[[:space:]]*\+\+\+[[:space:]]*(\r?\n(?s).*?(?-s))\+\+\+[[:space:]]*(?:$|(?:\r?\n((?s).*(?-s))$))",
     )
     .unwrap()
 });
 
 static YAML_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[[:space:]]*---(\r?\n(?s).*?(?-s))---[[:space:]]*(?:$|(?:\r?\n((?s).*(?-s))$))")
+    Regex::new(r"^[[:space:]]*---[[:space:]]*(\r?\n(?s).*?(?-s))---[[:space:]]*(?:$|(?:\r?\n((?s).*(?-s))$))")
         .unwrap()
 });
 
@@ -118,6 +118,22 @@ date: 2002-10-12
 ---
 Hello
 "#; "yaml")]
+    #[test_case(r#"
++++  
+title = "Title"
+description = "hey there"
+date = 2002-10-12
++++
+Hello
+"#; "toml with trailing whitespace")]
+    #[test_case(r#"
+---  
+title: Title
+description: hey there
+date: 2002-10-12
+---
+Hello
+"#; "yaml with trailing whitespace")]
     fn can_split_page_content_valid(content: &str) {
         let (front_matter, content) = split_page_content(Path::new(""), content).unwrap();
         assert_eq!(content, "Hello\n");


### PR DESCRIPTION
# Summary
Fixes #3146
Currently, Zola does not detect the opening deliminator for frontmatter if it contains trailing whitespace.
This fix allows trailing whitespace, standardizing it with allowing leading whitespace for deliminators.

## Changes
The regex in `components/content/src/frontmatter/split/rs` was changed to allow 0 or more spaces after detection of `+++` or `---`
Change is in bold, and same change for yaml frontmatter detection:
<pre>^[[:space:]]*\+\+\+<b>[[:space:]]*</b>(\r?\n(?s).*?(?-s))\+\+\+[[:space:]]*(?:$|(?:\r?\n((?s).*(?-s))$))</pre>

Additionally, I also added tests to verify the fix in that same file (named "toml with trailing whitespace" and "yaml with trailing whitespace").

## Backwards compatibility
It is backwards compatible and passes all existing tests.