### PR TITLE
Expose page aliases to templates

### DIFF
--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -56,6 +56,7 @@ pub struct SerializingPage<'a> {
     day: Option<u8>,
     taxonomies: &'a HashMap<String, Vec<String>>,
     authors: &'a [String],
+    aliases: &'a [String],
     extra: &'a Map<String, Value>,
     path: &'a str,
     components: &'a [String],
@@ -121,6 +122,7 @@ impl<'a> SerializingPage<'a> {
             day,
             taxonomies: &page.meta.taxonomies,
             authors: &page.meta.authors,
+            aliases: &page.meta.aliases,
             path: &page.path,
             components: &page.components,
             summary: &page.summary,
@@ -135,6 +137,26 @@ impl<'a> SerializingPage<'a> {
             translations,
             backlinks,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SerializingPage;
+    use crate::Page;
+    use tera::to_value;
+
+    #[test]
+    fn page_serialization_includes_aliases() {
+        let mut page = Page::default();
+        page.meta.aliases = vec!["/old-url/".to_owned(), "/legacy.html".to_owned()];
+
+        let serialized = to_value(SerializingPage::new(&page, None, false)).unwrap();
+
+        assert_eq!(
+            serialized.get("aliases").unwrap(),
+            &to_value(["/old-url/", "/legacy.html"]).unwrap()
+        );
     }
 }
 

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -160,6 +160,11 @@ fn can_build_site_without_live_reload() {
     assert!(file_exists!(public, "an-old-url/old-page/index.html"));
     assert!(file_contains!(public, "an-old-url/old-page/index.html", "something-else"));
     assert!(file_contains!(public, "another-old-url/index.html", "posts/"));
+    assert!(file_contains!(
+        public,
+        "posts/something-else/index.html",
+        "Page aliases: /an-old-url/old-page,/an-old-url/an-old-alias.html"
+    ));
 
     // html aliases work
     assert!(file_exists!(public, "an-old-url/an-old-alias.html"));

--- a/docs/content/documentation/templates/pages-sections.md
+++ b/docs/content/documentation/templates/pages-sections.md
@@ -23,6 +23,7 @@ updated: String?;
 slug: String;
 path: String;
 authors: Array<String>;
+aliases: Array<String>;
 draft: Bool;
 // the path, split on '/'
 components: Array<String>;

--- a/test_site/templates/page.html
+++ b/test_site/templates/page.html
@@ -4,6 +4,7 @@
     {{ page.title | safe }}
     {{ page.content | safe }}
     {{ page.relative_path | safe }}
+    {% if page.aliases %}Page aliases: {{ page.aliases | join(sep=",") | safe }}{% endif %}
     {{ page.toc }}
 
     {% if page.earlier %}Previous article: {{ page.earlier.permalink }}{% endif %}


### PR DESCRIPTION
## Summary
- serialize page aliases so templates can access page.aliases
- document the new Page variable
- add unit and integration coverage

Closes #3167

## Checks
- cargo fmt --all --check
- cargo test -p content -p zola page_serialization_includes_aliases
- cargo test -p site -p zola can_build_site_without_live_reload