### PR TITLE
Prevent template file lookups outside authorized roots

### DIFF
--- a/components/templates/src/helpers.rs
+++ b/components/templates/src/helpers.rs
@@ -22,10 +22,16 @@ pub fn search_for_file(
     theme: &Option<String>,
     output_path: &Path,
 ) -> Result<Option<(PathBuf, String)>> {
-    let mut search_paths =
-        vec![base_path.join("static"), base_path.join("content"), base_path.join(output_path)];
+    let output_search_path = base_path.join(output_path);
+    let mut search_paths = vec![
+        (base_path.to_path_buf(), base_path.to_path_buf()),
+        (base_path.join("static"), base_path.to_path_buf()),
+        (base_path.join("content"), base_path.to_path_buf()),
+        (output_search_path.clone(), output_search_path),
+    ];
     if let Some(t) = theme {
-        search_paths.push(base_path.join("themes").join(t).join("static"));
+        search_paths
+            .push((base_path.join("themes").join(t).join("static"), base_path.to_path_buf()));
     }
     let actual_path = if path.starts_with("@/") {
         Cow::Owned(path.replace("@/", "content/"))
@@ -33,24 +39,65 @@ pub fn search_for_file(
         Cow::Borrowed(path.trim_start_matches('/'))
     };
 
-    let mut file_path = base_path.join(&*actual_path);
-    let mut file_exists = file_path.exists();
-
-    if file_exists && !is_path_in_directory(base_path, &file_path)? {
-        bail!("{:?} is not inside the base site directory {:?}", path, base_path);
-    }
-
-    if !file_exists {
-        // we need to search in all search folders now
-        for dir in &search_paths {
-            let p = dir.join(&*actual_path);
-            if p.exists() {
-                file_path = p;
-                file_exists = true;
-                break;
+    for (dir, allowed_root) in search_paths {
+        let file_path = dir.join(&*actual_path);
+        if file_path.exists() {
+            if !is_path_in_directory(&allowed_root, &file_path)? {
+                bail!("{:?} is not inside the base site directory {:?}", path, base_path);
             }
+            return Ok(Some((file_path, actual_path.into_owned())));
         }
     }
 
-    if file_exists { Ok(Some((file_path, actual_path.into_owned()))) } else { Ok(None) }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::search_for_file;
+    use std::fs;
+
+    #[test]
+    fn rejects_escape_through_alternate_search_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("site");
+        fs::create_dir_all(base.join("static")).unwrap();
+        fs::write(temp.path().join("outside.txt"), "outside").unwrap();
+
+        let result = search_for_file(&base, "../../outside.txt", &None, &base.join("public"));
+
+        assert!(result.unwrap_err().to_string().contains("is not inside"));
+    }
+
+    #[test]
+    fn finds_file_in_static_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("site");
+        let expected = base.join("static").join("asset.txt");
+        fs::create_dir_all(expected.parent().unwrap()).unwrap();
+        fs::write(&expected, "asset").unwrap();
+
+        let (resolved, unified) =
+            search_for_file(&base, "asset.txt", &None, &base.join("public")).unwrap().unwrap();
+
+        assert_eq!(resolved, expected);
+        assert_eq!(unified, "asset.txt");
+    }
+
+    #[test]
+    fn finds_file_in_external_output_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("site");
+        let output = temp.path().join("output");
+        let expected = output.join("asset.txt");
+        fs::create_dir_all(&base).unwrap();
+        fs::create_dir_all(&output).unwrap();
+        fs::write(&expected, "asset").unwrap();
+
+        let (resolved, unified) =
+            search_for_file(&base, "asset.txt", &None, &output).unwrap().unwrap();
+
+        assert_eq!(resolved, expected);
+        assert_eq!(unified, "asset.txt");
+    }
 }


### PR DESCRIPTION
Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?

## Summary

- Validate every resolved template file candidate against its authorized root.
- Preserve lookups from the site, `static`, `content`, theme, and external output directories.
- Add regression coverage for traversal through fallback search paths.

## Root cause

`search_for_file` enforced directory containment only when the initial candidate under the site root existed. When that candidate did not exist, fallback candidates under `static`, `content`, the output directory, or theme assets were returned without the same validation.

A path containing parent-directory components could therefore resolve through a fallback root to an existing file outside the authorized directory. Functions such as `load_data` would then read that file with the permissions of the Zola process.

This is the same vulnerability class previously addressed for `zola serve` in #2258, but in the template file lookup path.

## Fix

Associate every search directory with its authorized root and validate each existing candidate before returning it. The output directory remains independently authorized so absolute external `--output-dir` configurations continue to work.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p templates --offline --locked` — 86 passed
- `cargo test --all --offline --locked`
- `cargo build --all --offline --locked`

Regression tests cover traversal through an alternate search path, ordinary static-file resolution, and an external output directory.
