### PR TITLE
docs: run the Cloudflare Workers build script with bash

### DIFF
--- a/docs/content/documentation/deployment/cloudflare-workers.md
+++ b/docs/content/documentation/deployment/cloudflare-workers.md
@@ -38,7 +38,7 @@ name = "blog"
 compatibility_date = "2026-01-22"
 
 [build]
-command = "./build.sh"
+command = "bash ./build.sh"
 
 [assets]
 directory = "./public"


### PR DESCRIPTION
The Cloudflare Workers deployment guide sets the wrangler build command to `./build.sh`:

```toml
[build]
command = "./build.sh"
```

The `build.sh` in the guide starts with `#!/usr/bin/env bash`, but the file checked out in Cloudflare's build environment is not guaranteed to carry the executable bit, so `./build.sh` fails to run and the deploy breaks (#3206). Invoking it through `bash` works regardless of the file's permissions:

```toml
[build]
command = "bash ./build.sh"
```

One line in `docs/content/documentation/deployment/cloudflare-workers.md`. This is the fix proposed in the issue by the reporter; @Keats invited a PR from a Cloudflare user.

Closes #3206.

---

Disclosure: prepared with AI assistance; I reviewed the change.
