### PR TITLE
Fix feed URL for non-default languages

### DIFF
--- a/components/site/src/queue.rs
+++ b/components/site/src/queue.rs
@@ -386,8 +386,13 @@ impl<'a> Queue<'a> {
                     self.site.library.pages.values().filter(|p| p.lang == *lang).collect();
                 let feed_data =
                     feeds::prepare_feed(&pages, self.site.config.feed_limit, &self.site.cache);
+                let base_path = if *lang == self.site.config.default_language {
+                    None
+                } else {
+                    Some(PathBuf::from(lang))
+                };
                 for feed_filename in &self.site.config.languages[*lang].feed_filenames {
-                    let feed_url = self.site.make_feed_url(None, feed_filename);
+                    let feed_url = self.site.make_feed_url(base_path.as_ref(), feed_filename);
                     let input = FeedInput {
                         feed_filename,
                         lang,

--- a/components/site/tests/site_i18n.rs
+++ b/components/site/tests/site_i18n.rs
@@ -116,7 +116,10 @@ fn can_build_multilingual_site() {
         "atom.xml",
         r#"<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">"#
     ));
+    assert!(file_contains!(public, "atom.xml", "<id>https://example.com/atom.xml</id>"));
     assert!(file_exists!(public, "fr/atom.xml"));
+    // each language's feed links to itself, not to the default language one
+    assert!(file_contains!(public, "fr/atom.xml", "<id>https://example.com/fr/atom.xml</id>"));
     assert!(!file_contains!(public, "fr/atom.xml", "https://example.com/blog/something-else/"));
     assert!(file_contains!(public, "fr/atom.xml", "https://example.com/fr/blog/something-else/"));
     assert!(file_contains!(


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?
* [x] Was a LLM used? If so, for what? I guided Claude to 1) locate the regression, 2) write the fix and 3) write the tests. I verified the bug and fix manually.

---

## Description

Since Zola 0.23.0, the `feed_url` variable passed to templates for non-default-language site feeds has lost its language prefix.

The feed is written to the correct path, and its entries retain the correct language, but `feed_url` points to the default-language feed. With the built-in `atom.xml` template, this causes both `<id>` and `<link rel="self">` to identify the wrong feed.

Expected, and what 0.22.0 did:

| File | `feed_url` |
|:--|:--|
| `public/atom.xml` | `https://example.com/atom.xml` |
| `public/es/atom.xml` | `https://example.com/es/atom.xml` |

What 0.23.0 does:

| File | `feed_url` |
|:--|:--|
| `public/atom.xml` | `https://example.com/atom.xml` |
| `public/es/atom.xml` | `https://example.com/atom.xml` |

Section feeds and taxonomy feeds are not affected. Only the per-language site feed is.

### Steps to reproduce

`config.toml`:

```toml
base_url = "https://example.com"
title = "Repro"
default_language = "en"
generate_feeds = true
feed_filenames = ["atom.xml"]

[languages.es]
generate_feeds = true
feed_filenames = ["atom.xml"]
```

With one page in each language, `zola build`, then look at `public/es/atom.xml`:

```
<id>https://example.com/atom.xml</id>
```

It should read `https://example.com/es/atom.xml`.

The regression was introduced in #3105. The output path retained the language prefix, but the corresponding URL was constructed without it.

I checked [the RFC](https://www.rfc-editor.org/rfc/rfc4287.html) to verify which one was correct. To me, this looks like a regression:

>    o  atom:feed elements SHOULD contain one atom:link element with a rel
>       attribute value of "self".  This is the preferred URI for
>       retrieving Atom Feed Documents representing this Atom feed.