### PR TITLE
docs: fix inconsistent whitespace in shortcode template

### DIFF
--- a/docs/content/documentation/content/shortcodes.md
+++ b/docs/content/documentation/content/shortcodes.md
@@ -123,7 +123,7 @@ Let's imagine that we have the following shortcode `quote.html` template:
 ```jinja
 <blockquote>
     {{ body }} <br>
-    -- {{ author}}
+    -- {{ author }}
 </blockquote>
 ```
 


### PR DESCRIPTION
Fix inconsistent whitespace in the shortcodes documentation. The blockquote template example had missing space before closing braces in the author variable.