### PR TITLE
docs(syntax-highlighting): fix typo and make theme link clickable

### DIFF
--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -24,9 +24,9 @@ You can see a full list of supported languages and themes in the README: <https:
 
 If a theme or a language you want to highlight is not supported, you can find the JSON grammar files and JSON theme files, copy them somewhere in your site
 and load them from the configurations with `extra_grammars` and `extra_themes` in the `[markdown.highlighting]` section.
-You can see the list of supported themes at https://textmate-grammars-themes.netlify.app/
+You can see the list of supported themes at [textmate-grammars-themes.netlify.app](https://textmate-grammars-themes.netlify.app/)
 
-In any cases, you will need to add the following CSS to your site CSS for things to display correctly:
+In any case, you will need to add the following CSS to your site CSS for things to display correctly:
 
 ```css
 .giallo-l {


### PR DESCRIPTION
## Summary

Fix two issues in the syntax highlighting documentation page:
- Change "In any cases" to "In any case"
- Convert bare URL to a clickable Markdown link

## Related Issue

Partial fix for #3130

## Type of Change

- [x] Bug fix (non-breaking change)

## Checklist

- [x] My code follows the existing style.
- [x] CI is green (passing all checks).