### PR TITLE
docs: Fix docs for higher / lower when sorting by date

### DIFF
--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -60,9 +60,9 @@ pub struct Page {
     /// When <!-- more --> is found in the text, will take the content up to that part
     /// as summary
     pub summary: Option<String>,
-    /// The previous page when sorting: earlier/earlier_updated/lighter/prev
+    /// The previous page when sorting: later/later_updated/lighter/prev
     pub lower: Option<PathBuf>,
-    /// The next page when sorting: later/later_updated/heavier/next
+    /// The next page when sorting: earlier/earlier_updated/heavier/next
     pub higher: Option<PathBuf>,
     /// Toc made from the headings of the markdown file
     pub toc: Vec<Heading>,

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -167,9 +167,9 @@ The `sort_by` front-matter variable can have the following values:
 
 ### `date`
 This will sort all pages by their `date` field, from the most recent (at the
-top of the list) to the oldest (at the bottom of the list). Each page will
-get `page.lower` and `page.higher` variables that contain the pages with
-earlier and later dates, respectively.
+top of the list) to the oldest (at the bottom of the list). Each page will get
+`page.higher` and `page.lower` variables that contain the pages with earlier and
+later dates, respectively.
 
 ### `update_date`
 Same as `date` except it will take into account any `updated` date for the pages.

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -35,9 +35,9 @@ toc: Array<Header>,
 word_count: Number;
 // Based on https://help.medium.com/hc/en-us/articles/214991667-Read-time
 reading_time: Number;
-// earlier / lighter
+// later / lighter
 lower: Page?;
-// later / heavier
+// earlier / heavier
 higher: Page?;
 // Year/month/day is only set if the page has a date and month/day are 1-indexed
 year: Number?;


### PR DESCRIPTION
The documentation (and some doc comments) state that `lower` corresponds to earlier pages and `higher` to later pages when sorting by date. This is the opposite of what the code actually does.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?