### PR TITLE
Fix colocated assets

### DIFF
--- a/components/site/src/queue.rs
+++ b/components/site/src/queue.rs
@@ -23,6 +23,7 @@ enum Job<'a> {
     Alias { from: &'a str, to: &'a str },
     Page(&'a Page),
     Section { section: &'a Section, path: PathBuf },
+    SectionAssets { section: &'a Section, path: PathBuf },
     Paginated { paginator_index: usize, pager_index: usize, path: PathBuf },
     TaxonomyList { taxonomy: &'a Taxonomy, path: PathBuf },
     TaxonomyTerm { taxonomy: &'a Taxonomy, term: &'a TaxonomyTerm, path: PathBuf },
@@ -94,16 +95,20 @@ impl<'a> Queue<'a> {
             self.jobs.push(Job::Feed(Feed::Section { pages, section }));
         }
 
-        if !section.meta.render {
-            return;
-        }
-
         let mut base_path = PathBuf::new();
         if section.lang != self.site.config.default_language {
             base_path.push(&section.lang);
         }
         for component in &section.file.components {
             base_path.push(component);
+        }
+
+        if !section.assets.is_empty() {
+            self.jobs.push(Job::SectionAssets { section, path: base_path.clone() });
+        }
+
+        if !section.meta.render {
+            return;
         }
 
         if section.meta.is_paginated() {
@@ -232,7 +237,7 @@ impl<'a> Queue<'a> {
                         .join(page.path.strip_prefix('/').unwrap_or(&page.path));
                     self.site.copy_assets(page.file.path.parent().unwrap(), &page.assets, &dest)?;
                 }
-                Job::Section { section, path } if section.meta.redirect_to.is_none() => {
+                Job::SectionAssets { section, path } => {
                     let dest = self.site.output_path.join(path);
                     self.site.copy_assets(
                         section.file.path.parent().unwrap(),
@@ -518,6 +523,7 @@ impl<'a> Queue<'a> {
             Job::Alias { from, to } => Ok(vec![self.render_alias(from, to)?]),
             Job::Page(page) => Ok(vec![self.render_page(page)?]),
             Job::Section { section, path } => Ok(vec![self.render_section(section, path)?]),
+            Job::SectionAssets { .. } => Ok(Vec::new()),
             Job::Paginated { paginator_index, pager_index, path } => {
                 self.render_paginated(*paginator_index, *pager_index, path)
             }

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -151,6 +151,9 @@ fn can_build_site_without_live_reload() {
     // "render = false" should not generate an index.html
     assert!(!file_exists!(public, "posts/render/index.html"));
 
+    assert!(file_exists!(public, "posts/2018/asset.txt"));
+    assert!(file_exists!(public, "posts/tutorials/devops/asset.txt"));
+
     // Sections
     assert!(file_exists!(public, "posts/index.html"));
     assert!(file_exists!(public, "posts/tutorials/index.html"));
@@ -457,6 +460,7 @@ fn can_build_site_with_pagination_for_section() {
     // even if there is no pages, only the section!
     assert!(file_exists!(public, "paginated/page/1/index.html"));
     assert!(file_exists!(public, "paginated/index.html"));
+    assert!(file_exists!(public, "paginated/asset.txt"));
     // should redirect to posts/
     assert!(file_contains!(
         public,

--- a/test_site/content/paginated/asset.txt
+++ b/test_site/content/paginated/asset.txt
@@ -1,0 +1,1 @@
+I told you once and I told you twice, why be mean when you can be nice? — Michael Hurley

--- a/test_site/content/posts/2018/asset.txt
+++ b/test_site/content/posts/2018/asset.txt
@@ -1,0 +1,1 @@
+All those moments will be lost in time, like tears in rain… Time to die. — David Peoples & Rutger Hauer

--- a/test_site/content/posts/tutorials/devops/asset.txt
+++ b/test_site/content/posts/tutorials/devops/asset.txt
@@ -1,0 +1,5 @@
+I've come a long way,
+the cold seeps through my worn clothes.
+This afternoon the sky is clear,
+oh how my heart aches!
+— Hiromi Kawakami


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request adding a new feature without discussing it first.**

The place to discuss new features is the forum: <https://zola.discourse.group/>
If you want to add a new feature, please open a thread there first in the feature requests section.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes
(Delete or ignore this section for documentation changes)

* [x] Are you doing the PR on the `next` branch?
* [x] Was a LLM used? If so, for what? Claude Code was used to locate the regression, write the fix and the test. I verified by building my site with 0.22.0 and 0.23.0. Used Codex to review code and re-verify claims.

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)? *(N/A: bug fix, no behaviour change to document)*

---

## Description

Since 0.23.0, a section's colocated assets are silently dropped from the output in three cases:

1. The section is paginated (`paginate_by` is set).
2. The section sets `redirect_to`.
3. The section sets `render = false`.

0.22.0 copied colocated assets for all sections. Nothing warns about the missing files, and the build succeeds. The first sign is a 404 on the live site.

Pages are not affected. Only sections are.

### How this was found

Rebuilding the [tabi](https://github.com/welpo/tabi) theme for 0.23 compatibility. tabi stores each section's social card next to its `_index.md`. The blog section is paginated, so `blog.jpg` stopped being written to `public/`, while `<meta property="og:image">` kept pointing at it. Comparing the full output against a 0.22.0 build is what surfaced it.

### Steps to reproduce

```
config.toml
content/blog/_index.md      # with paginate_by = 5
content/blog/card.jpg
content/redir/_index.md     # with redirect_to = "blog"
content/redir/b.jpg
content/norender/_index.md  # with render = false
content/norender/a.jpg
templates/section.html
templates/page.html
```

`zola build` on 0.22.0 writes `public/blog/card.jpg`, `public/redir/b.jpg` and `public/norender/a.jpg`.

`zola build` on 0.23.0 writes none of them.

Removing `paginate_by` makes 0.23.0 copy `card.jpg` again, which is the quickest way to confirm the pagination case.

#3105 caused the regression.

In 0.22.0, `Site::render_section` called `copy_assets` once, before it branched on `render`, on `redirect_to` and on pagination:

```rust
// components/site/src/lib.rs, v0.22.0
self.copy_assets(section.file.path.parent().unwrap(), &section.assets, &output_path)?;

  if !section.meta.render {
      return Ok(());
  }

  if let Some(ref redirect_to) = section.meta.redirect_to {
      // ...
      return Ok(());
  }

  if section.meta.is_paginated() {
      // ...
  }
```

After the refactor, assets were copied only by the guarded Job::Section arm. That excludes the affected sections in three different ways:

- Job::Section { section, path } if section.meta.redirect_to.is_none() excludes redirects.
- add_section_jobs returns early for render = false.
- Paginated sections produce Job::Paginated rather than Job::Section.

Consequently, none of these paths reaches the section asset-copying code.