### PR TITLE
docs: fix incorrectly escaped code blocks in docs

### DIFF
--- a/docs/content/documentation/content/image-processing/index.md
+++ b/docs/content/documentation/content/image-processing/index.md
@@ -198,7 +198,7 @@ To call it from a Markdown file, simply do:
 ```jinja
 {% raw -%}
 {{ <gallery page /> }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 Here is the result:
@@ -230,7 +230,7 @@ It can be invoked from Markdown like this:
 ```jinja
 {% raw -%}
 {{ <resize_image_relative path="documentation/content/image-processing/01-zola.png" scale={0.5} /> }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 {{ <resize_image_relative path="documentation/content/image-processing/01-zola.png" scale={0.5} /> }}

--- a/docs/content/documentation/content/page.md
+++ b/docs/content/documentation/content/page.md
@@ -181,5 +181,5 @@ By default, it will show an ellipsis (…) regardless of the content of the summ
 ```jinja
 {% raw -%}
 {% if summary is matching("\PP$") %}&hellip;{% endif %}
-{%- endraw -%}
+{%- endraw %}
 ```

--- a/docs/content/documentation/content/section.md
+++ b/docs/content/documentation/content/section.md
@@ -150,7 +150,7 @@ create a list of links to the posts, a simple template might look like this:
 {% for post in section.pages %}
   <h1><a href="{{ post.permalink }}">{{ post.title }}</a></h1>
 {% endfor %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 This would iterate over the posts in the order specified

--- a/docs/content/documentation/deployment/aws-s3.md
+++ b/docs/content/documentation/deployment/aws-s3.md
@@ -91,7 +91,7 @@ jobs:
           # Use the next two only if you have created a CloudFront distribution
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
           invalidation: /*
-{%- endraw -%}
+{%- endraw %}
 ```
 
 Note, that you may need to change the branch name in the above snippet if you desire a different behavior.

--- a/docs/content/documentation/deployment/azure-static-webapps.md
+++ b/docs/content/documentation/deployment/azure-static-webapps.md
@@ -71,6 +71,6 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN<WEB_APP_NAME> }}
           action: "close"
-{%- endraw -%}
+{%- endraw %}
 ```
 Once your YAML changes have been pushed, GitHub will automatically kick off a workflow deploying your site!

--- a/docs/content/documentation/getting-started/overview.md
+++ b/docs/content/documentation/getting-started/overview.md
@@ -98,7 +98,7 @@ Let's make a template for a home page. Create `templates/base.html` with the fol
 </body>
 
 </html>
-{%- endraw -%}
+{%- endraw %}
 ```  
 
 Now, let's create `templates/index.html` with the following content.
@@ -112,7 +112,7 @@ Now, let's create `templates/index.html` with the following content.
   This is my blog made with Zola.
 </h1>
 {% endblock content %}
-{%- endraw -%}
+{%- endraw %}
 ```  
 
 This tells Zola that `index.html` extends our `base.html` file and replaces the block called "content" with the text between the `{% raw %}{% block content %}{% endraw %}` and `{% raw %}{% endblock content %}{% endraw %}` tags.
@@ -137,7 +137,7 @@ To create a template for a page that lists all blog posts, create `templates/blo
   {% endfor %}
 </ul>
 {% endblock content %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 As done by `index.html`, `blog.html` extends `base.html`, but in this template we want to list the blog posts. Here we also see expressions such as `{% raw %}{{ section.[...] }}{% endraw %}` and `{% raw %}{{ page.[...] }}{% endraw %}` which will be replaced with values from our [content](#content) when zola combines content with this template to render a page. 
@@ -159,7 +159,7 @@ We have templates describing our home page and a page that lists all blog posts.
 <p class="subtitle"><strong>{{ page.date }}</strong></p>
 {{ page.content | safe }}
 {% endblock content %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 > Note the `| safe` filter for `{% raw %}{{ page.content }}{% endraw %}`.
@@ -255,7 +255,7 @@ As a final step, let's modify `templates/index.html` (our home page) to link to 
 </h1>
 <p><a href="{{ get_url(path='@/blog/_index.md') }}">Posts</a>.</p>
 {% endblock content %}
-{%- endraw -%}
+{%- endraw %}
 ```  
 
 This has been a quick overview of Zola. You can now dive into the rest of the documentation.

--- a/docs/content/documentation/templates/archive.md
+++ b/docs/content/documentation/templates/archive.md
@@ -17,7 +17,7 @@ all post titles ordered by year). However, this can be accomplished directly in 
     {% endfor %}
     </ul>
 {% endfor %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 This snippet assumes that posts are sorted by date and that you want to display the archive
@@ -34,5 +34,5 @@ process the list of pages:
     {% set posts = posts_by_year[year] %}
     {# (same as the previous snippet) #}
 {% endfor %}
-{%- endraw -%}
+{%- endraw %}
 ```

--- a/docs/content/documentation/templates/feeds/index.md
+++ b/docs/content/documentation/templates/feeds/index.md
@@ -71,7 +71,7 @@ You can enable posts autodiscovery modifying your blog `base.html` template addi
 {% block rss %}
   <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml", trailing_slash=false) }}">
 {% endblock %}
-{%- endraw -%}
+{%- endraw %}
 ```
 You can as well use an Atom feed using `type="application/atom+xml"` and `path="atom.xml"`.
 
@@ -84,7 +84,7 @@ In order to enable the tag feeds as well, you can overload the `block rss` using
   {% set rss_path = "tags/" ~ term.name ~ "/rss.xml" %}
   <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path=rss_path, trailing_slash=false) }}">
 {% endblock rss %}
-{%- endraw -%}
+{%- endraw %}
 ```
 Each tag page will refer to it's dedicated feed.
 

--- a/docs/content/documentation/templates/overview.md
+++ b/docs/content/documentation/templates/overview.md
@@ -78,7 +78,7 @@ pass `true` to the inline argument:
 ```jinja
 {% raw -%}
 {{ some_text | markdown(inline=true) }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 You do not need to use this filter with `page.content` or `section.content`, the content is already rendered.
@@ -96,7 +96,7 @@ Replace text via regular expressions.
 {% raw -%}
 {{ "World Hello" | regex_replace(pattern=`(?P<subject>\w+), (?P<greeting>\w+)`, rep=`$greeting $subject`) }}
 <!-- Hello World -->
-{%- endraw -%}
+{%- endraw %}
 ```
 
 ### num_format
@@ -106,7 +106,7 @@ Format a number into its string representation.
 {% raw -%}
 {{ 1000000 | num_format }}
 <!-- 1,000,000 -->
-{%- endraw -%}
+{%- endraw %}
 ```
 
 By default this will format the number using the locale set by `config.default_language` in zola.toml.
@@ -117,7 +117,7 @@ To format a number for a specific locale, you can use the `locale` argument and 
 {% raw -%}
 {{ 1000000 | num_format(locale="en-IN") }}
 <!-- 10,00,000 -->
-{%- endraw -%}
+{%- endraw %}
 ```
 
 ## Built-in functions
@@ -149,7 +149,7 @@ Takes a path to an `.md` file and returns the associated page. The base path is 
 ```jinja
 {% raw -%}
 {% set page = get_page(path="blog/page2.md") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 If selecting a specific language for the page, you can pass `lang` with the language code to the function:
@@ -160,8 +160,7 @@ If selecting a specific language for the page, you can pass `lang` with the lang
 
 {# If "fr" is the default language, this is equivalent to #}
 {% set page = get_page(path="blog/page2.md") %}
-{%- endraw -%}
-
+{%- endraw %}
 ```
 
 If you want to ignore a missing page instead of raising an error, like in the case where you have a link to a draft page you want to handle yourself, you can pass `allow_missing=true` to the function:
@@ -176,7 +175,7 @@ If you want to ignore a missing page instead of raising an error, like in the ca
 {% else %}
 <span></span>
 {% endif %}
-
+{%- endraw %}
 ```
 
 ### `get_section`
@@ -185,7 +184,7 @@ Takes a path to an `_index.md` file and returns the associated section. The base
 ```jinja
 {% raw -%}
 {% set section = get_section(path="blog/_index.md") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 If you only need the metadata of the section, you can pass `metadata_only=true` to the function:
@@ -193,7 +192,7 @@ If you only need the metadata of the section, you can pass `metadata_only=true` 
 ```jinja
 {% raw -%}
 {% set section = get_section(path="blog/_index.md", metadata_only=true) %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 If selecting a specific language for the section, you can pass `lang` with the language code to the function:
@@ -204,7 +203,7 @@ If selecting a specific language for the section, you can pass `lang` with the l
 
 {# If "fr" is the default language, this is equivalent to #}
 {% set section = get_section(path="blog/_index.md") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 If you want to ignore a missing section instead of raising an error, like in the case where you have a link to a draft section you want to handle yourself, you can pass `allow_missing=true` to the function:
@@ -219,7 +218,7 @@ If you want to ignore a missing section instead of raising an error, like in the
 {% else %}
 <span></span>
 {% endif %}
-
+{%- endraw %}
 ```
 
 ### `get_taxonomy_url`
@@ -228,7 +227,7 @@ Gets the permalink for the taxonomy item found.
 ```jinja
 {% raw -%}
 {% set url = get_taxonomy_url(kind="categories", term=page.taxonomies.category, lang=page.lang) %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 `term` will almost always come from a variable but in case you want to do it manually,
@@ -244,7 +243,7 @@ Gets the whole taxonomy of a specific kind.
 ```jinja
 {% raw -%}
 {% set categories = get_taxonomy(kind="categories") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 The type of the output is:
@@ -268,7 +267,7 @@ Gets a single term from a taxonomy of a specific kind.
 ```jinja
 {% raw -%}
 {% set categories = get_taxonomy_term(kind="categories", term="term_name") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 The type of the output is a single `TaxonomyTerm` item.
@@ -290,7 +289,7 @@ a colocated asset,  starting from the root `content` directory as well as valida
 {% raw -%}
 {% set url = get_url(path="@/blog/_index.md") %}
 {% set asset = get_url(path="@/blog/my-article/graph.png", lang="fr") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 It accepts an optional parameter `lang` in order to compute a *language-aware URL* in multilingual websites. Assuming `config.base_url` is `"http://example.com"`, the following snippet will:
@@ -302,7 +301,7 @@ It accepts an optional parameter `lang` in order to compute a *language-aware UR
 ```jinja
 {% raw -%}
 {% set url = get_url(path="@/blog/_index.md", lang="en") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 This can also be used to get the permalink for a static file, for example if
@@ -311,7 +310,7 @@ you want to link to the file that is located at `static/css/app.css`:
 ```jinja
 {% raw -%}
 {{ get_url(path="css/app.css") }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 By default, the link will not have a trailing slash. You can force one by passing `trailing_slash=true` to the `get_url` function.
@@ -320,7 +319,7 @@ An example is:
 ```jinja
 {% raw -%}
 {{ get_url(path="css/app.css", trailing_slash=true) }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 In the case of a non-internal link, you can also add a cachebust of the format `?h=<sha256>` at the end of a URL
@@ -343,7 +342,7 @@ Either `path` or `literal` must be given.
 {% raw -%}
 {{ get_hash(literal="Hello World", sha_type=256) }}
 {{ get_hash(path="static/js/app.js", sha_type=256) }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 The function can also output a base64-encoded hash value when its `base64`
@@ -354,7 +353,7 @@ integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Int
 {% raw -%}
 <script src="{{ get_url(path="static/js/app.js") }}"
   integrity="sha384-{{ get_hash(path="static/js/app.js", sha_type=384, base64=true) | safe }}"></script>
-{%- endraw -%}
+{%- endraw %}
 ```
 
 Do note that subresource integrity is typically used when using external scripts, which `get_hash` does not support.
@@ -374,7 +373,7 @@ The method returns a map containing `width`, `height`, `format`, `mime`, `descri
 {% raw -%}
   {% set meta = get_image_metadata(path="...") %}
   Our image (.{{meta.format}}) has format is {{ meta.width }}x{{ meta.height }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 ### `load_data`
@@ -389,7 +388,7 @@ The `path` argument specifies the path to a local data file, according to the [F
 ```jinja
 {% raw -%}
 {% set data = load_data(path="content/blog/story/data.toml") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 Alternatively, the `url` argument specifies the location of a remote URL to load.
@@ -397,7 +396,7 @@ Alternatively, the `url` argument specifies the location of a remote URL to load
 ```jinja
 {% raw -%}
 {% set data = load_data(url="https://en.wikipedia.org/wiki/Commune_of_Paris") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 Alternatively, the `literal` argument specifies an object literal. Note: if the `format` argument is not specified, then plain text will be what is assumed.
@@ -406,7 +405,7 @@ Alternatively, the `literal` argument specifies an object literal. Note: if the 
 {% raw -%}
 {% set data = load_data(literal='{"name": "bob"}', format="json") %}
 {{ data["name"] }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 *Note: the `required` parameter has no effect when used in combination with the `literal` argument.*
@@ -419,7 +418,7 @@ The snippet below outputs the HTML from a Wikipedia page, or "No data found" if 
 {% raw -%}
 {% set data = load_data(url="https://en.wikipedia.org/wiki/Commune_of_Paris", required=false) %}
 {% if data %}{{ data | safe }}{% else %}No data found{% endif %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 The optional `format` argument allows you to specify and override which data type is contained within the specified file or URL.
@@ -430,7 +429,7 @@ path extension is used. In the case of a literal, `plain` is assumed if `format`
 ```jinja
 {% raw -%}
 {% set data = load_data(path="content/blog/story/data.txt", format="json") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 Use the `plain` format for when your file has a supported extension but you want to load it as plain text.
@@ -444,7 +443,7 @@ In the template:
 ```jinja
 {% raw -%}
 {% set data = load_data(path="content/blog/story/data.csv") %}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 In the *content/blog/story/data.csv* file:
@@ -517,7 +516,7 @@ Finally, the bibtex data can be accessed from the template as follows:
 {% raw -%}
 {% set tags = data.bibliographies[0].tags %}
 This was generated using {{ tags.title }}, authored by {{ tags.author }}.
-{%- endraw -%}
+{%- endraw %}
 ```
 
 #### Remote content
@@ -529,7 +528,7 @@ to `load_data` rather than `path`.
 {% raw -%}
 {% set response = load_data(url="https://api.github.com/repos/getzola/zola") %}
 {{ response }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 By default, the response body will be returned with no parsing. This can be changed by using the `format` argument
@@ -540,7 +539,7 @@ as below.
 {% raw -%}
 {% set response = load_data(url="https://api.github.com/repos/getzola/zola", format="json") %}
 {{ response }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 When no other parameters are specified the URL will always be retrieved using a HTTP GET request.
@@ -564,7 +563,7 @@ This example will make a POST request to the kroki service to generate a SVG.
   'very easy!' [color = 'orange'];
 }")%}
 {{postdata|safe}}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 If you need additional handling for the HTTP headers, you can use the `headers` parameter.
@@ -578,7 +577,7 @@ This example will make a POST request to the GitHub markdown rendering service.
 {% raw -%}
 {% set postdata = load_data(url="https://api.github.com/markdown", format="plain", method="POST", content_type="application/json", headers=["accept=application/vnd.github.v3+json"], body='{"text":"headers support added in #1710, commit before it: b3918f124d13ec1bedad4860c15a060dd3751368","context":"getzola/zola","mode":"gfm"}')%}
 {{postdata|safe}}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 The following example shows how to send a GraphQL query to GitHub (requires authentication).
@@ -591,7 +590,7 @@ environment variable to the access token you have obtained.
 {% set token = get_env(name="GITHUB_TOKEN") %}
 {% set postdata = load_data(url="https://api.github.com/graphql", format="json", method="POST" ,content_type="application/json", headers=["accept=application/vnd.github.v4.idl", "authorization=Bearer " ~ token], body='{"query":"query { viewer { login }}"}')%}
 {{postdata|safe}}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 In case you need to specify multiple headers with the same name, you can specify them like this:
@@ -624,7 +623,7 @@ Gets the horizontal text directionality for the `default_language`, the `lang`ua
 {{ text_direction() }}
 {{ text_direction(lang="fr") }}
 {{ text_direction(lang=lang) }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 Returns the string literal `ltr` or `rtl`, which may be passed directly into the [`dir` global HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/dir).
@@ -637,7 +636,7 @@ Gets the translation of the given `key`, for the `default_language`, the `lang`u
 {{ trans(key="title") }}
 {{ trans(key="title", lang="fr") }}
 {{ trans(key="title", lang=lang) }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 ### `resize_image`

--- a/docs/content/documentation/templates/pagination.md
+++ b/docs/content/documentation/templates/pagination.md
@@ -85,5 +85,5 @@ Here is an example from a theme on how to use pagination on a page (`index.html`
         <a class="next" href="{{ paginator.next }}">Next ›</a>
     {% endif %}
 </nav>
-{%- endraw -%}
+{%- endraw %}
 ```

--- a/docs/content/documentation/templates/robots.md
+++ b/docs/content/documentation/templates/robots.md
@@ -15,7 +15,7 @@ User-agent: *
 Disallow:
 Allow: /
 Sitemap: {{ get_url(path="sitemap.xml") }}
-{%- endraw -%}
+{%- endraw %}
 ```
 
 The file can be extended & expanded like other templates using e.g. Tera's `include` tag:
@@ -28,5 +28,5 @@ Allow: /
 Sitemap: {{ get_url(path="sitemap.xml") }}
 
 {% include "path/to/other/robots.txt" %}
-{%- endraw -%}
+{%- endraw %}
 ```


### PR DESCRIPTION
Hi folks,

This resolves an issue I saw in the docs where code blocks weren't being correctly escaped due to {%- endraw -%} stripping off the newline before the closing ``` fence. The fix here was to replace it with {%- endraw %}, which doesn't strip the newline.

Fixed using grep/sed. Verified manually (using my eyes). 

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

N/A currently open.

* [x] Have you created/updated the relevant documentation page(s)?

Yes! All of them with the old endraw.



