### PR TITLE
fix(content): slugify ancestor directory components in page paths

### DIFF
--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -148,7 +148,19 @@ impl Page {
                     page.slug.clone()
                 }
             } else {
-                format!("{}/{}", page.file.components.join("/"), page.slug)
+                // Ancestor directory names must be slugified the same way as the
+                // slug itself. Otherwise a non-index page keeps its raw parent
+                // directory name (e.g. `chim_climbing/changelog`) while the sibling
+                // `index.md`, whose directory becomes the slug, is slugified
+                // (`chim-climbing`). See #3114.
+                let components = page
+                    .file
+                    .components
+                    .iter()
+                    .map(|c| slugify_paths(c, config.slugify.paths))
+                    .collect::<Vec<_>>()
+                    .join("/");
+                format!("{}/{}", components, page.slug)
             };
 
             if page.lang != config.default_language {
@@ -287,6 +299,29 @@ Hello world"#;
         assert_eq!(page.path, "/posts/intro/hello-world/");
         assert_eq!(page.components, vec!["posts", "intro", "hello-world"]);
         assert_eq!(page.permalink, "http://hello.com/posts/intro/hello-world/");
+    }
+
+    #[test]
+    fn can_slugify_ancestor_directories_in_path() {
+        // A non-index page in a directory whose name is not slug-safe must have
+        // that ancestor directory slugified, matching how the sibling `index.md`
+        // (whose directory becomes the slug) is already handled. See #3114.
+        let content = r#"
+    +++
+    +++
+    Hello world"#;
+        let mut config = Config::default();
+        config.slugify.paths = SlugifyStrategy::On;
+        let res = Page::parse(
+            Path::new("content/chim_climbing/changelog.md"),
+            content,
+            &config,
+            &PathBuf::new(),
+        );
+        assert!(res.is_ok());
+        let page = res.unwrap();
+        assert_eq!(page.path, "/chim-climbing/changelog/");
+        assert_eq!(page.components, vec!["chim-climbing", "changelog"]);
     }
 
     #[test]

--- a/components/content/src/page.rs
+++ b/components/content/src/page.rs
@@ -148,11 +148,7 @@ impl Page {
                     page.slug.clone()
                 }
             } else {
-                // Ancestor directory names must be slugified the same way as the
-                // slug itself. Otherwise a non-index page keeps its raw parent
-                // directory name (e.g. `chim_climbing/changelog`) while the sibling
-                // `index.md`, whose directory becomes the slug, is slugified
-                // (`chim-climbing`). See #3114.
+                // Slugify ancestor directory components too, like the index.md slug. See #3114.
                 let components = page
                     .file
                     .components
@@ -303,9 +299,7 @@ Hello world"#;
 
     #[test]
     fn can_slugify_ancestor_directories_in_path() {
-        // A non-index page in a directory whose name is not slug-safe must have
-        // that ancestor directory slugified, matching how the sibling `index.md`
-        // (whose directory becomes the slug) is already handled. See #3114.
+        // See #3114.
         let content = r#"
     +++
     +++


### PR DESCRIPTION
## Summary

With `slugify.paths` enabled, only part of a page's URL was slugified. A page's own slug is slugified, but the ancestor directory names (`file.components`) were joined into the path verbatim.

The effect, from #3114: in a directory `chim_climbing/` containing `index.md` and `changelog.md`, the colocated `index.md` (whose directory name becomes its slug) renders at `/chim-climbing/`, but the sibling `changelog.md` renders at `/chim_climbing/changelog/` — the parent directory keeps its raw, un-slugified name. The same applies to any non-slug-safe ancestor directory (including deeper ancestors of an `index.md`).

## Fix

Slugify each ancestor component with the configured strategy when building the page path, matching how the slug itself is already handled. `SlugifyStrategy::Off` returns names unchanged, so behaviour is unchanged when path slugification is disabled.

## Testing

Added `can_slugify_ancestor_directories_in_path` in `components/content/src/page.rs`: a non-index page under `content/chim_climbing/` with `slugify.paths = On` now resolves to `/chim-climbing/changelog/`. Verified it fails on the previous code (`/chim_climbing/changelog/`) and passes with the fix. Full `content` crate suite green (146 tests), `cargo fmt` and `clippy` clean.

Closes #3114