### PR TITLE
fix(config): reject unknown highlighting fields

### DIFF
--- a/components/config/src/config/markup.rs
+++ b/components/config/src/config/markup.rs
@@ -26,6 +26,7 @@ pub enum HighlightConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Highlighting {
     /// Emit an error for missing highlight languages. Defaults to false
     #[serde(default)]

--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -537,6 +537,22 @@ base_url = "https://replace-this-with-your-url.com"
     }
 
     #[test]
+    fn errors_when_unknown_highlighting_field() {
+        let config = r#"
+title = "My site"
+base_url = "https://replace-this-with-your-url.com"
+
+[markdown.highlighting]
+theme = "base16-ocean-dark"
+extra_grammar = ["static/grammar/pillar.json"]
+        "#;
+
+        let config = Config::parse(config);
+        assert!(config.is_err());
+        assert!(config.unwrap_err().to_string().contains("extra_grammar"));
+    }
+
+    #[test]
     fn errors_when_missing_required_field() {
         // base_url is required
         let config = r#"


### PR DESCRIPTION
Closes #3127.

## What changed

- Add `deny_unknown_fields` to the `[markdown.highlighting]` config struct so misspelled keys like `extra_grammar` are reported while parsing `config.toml` instead of being silently ignored.
- Add a regression test for the singular `extra_grammar` typo from the issue.

## Verification

- `cargo fmt --check`
- `cargo test -p config`

## Risk

Low. This only tightens validation within the `[markdown.highlighting]` table and should surface existing typos as config errors rather than changing highlighting behavior for valid configs.
