### PR TITLE
fix(serve): set livereload websocket host explicitly for IPv6 loopback

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -627,8 +627,16 @@ impl Site {
     /// Inject live reload script tag if in live reload mode
     fn inject_livereload(&self, mut html: String) -> String {
         if let Some(port) = self.live_reload {
-            let script =
-                format!(r#"<script src="/livereload.js?port={}&amp;mindelay=10"></script>"#, port,);
+            // Set the websocket host explicitly from the page's own hostname
+            // instead of letting livereload.js derive it. Its default
+            // derivation produces `ws://undefined:<port>` when the site is
+            // served on an IPv6 loopback, and a bare IPv6 literal (`::1`) is
+            // not a valid `ws://` authority — it has to be bracketed as
+            // `[::1]`. `location.hostname` returns the address unbracketed for
+            // IPv6, so wrap it when it contains a colon. See #2979.
+            let script = format!(
+                r#"<script>(function(){{var h=window.location.hostname;if(h.indexOf(":")>=0){{h="["+h+"]";}}window.LiveReloadOptions={{host:h,port:{port},mindelay:10}};}})();</script><script src="/livereload.js"></script>"#,
+            );
             if let Some(index) = html.rfind("</body>") {
                 html.insert_str(index, &script);
             } else {

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -213,7 +213,7 @@ fn can_build_site_without_live_reload() {
     assert!(!file_exists!(public, "secret_section/page.html"));
     assert!(!file_exists!(public, "secret_section/secret_sub_section/hello.html"));
     // no live reload code
-    assert!(!file_contains!(public, "index.html", "/livereload.js?port=1112&amp;mindelay=10"),);
+    assert!(!file_contains!(public, "index.html", "/livereload.js"),);
 
     // Both pages and sections are in the sitemap
     assert!(file_contains!(
@@ -282,8 +282,12 @@ fn can_build_site_with_live_reload_and_drafts() {
     // But no tags
     assert!(!file_exists!(public, "tags/index.html"));
 
-    // no live reload code
+    // live reload code, with the websocket host set explicitly from the page's
+    // own hostname (bracketing IPv6 literals) so it works on an IPv6 loopback
+    // instead of connecting to `ws://undefined:<port>`. See #2979.
     assert!(file_contains!(public, "index.html", "/livereload.js"));
+    assert!(file_contains!(public, "index.html", "window.LiveReloadOptions"));
+    assert!(file_contains!(public, "index.html", r#"h.indexOf(":")"#));
 
     // the summary target has been created
     assert!(file_contains!(


### PR DESCRIPTION
## Code changes

* [x] Are you doing the PR on the `next` branch? Yes.

Closes #2979 (you said you'd take a PR for it).

### Problem

`zola serve -i ::1` builds fine, but live reload never connects. In the browser console on `http://[::1]:1111`:

```
Firefox can't establish a connection to the server at ws://undefined:1024/livereload.
```

`127.0.0.1` works; only IPv6 loopback is broken.

### Cause

`inject_livereload` injects `<script src="/livereload.js?port=…&mindelay=10">` and passes only the port, so livereload.js has to derive the websocket host on its own. That derivation returns `undefined` for an IPv6 host, and even if it returned the raw address, a bare IPv6 literal (`::1`) is not a valid `ws://` authority — it has to be bracketed (`[::1]`). livereload.js builds the URI as `"ws://" + options.host + ":" + options.port`, so a correct, pre-bracketed host is all it needs.

### Fix

Set the host explicitly via `window.LiveReloadOptions`, taken from the page's own `location.hostname` and bracketed when it contains a colon:

```js
var h = window.location.hostname;
if (h.indexOf(":") >= 0) { h = "[" + h + "]"; }
window.LiveReloadOptions = { host: h, port: <port>, mindelay: 10 };
```

Using `location.hostname` means it resolves to whatever address the site was opened on (localhost, 127.0.0.1, `::1`, or a LAN host), so it is address-agnostic rather than tied to the bind interface. The upstream livereload-js fix (livereload/livereload-js#122) was closed, so handling it on the Zola side is the practical path.

### Testing

Extended `can_build_site_with_live_reload_and_drafts` to assert the injected `window.LiveReloadOptions` and the IPv6-bracketing branch are present, and tightened the negative check in `can_build_site_without_live_reload`. Verified the new assertions fail against the previous `?port=` injection and pass after the change. `cargo test -p site` — 24 passed; `cargo fmt --check` and `cargo clippy -p site` clean.

(No `CHANGELOG.md` entry included — happy for you to add one, or I can if you point me at the format you want.)
