### PR TITLE
fix: resolve #2816 — Img tags with relative paths have odd behavior

### DIFF
--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -160,6 +160,7 @@ impl Section {
             self.meta.insert_anchor_links.unwrap_or(config.markdown.insert_anchor_links),
         );
         context.set_shortcode_definitions(shortcode_definitions);
+        context.set_colocated_path(self.permalink.clone());
         context.set_current_page_path(&self.file.relative);
         context
             .tera_context
@@ -237,6 +238,50 @@ impl Section {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn colocated_base_uses_section_permalink() {
+        use std::collections::HashMap;
+
+        use config::Config;
+        use tera::Tera;
+
+        let config = Config::default();
+        let mut section = super::Section::default();
+        section.lang = config.default_language.clone();
+        section.permalink = "https://example.com/posts/".to_string();
+        section.raw_content = "[asset](image.png)".to_string();
+
+        let permalinks = HashMap::new();
+        let tera = Tera::default();
+        let shortcode_definitions = HashMap::new();
+
+        section.render_markdown(&permalinks, &tera, &config, &shortcode_definitions).unwrap();
+
+        assert!(section.content.contains("posts/image.png"));
+    }
+
+    #[test]
+    fn colocated_base_does_not_rewrite_absolute_links() {
+        use std::collections::HashMap;
+
+        use config::Config;
+        use tera::Tera;
+
+        let config = Config::default();
+        let mut section = super::Section::default();
+        section.lang = config.default_language.clone();
+        section.permalink = "https://example.com/posts/".to_string();
+        section.raw_content = "[ext](https://other.com/image.png)".to_string();
+
+        let permalinks = HashMap::new();
+        let tera = Tera::default();
+        let shortcode_definitions = HashMap::new();
+
+        section.render_markdown(&permalinks, &tera, &config, &shortcode_definitions).unwrap();
+
+        assert!(section.content.contains("https://other.com/image.png"));
+    }
+
     use std::fs::{File, create_dir, create_dir_all};
     use std::io::Write;
     use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary

Sections are always served at their own directory URL, and section assets are copied there, so relative asset links should resolve against the section permalink. Update section rendering to populate the new RenderContext field consistently with pages

Fixes #2816

## Changes

- `components/content/src/section.rs`

## Why

`components/content/src/section.rs`: Sections are always served at their own directory URL, and section assets are copied there, so relative asset links should resolve against the section permalink. Update section rendering to populate the new RenderContext field consistently with pages.
