### PR TITLE
docs(vercel): shorten custom install command to fit Vercel's 256-char limit

### DIFF
--- a/docs/content/documentation/deployment/vercel.md
+++ b/docs/content/documentation/deployment/vercel.md
@@ -94,13 +94,15 @@ Vercel to not get use of `ZOLA_VERSION` variable anymore automatically.
 Then, set "Install Command" to:
 
 ```bash
-echo "${ZOLA_VERSION:-"latest"}" | sed '/^latest$/!s/\(.*\)/tags\/v\1/' | xargs -I% curl -fsSL "https://api.github.com/repos/getzola/zola/releases/%" | grep -oP "\"browser_download_url\": ?\"\\K(.+linux-${ZOLA_LIBC:-"musl"}\\.tar\\.gz)" | xargs curl -fsSL | tar -xz
+v=${ZOLA_VERSION:+tags/v$ZOLA_VERSION};curl -fsSL https://api.github.com/repos/getzola/zola/releases/${v:-latest}|grep -o '"browser_download_url": *"[^"]*x86_64-unknown-linux-'${ZOLA_LIBC:-musl}'\.tar\.gz"'|cut -d'"' -f4|xargs curl -fsSL|tar -xz
 ```
 
 This command will download Zola from the file URL obtained from GitHub API and extract it.
 This way we can continue using same `ZOLA_VERSION` environment variable name to pin to a
-specific Zola version (same as how Vercel does) - or set it to `latest` to always pull the
-latest version whenever an deployment is initiated on Vercel.
+specific Zola version (same as how Vercel does) - or leave it unset to always pull the
+latest version whenever an deployment is initiated on Vercel. The command is restricted to
+`x86_64` binaries, since that's what Vercel's build images run, and some Zola releases
+publish both `x86_64` and `aarch64` builds for a given libc.
 
 We also pull `musl` binaries by default in the command, so we no longer have to worry
 about Vercel's build images. But if you would like to use older versions (below of
@@ -117,7 +119,7 @@ If you prefer to use `vercel.json` instead,
 ```json
 {
     "framework": null,
-    "installCommand": "echo \"${ZOLA_VERSION:-\"latest\"}\" | sed '/^latest$/!s/\\(.*\\)/tags\\/v\\1/' | xargs -I% curl -fsSL \"https://api.github.com/repos/getzola/zola/releases/%\" | grep -oP \"\\\"browser_download_url\\\": ?\\\"\\K(.+linux-${ZOLA_LIBC:-\"musl\"}\\\\.tar\\\\.gz)\" | xargs curl -fsSL | tar -xz",
+    "installCommand": "v=${ZOLA_VERSION:+tags/v$ZOLA_VERSION};curl -fsSL https://api.github.com/repos/getzola/zola/releases/${v:-latest}|grep -o '\"browser_download_url\": *\"[^\"]*x86_64-unknown-linux-'${ZOLA_LIBC:-musl}'\\.tar\\.gz\"'|cut -d'\"' -f4|xargs curl -fsSL|tar -xz",
     "buildCommand": "./zola build",
     "outputDirectory": "public"
 }


### PR DESCRIPTION
## Summary
- The suggested "Install Command" for using a custom Zola binary on Vercel is 262 characters, which exceeds Vercel's 256-character limit for that field, so it can't actually be saved in the dashboard (screenshot in the issue).
- While shortening it, I also fixed two latent bugs I found by actually running the commands:
  - The straightforward shortening (resolving `ZOLA_VERSION` with two separate `${VAR:+...}`/`${VAR:-...}` expansions) causes the pinned-version URL to get corrupted (e.g. `tags/v0.21.00.21.0`), because `${VAR:-default}` only substitutes when the variable is *unset*, not when it holds a different value. Fixed by resolving the whole "tags/vX" vs "latest" path segment into one variable first.
  - Matching on `linux-<libc>` alone can match both `x86_64` and `aarch64` binaries when a release ships both for the same libc (this is the case for recent `gnu` builds), which corrupts the downloaded tarball when both get piped into `tar` back to back. Fixed by matching `x86_64-unknown-linux-<libc>` explicitly, since Vercel's build images are x86_64.
- New command is 245 characters (under the 256 limit), documented in both the "Install Command" bash block and the equivalent `vercel.json` example.

## Test plan
Ran the exact command (and the `vercel.json`-escaped variant, parsed back with `JSON.parse` to confirm it round-trips to the same string) for:
- [x] `ZOLA_VERSION` unset, `ZOLA_LIBC` unset → latest release, `musl`, produces a valid x86_64 ELF `zola` binary
- [x] `ZOLA_VERSION=0.22.1 ZOLA_LIBC=gnu` → a release that ships both `x86_64` and `aarch64` `linux-gnu` binaries; confirmed only the `x86_64` one is downloaded and extracted correctly
- [x] `ZOLA_VERSION=0.19.2 ZOLA_LIBC=gnu` → an older release with only a single `x86_64` `linux-gnu` binary, still works
- [x] Verified under both `bash` and `sh`
- [x] Confirmed character count is 245 (under Vercel's 256-char limit) via `wc -c`
- No code changes outside of the doc file.

Closes #3171