### PR TITLE
fix: panic when templating a section body that has subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.23.3 (unreleased)
 
+- Fix panic when templating a section body that has subsections
+
 ## 0.23.2 (2026-08-07)
 
 - Fix dual class CSS generation

--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -162,7 +162,7 @@ impl<'a> SerializingSection<'a> {
         let subsections: Vec<&str> = section
             .subsections
             .iter()
-            .map(|p| library.sections[p].file.relative.as_str())
+            .filter_map(|p| library.sections.get(p).map(|s| s.file.relative.as_str()))
             .collect();
         let backlinks = find_backlinks(&section.file.relative, library);
 

--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -34,6 +34,8 @@ use utils::types::InsertAnchor;
 pub static SITE_CONTENT: LazyLock<Arc<RwLock<HashMap<RelativePathBuf, String>>>> =
     LazyLock::new(|| Arc::new(RwLock::new(HashMap::new())));
 
+static CONTENT_LIBRARY: LazyLock<Library> = LazyLock::new(Library::default);
+
 /// Where are we building the site
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum BuildMode {
@@ -473,8 +475,7 @@ impl Site {
         }
 
         // For rendering content, we do not need the real library since it's not going to be filled
-        let dummy_library = Library::default();
-        let renderer = Renderer { tera, config, library: &dummy_library, cache: &self.cache };
+        let renderer = Renderer::new(tera, config, &CONTENT_LIBRARY, &self.cache);
 
         let library = Arc::make_mut(&mut self.library);
         library
@@ -535,7 +536,7 @@ impl Site {
                 self.find_parent_section_insert_anchor(&page.file.parent, &page.lang);
             md_render::render_page(
                 &mut page,
-                self.renderer(),
+                self.content_renderer(),
                 &self.permalinks,
                 &self.library.colocated_assets,
                 &self.tera,
@@ -567,7 +568,7 @@ impl Site {
         if render_md {
             md_render::render_section(
                 &mut section,
-                self.renderer(),
+                self.content_renderer(),
                 &self.permalinks,
                 &self.library.colocated_assets,
                 &self.tera,
@@ -632,9 +633,9 @@ impl Site {
         self.cache = Arc::new(cache);
     }
 
-    /// Create a Renderer for this site
-    fn renderer(&self) -> Renderer<'_> {
-        Renderer::new(&self.tera, &self.config, &self.library, &self.cache)
+    /// Create a Renderer to template the content of a page/section
+    fn content_renderer(&self) -> Renderer<'_> {
+        Renderer::new(&self.tera, &self.config, &CONTENT_LIBRARY, &self.cache)
     }
 
     /// Inject live reload script tag if in live reload mode

--- a/components/site/src/md_render.rs
+++ b/components/site/src/md_render.rs
@@ -121,12 +121,12 @@ mod tests {
     use ahash::AHashMap;
 
     use config::Config;
-    use content::{Library, Page};
+    use content::{Library, Page, Section};
     use render::{RenderCache, Renderer};
     use templates::ZOLA_TERA;
     use utils::types::InsertAnchor;
 
-    use super::render_page;
+    use super::{render_page, render_section};
 
     fn make_renderer<'a>(
         config: &'a Config,
@@ -134,6 +134,31 @@ mod tests {
         cache: &'a RenderCache,
     ) -> Renderer<'a> {
         Renderer::new(&ZOLA_TERA, config, library, cache)
+    }
+
+    #[test]
+    fn can_render_section_with_subsections() {
+        let config = Config::default_for_test();
+        let library = Library::default();
+        let mut cache = RenderCache::new(&config);
+        cache.build(&library, &[], &ZOLA_TERA);
+        let content = "+++\n+++\n{{ 1 + 1 }}";
+        let res = Section::parse(Path::new("_index.md"), content, &config, &PathBuf::new());
+        assert!(res.is_ok());
+        let mut section = res.unwrap();
+        section.subsections.push(PathBuf::from("content/guide/_index.md"));
+
+        let renderer = make_renderer(&config, &library, &cache);
+        render_section(
+            &mut section,
+            renderer,
+            &HashMap::default(),
+            &AHashMap::default(),
+            &ZOLA_TERA,
+            &config,
+        )
+        .unwrap();
+        assert!(section.content.contains("<p>2</p>"));
     }
 
     #[test]

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use ahash::AHashMap;
 use common::{build_site, build_site_with_setup};
 use config::TaxonomyConfig;
-use content::Page;
+use content::{Page, Section};
 use site::Site;
 use site::sitemap;
 use tera::Value;
@@ -124,6 +124,24 @@ fn errors_on_unknown_taxonomies() {
         err.to_string(),
         "Page `unknown/taxo.md` has taxonomy `wrong` which is not defined in config.toml"
     );
+}
+
+#[test]
+fn content_templating_never_sees_the_library() {
+    let (mut site, _, _) = build_site("test_site");
+    // `serve --fast` re-renders a single section while the library is fully populated but the
+    // content templating still has to get the empty one, otherwise the output of `zola serve`
+    // would differ from the output of `zola build`
+    let subsection = site.library.sections.keys().next().unwrap().clone();
+    let content = "+++\n+++\nsubsections:{% for s in section.subsections %} {{ s }}{% endfor %}";
+    let mut section =
+        Section::parse(Path::new("_index.md"), content, &site.config, &PathBuf::new()).unwrap();
+    section.subsections.push(subsection);
+    let path = section.file.path.clone();
+
+    site.add_section(section, true).unwrap();
+
+    assert_eq!(site.library.sections[&path].content.trim(), "<p>subsections:</p>");
 }
 
 #[test]


### PR DESCRIPTION
Fixes  https://github.com/getzola/zola/issues/3226

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?
* [x] Was a LLM used?

> [!NOTE]
> I am very new to Rust. While I've tried my best to understand the problem and the fix, two separate LLMs were used to identify, address, review and test the issue. The below description is me rewriting the LLM's explanation as I understand it.

---

### Root cause

`SerializingSection::new` looked up each entry of `section.subsections` with `library.sections[p]`. On a full build those lookups always miss:

1. `populate_sections` fills in `section.subsections` with real paths.
2. `render_markdown` then templates every section body in parallel. To do that it takes `Arc::make_mut(&mut self.library)`, so it cannot also lend the real library to the renderer, and passes a `Library::default()` instead.

So the paths are present but the map they point into is empty, and the index panics with `no entry found for key`. Any section body that trips `needs_templating` and has at least one subsection hits this.

The `serve --fast` path did not panic, because `add_section` rendered through `self.renderer()`, which has the real, fully populated library.

### What this does

Two changes:

- `SerializingSection::new` uses `.get()` in a `filter_map`, so a subsection that cannot be resolved is skipped rather than fatal. This is how the neighbouring fields already behave when the library is not queryable: `pages` arrives as `Vec::new()`, and `RenderCache` already used `filter_map` for the same lookup.
- All content templating now shares one always-empty `CONTENT_LIBRARY`. `render_markdown` uses it in place of its local dummy, and `renderer()` becomes `content_renderer()`, which no longer hands over the real library.
  - Its only two callers, `add_page` and `add_section`, are content templating, and `Renderer.library` is read only by `render_page_content` and `render_section_content`, so template rendering is untouched while build and serve now produce the same output.
  - The alternative, giving `render_markdown` the real library, would mean cloning the whole library on every build just to satisfy the borrow the parallel loop needs.

### Tests

Both were confirmed to fail without the fix:

- `can_render_section_with_subsections` covers the panic.
- `content_templating_never_sees_the_library` builds the real `test_site`, so the library is fully populated, then re-renders a section through `add_section(.., true)` as `serve --fast` does, and asserts that a loop over `section.subsections` in the body produces nothing.

