### PR TITLE
0.23: site feed fails - needs to be migrated to Tera v2

### DIFF
--- a/components/templates/src/builtins/rss.xml
+++ b/components/templates/src/builtins/rss.xml
@@ -3,7 +3,7 @@
     <channel>
       <title>{{ config.title }}
         {%- if term %} - {{ term.name }}
-        {%- elif section.title %} - {{ section.title }}
+        {%- elif section and section.title %} - {{ section.title }}
         {%- endif -%}
       </title>
       <link>


### PR DESCRIPTION
# Bug Report

## Environment

Zola version: 0.23.1

## Expected Behavior
Site-level rss.xml builds correctly.

## Current Behavior
`zola build` fails:
```
ERROR Failed to render feed 'rss.xml' --> __zola_builtins/rss.xml:6:18 Variable section is not defined
```
This is because `{% if section.title %}` is a strict error in Tera v2 if `section` is not defined (it was falsy in v1).
https://github.com/Keats/tera/blob/master/MIGRATION.md#behaviour-changes.

## Step to reproduce
1. `generate_feeds = true` in `config.toml`
2. `feed_filenames = ["rss.xml"]` in `config.toml`
3. Run `zola build`