### PR TITLE
fix(serve): rebuild the whole site when anchor-link.html changes

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -69,6 +69,9 @@ enum WatchMode {
 const METHOD_NOT_ALLOWED_TEXT: &[u8] = b"Method Not Allowed";
 const NOT_FOUND_TEXT: &[u8] = b"Not Found";
 
+// Templates used while rendering Markdown: reloading the registry isn't enough. See #2940.
+const ALWAYS_FULL_REBUILD: &[&str] = &["anchor-link.html"];
+
 // This is dist/livereload.min.js from the LiveReload.js v3.2.4 release
 const LIVE_RELOAD: &str = include_str!("livereload.js");
 
@@ -827,10 +830,6 @@ pub fn serve(
                                 .join(", ");
                             log::info!("-> Template file(s) changed {combined_paths}");
 
-                            // These are used while rendering Markdown, so a
-                            // registry reload isn't enough - the pages are
-                            // already rendered and need a full rebuild. See #2940.
-                            const ALWAYS_FULL_REBUILD: &[&str] = &["anchor-link.html"];
                             let needs_full_rebuild = full_paths.iter().any(|p| {
                                 p.file_name()
                                     .and_then(|n| n.to_str())

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -56,9 +56,7 @@ use site::sass::compile_sass;
 use site::{BuildMode, SITE_CONTENT, Site};
 use utils::fs::{clean_site_output_folder, copy_file, create_directory};
 
-use crate::fs_utils::{
-    ChangeKind, SimpleFileSystemEventKind, filter_events, template_change_requires_full_rebuild,
-};
+use crate::fs_utils::{ChangeKind, SimpleFileSystemEventKind, filter_events};
 use crate::messages;
 
 #[derive(Debug, PartialEq)]
@@ -829,12 +827,16 @@ pub fn serve(
                                 .join(", ");
                             log::info!("-> Template file(s) changed {combined_paths}");
 
-                            // Templates consumed during Markdown rendering (e.g.
-                            // anchor-link.html for heading anchors) are baked into
-                            // the already-rendered page HTML, so reloading the
-                            // template registry alone leaves the live pages stale.
-                            // Rebuild the whole site in that case. See #2940.
-                            if full_paths.iter().any(|p| template_change_requires_full_rebuild(p)) {
+                            // These are used while rendering Markdown, so a
+                            // registry reload isn't enough - the pages are
+                            // already rendered and need a full rebuild. See #2940.
+                            const ALWAYS_FULL_REBUILD: &[&str] = &["anchor-link.html"];
+                            let needs_full_rebuild = full_paths.iter().any(|p| {
+                                p.file_name()
+                                    .and_then(|n| n.to_str())
+                                    .is_some_and(|n| ALWAYS_FULL_REBUILD.contains(&n))
+                            });
+                            if needs_full_rebuild {
                                 log::info!("Rebuilding the site");
                                 if let Some(s) = recreate_site() {
                                     site = s;

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -56,7 +56,9 @@ use site::sass::compile_sass;
 use site::{BuildMode, SITE_CONTENT, Site};
 use utils::fs::{clean_site_output_folder, copy_file, create_directory};
 
-use crate::fs_utils::{ChangeKind, SimpleFileSystemEventKind, filter_events};
+use crate::fs_utils::{
+    ChangeKind, SimpleFileSystemEventKind, filter_events, template_change_requires_full_rebuild,
+};
 use crate::messages;
 
 #[derive(Debug, PartialEq)]
@@ -827,8 +829,20 @@ pub fn serve(
                                 .join(", ");
                             log::info!("-> Template file(s) changed {combined_paths}");
 
-                            log::info!("Reloading only template");
-                            reload_templates(&mut site)
+                            // Templates consumed during Markdown rendering (e.g.
+                            // anchor-link.html for heading anchors) are baked into
+                            // the already-rendered page HTML, so reloading the
+                            // template registry alone leaves the live pages stale.
+                            // Rebuild the whole site in that case. See #2940.
+                            if full_paths.iter().any(|p| template_change_requires_full_rebuild(p)) {
+                                log::info!("Rebuilding the site");
+                                if let Some(s) = recreate_site() {
+                                    site = s;
+                                }
+                            } else {
+                                log::info!("Reloading only template");
+                                reload_templates(&mut site)
+                            }
                         }
                         ChangeKind::StaticFiles => {
                             for (partial_path, full_path, _) in change_group.iter() {

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -190,6 +190,16 @@ fn detect_change_kind(pwd: &Path, path: &Path, config_path: &Path) -> (ChangeKin
     (change_kind, partial_path)
 }
 
+/// Some templates are consumed while rendering Markdown (e.g. `anchor-link.html`
+/// for heading anchors) rather than while rendering a Tera page. Reloading the
+/// template registry is not enough for those: the affected pages have already
+/// been rendered to HTML, so `zola serve` has to rebuild the whole site for the
+/// change to show up. Returns whether a changed template path is one of them.
+/// See #2940.
+pub fn template_change_requires_full_rebuild(path: &Path) -> bool {
+    matches!(path.file_name().and_then(|name| name.to_str()), Some("anchor-link.html"))
+}
+
 #[cfg(test)]
 mod tests {
     use notify_debouncer_full::notify::event::*;
@@ -197,7 +207,7 @@ mod tests {
 
     use super::{
         ChangeKind, SimpleFileSystemEventKind, detect_change_kind, get_relevant_event_kind,
-        is_temp_file,
+        is_temp_file, template_change_requires_full_rebuild,
     };
 
     // This test makes sure we at least have code coverage on the `notify` event kinds we care
@@ -348,5 +358,17 @@ mod tests {
         let path = Path::new("templates/hello.html");
         let config_filename = Path::new("config.toml");
         assert_eq!(expected, detect_change_kind(pwd, path, config_filename));
+    }
+
+    #[test]
+    fn anchor_link_template_requires_full_rebuild() {
+        // anchor-link.html is applied during Markdown rendering, so a change to
+        // it needs a full rebuild, not just a template reload. Ordinary
+        // templates only need the registry reloaded. See #2940.
+        assert!(template_change_requires_full_rebuild(Path::new(
+            "/site/templates/anchor-link.html"
+        )));
+        assert!(!template_change_requires_full_rebuild(Path::new("/site/templates/index.html")));
+        assert!(!template_change_requires_full_rebuild(Path::new("/site/templates/page.html")));
     }
 }

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -190,16 +190,6 @@ fn detect_change_kind(pwd: &Path, path: &Path, config_path: &Path) -> (ChangeKin
     (change_kind, partial_path)
 }
 
-/// Some templates are consumed while rendering Markdown (e.g. `anchor-link.html`
-/// for heading anchors) rather than while rendering a Tera page. Reloading the
-/// template registry is not enough for those: the affected pages have already
-/// been rendered to HTML, so `zola serve` has to rebuild the whole site for the
-/// change to show up. Returns whether a changed template path is one of them.
-/// See #2940.
-pub fn template_change_requires_full_rebuild(path: &Path) -> bool {
-    matches!(path.file_name().and_then(|name| name.to_str()), Some("anchor-link.html"))
-}
-
 #[cfg(test)]
 mod tests {
     use notify_debouncer_full::notify::event::*;
@@ -207,7 +197,7 @@ mod tests {
 
     use super::{
         ChangeKind, SimpleFileSystemEventKind, detect_change_kind, get_relevant_event_kind,
-        is_temp_file, template_change_requires_full_rebuild,
+        is_temp_file,
     };
 
     // This test makes sure we at least have code coverage on the `notify` event kinds we care
@@ -358,17 +348,5 @@ mod tests {
         let path = Path::new("templates/hello.html");
         let config_filename = Path::new("config.toml");
         assert_eq!(expected, detect_change_kind(pwd, path, config_filename));
-    }
-
-    #[test]
-    fn anchor_link_template_requires_full_rebuild() {
-        // anchor-link.html is applied during Markdown rendering, so a change to
-        // it needs a full rebuild, not just a template reload. Ordinary
-        // templates only need the registry reloaded. See #2940.
-        assert!(template_change_requires_full_rebuild(Path::new(
-            "/site/templates/anchor-link.html"
-        )));
-        assert!(!template_change_requires_full_rebuild(Path::new("/site/templates/index.html")));
-        assert!(!template_change_requires_full_rebuild(Path::new("/site/templates/page.html")));
     }
 }


### PR DESCRIPTION
## Summary

Editing `templates/anchor-link.html` while `zola serve` is running does not show up in the browser until the server is restarted, even though Zola logs that it reloaded the template (#2940).

The reason, as noted by @Keats on the issue: reloading only recompiles the Tera template registry, but `anchor-link.html` is consumed during **Markdown rendering** (heading anchors), which is baked into the already-rendered page HTML. A template-registry reload doesn't re-render the Markdown, so the live pages stay stale.

## Fix

In the `serve` watcher's `Templates` change handler, detect whether any changed template is one that affects Markdown rendering (currently `anchor-link.html`) and trigger a full site rebuild for it, instead of the template-only reload. All other template changes keep the existing reload-only fast path.

The classification is a small pure helper, `template_change_requires_full_rebuild`, so it's unit-tested directly.

## Testing

Added `anchor_link_template_requires_full_rebuild` in `src/fs_utils.rs` (anchor-link.html -> full rebuild; ordinary templates -> reload-only). `cargo test -p zola fs_utils` green, `fmt` and `clippy` clean. Also verified manually: with `insert_anchor_links` set, editing `anchor-link.html` under `zola serve` now reflects in the served page without a restart.

Closes #2940