### PR TITLE
docs(docker): bump example to 0.22.1 and use uppercase AS

### DIFF
--- a/docs/content/documentation/deployment/docker-image.md
+++ b/docs/content/documentation/deployment/docker-image.md
@@ -11,7 +11,7 @@ Here is an example that builds the current folder, and put the result in a docke
 Of course, you may want to replace the second stage with another static web server like Nginx or Apache.
 
 ```Dockerfile
-FROM ghcr.io/getzola/zola:v0.17.1 as zola
+FROM ghcr.io/getzola/zola:v0.22.1 AS zola
 
 COPY . /project
 WORKDIR /project


### PR DESCRIPTION
Fixes #3147.

The Dockerfile snippet pinned `getzola/zola:v0.17.1`, which can't read configs written by 0.22.1+ (`could not find directory containing config file`). Bump to the current release and switch `as zola` → `AS zola` to match Docker's recommended casing.