### PR TITLE
Update the Debian install docs to the pkg.haus APT archive

### DIFF
--- a/docs/content/documentation/getting-started/installation.md
+++ b/docs/content/documentation/getting-started/installation.md
@@ -40,11 +40,13 @@ $ apk add zola
 
 ### Debian
 
-Zola is available over at [barnumbirr/zola-debian](https://github.com/barnumbirr/zola-debian).
-Grab the latest `.deb` for your Debian version then simply run:
+Zola is available from the [pkg.haus](https://pkg.haus) APT archive for
+Debian stable, testing and unstable on amd64 and arm64, built from source
+at release tags. Set up the archive per the instructions on
+[pkg.haus](https://pkg.haus), then run:
 
 ```sh
-$ sudo dpkg -i zola_<version>_amd64_debian_<debian_version>.deb
+$ sudo apt install zola
 ```
 
 ### Gentoo


### PR DESCRIPTION
The barnumbirr/zola-debian per-release .deb flow this section documented has been superseded: the packaging moved into the pkghaus org and releases now publish to the [pkg.haus](https://pkg.haus) APT archive (Debian stable, testing and unstable, amd64/arm64, built from source at release tags, signed). This updates the section to the current install path.