### PR TITLE
docs: note hard_link_static also applies to colocated assets

### DIFF
--- a/docs/content/documentation/content/overview.md
+++ b/docs/content/documentation/content/overview.md
@@ -44,6 +44,12 @@ assets, such as images or spreadsheets. Zola supports this pattern out of the bo
 All non-Markdown files you add in a page/section directory will be copied alongside the generated page when the site is
 built, which allows us to use a relative path to access them.
 
+By default these files are copied, so an asset shared across several outputs (for example the same image in multiple
+localized versions of a page) ends up duplicated on disk. Setting `hard_link_static = true` in the
+[configuration](@/documentation/getting-started/configuration.md) hard-links colocated assets instead of copying them,
+avoiding that duplication. As with the `static` directory, this requires the content and output directories to be on the
+same filesystem.
+
 Pages with co-located assets should not be placed directly in their section directory (such as `latest-experiment.md`), but
 as an `index.md` file in a dedicated directory (`latest-experiment/index.md`), like so:
 

--- a/docs/content/documentation/getting-started/configuration.md
+++ b/docs/content/documentation/getting-started/configuration.md
@@ -81,9 +81,9 @@ feed_filenames = ["atom.xml"]
 # this limit is not set (the default).
 # feed_limit = 20
 
-# When set to "true", files in the `static` directory are hard-linked. Useful for large
-# static files. Note that for this to work, both `static` and the
-# output directory need to be on the same filesystem. Note that the theme's `static`
+# When set to "true", files in the `static` directory and colocated page/section assets are
+# hard-linked instead of copied. Useful for large static files. Note that for this to work, the
+# source and output directory need to be on the same filesystem. Note that the theme's `static`
 # files are always copied, regardless of this setting.
 hard_link_static = false
 


### PR DESCRIPTION
Per your call on #3176 ("let's just update the docs").

`hard_link_static` already covers colocated page/section assets, not just the `static` directory (`copy_assets` passes it through to `copy_file_if_needed`), but the docs only mentioned `static`. This notes it in the Asset colocation section and broadens the config option description, so someone hitting the "assets duplicated across localized outputs" case from #3176 knows `hard_link_static = true` deduplicates them.

Docs only, on `next`. Closes #3176.