### PR TITLE
fix(config): generate feeds per language option in multilingual sites

### DIFF
--- a/components/config/src/config/mod.rs
+++ b/components/config/src/config/mod.rs
@@ -297,11 +297,6 @@ impl Config {
             if base_language_options == languages::LanguageOptions::default() {
                 return Ok(());
             }
-            log::warn!(
-                "config.toml contains both default language specific information at base and under section `[languages.{}]`, \
-                which may cause merge conflicts. Please use only one to specify language specific information",
-                self.default_language
-            );
             base_language_options.merge(section_language_options)?;
         }
         self.languages.insert(self.default_language.clone(), base_language_options);

--- a/components/site/src/queue.rs
+++ b/components/site/src/queue.rs
@@ -208,11 +208,6 @@ impl<'a> Queue<'a> {
             }
         }
 
-        // Whole site feed: generate per-language based on each language's own
-        // `generate_feeds` option, which already merges the global value with any
-        // per-language override. The previous outer `if site.config.generate_feeds`
-        // gate meant feeds were skipped entirely when the option was set only in a
-        // `[languages.xx]` section but not globally. See issue #2360.
         for (lang, lang_config) in &site.config.languages {
             if !lang_config.generate_feeds {
                 continue;

--- a/components/site/src/queue.rs
+++ b/components/site/src/queue.rs
@@ -208,14 +208,16 @@ impl<'a> Queue<'a> {
             }
         }
 
-        // Whole site feed
-        if site.config.generate_feeds {
-            for (lang, lang_config) in &site.config.languages {
-                if !lang_config.generate_feeds {
-                    continue;
-                }
-                queue.jobs.push(Job::Feed(Feed::Site { lang }));
+        // Whole site feed: generate per-language based on each language's own
+        // `generate_feeds` option, which already merges the global value with any
+        // per-language override. The previous outer `if site.config.generate_feeds`
+        // gate meant feeds were skipped entirely when the option was set only in a
+        // `[languages.xx]` section but not globally. See issue #2360.
+        for (lang, lang_config) in &site.config.languages {
+            if !lang_config.generate_feeds {
+                continue;
             }
+            queue.jobs.push(Job::Feed(Feed::Site { lang }));
         }
 
         queue


### PR DESCRIPTION
## Summary

Fixes #2360 — two related problems in multilingual sites that set `generate_feeds` only in a `[languages.xx]` section.

## Root cause

**Part 1 — the warning.** `add_default_language()` warned about a possible merge conflict whenever the user set options both globally and in the default language section, even when there was no real conflict. The merge logic in `languages.rs` already errors on actual conflicts (e.g. two different values for the same field), so the warning was unnecessary.

**Part 2 — the feed-generation gate.** `queue.rs` checked the raw global field (`site.config.generate_feeds`) to decide whether to generate whole-site feeds. When `generate_feeds` was `true` only in a per-language section, the global was `false` and no feeds were generated at all — even though the per-language option was `true`. The per-language check (`lang_config.generate_feeds`) already correctly handles each language's own option.

## The fix

- `components/config/src/config/mod.rs` — remove the `log::warn!` call in `add_default_language()`.
- `components/site/src/queue.rs` — remove the outer `if site.config.generate_feeds` gate. The loop now runs for all languages, gated only by each language's own `generate_feeds` option (which already merges the global value with any per-language override via `languages.rs`).

+9 / -12, 2 files, 1 commit.

## Notes

- This follows the approach @Keats confirmed on 2026-07-18 ("let's remove it" for the warning; "seems right" for removing the outer condition).
- I could not run `cargo test` locally (no Rust toolchain in my environment); the fix is a minimal, mechanical change and CI will run the full test suite on this PR.
- An LLM assisted in locating the code and drafting this change. I reviewed, edited, and stand by every line of the diff, per the project's LLM-usage guidance.

Fixes #2360