### PR TITLE
Document code fence filenames

### DIFF
--- a/docs/content/documentation/content/syntax-highlighting.md
+++ b/docs/content/documentation/content/syntax-highlighting.md
@@ -146,6 +146,33 @@ highlight(code);
 ```
 ````
 
+Zola adds the name to the generated `<code>` element as a `data-name`
+attribute. The example above produces HTML with the following structure
+(highlighting markup and styles are omitted):
+
+```html
+<pre class="giallo">
+  <code data-lang="rust" data-name="mod.rs">...</code>
+</pre>
+```
+
+Zola does not display the name by default. You can use CSS to present it, for
+example:
+
+```css
+pre > code[data-name]::before {
+  content: attr(data-name);
+  display: block;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid currentcolor;
+  font-family: sans-serif;
+  font-weight: bold;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+```
+
 Here's an example with all the options used: `scss, linenos, linenostart=10, hl_lines=3-4 8-9, hide_lines=2 7`.
 
 ```scss, linenos, linenostart=10, hl_lines=3-4 8-9, hide_lines=2 7


### PR DESCRIPTION
## Summary

Document how the `name` code-fence attribute becomes `data-name` on the
generated `<code>` element, and provide a small CSS example for displaying the
filename.

Fixes #2867.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Validation

- built the documentation site with the current Zola binary
- confirmed the generated HTML contains the documented `data-name` markup and CSS
- `git diff --check origin/master...HEAD`

Assisted by OpenAI Codex; the source, generated markup, and documentation build were reviewed and validated by me.
