### PR TITLE
Support self-fragment wikilinks

### DIFF
--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -421,6 +421,14 @@ impl<'a> State<'a> {
                 Some((k, a)) => (k, Some(a.to_string())),
                 None => (link, None),
             };
+            if key.is_empty()
+                && let Some(anchor) = anchor
+            {
+                if !ctx.current_path.is_empty() {
+                    self.internal_links.push((ctx.current_path.to_owned(), Some(anchor.clone())));
+                }
+                return Ok(format!("{}#{anchor}", ctx.current_permalink));
+            }
             if let Some(md_path) = ctx.wikilinks.get(key) {
                 let permalink = &ctx.permalinks[md_path];
                 self.internal_links.push((md_path.clone(), anchor.clone()));

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -499,11 +499,15 @@ fn wikilink_resolution() {
         "[[guides/quickstart]]",
         "[[quickstart#install]]",
         "[[quickstart|Get Started]]",
+        "[[#details]]",
+        "[[#details|Details]]",
     ];
 
-    let res = common::render_with_config(&cases.join("\n"), config).unwrap();
+    let markdown = format!("{}\n\n## Details", cases.join("\n"));
+    let res = common::render_with_config(&markdown, config).unwrap();
     insta::assert_snapshot!(res.body);
     assert!(res.internal_links.contains(&("guides/quickstart.md".into(), Some("install".into()))));
+    assert!(res.internal_links.contains(&("my_page.md".into(), Some("details".into()))));
 }
 
 #[test]

--- a/components/markdown/tests/snapshots/markdown__wikilink_resolution.snap
+++ b/components/markdown/tests/snapshots/markdown__wikilink_resolution.snap
@@ -5,4 +5,7 @@ expression: res.body
 <p><a href="https://getzola.org/guides/quickstart/">quickstart</a>
 <a href="https://getzola.org/guides/quickstart/">guides/quickstart</a>
 <a href="https://getzola.org/guides/quickstart/#install">quickstart#install</a>
-<a href="https://getzola.org/guides/quickstart/">Get Started</a></p>
+<a href="https://getzola.org/guides/quickstart/">Get Started</a>
+<a href="https://www.getzola.org/test/#details">#details</a>
+<a href="https://www.getzola.org/test/#details">Details</a></p>
+<h2 id="details">Details</h2>


### PR DESCRIPTION
As discussed in #3116, this PR adds self-fragment wikilinks such as [[#details]] by resolving an empty page key against the current page. These links reuse Zola’s existing anchor validation and internal-link tracking.

AI was used for writing the code. GPT-5.6-Sol w/ high effort and a touch of sass. Reviewed by human and tested in prod.

No documentation exists to update yet on the wikilinks branch.

Sanity check:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/getzola/zola/pulls) for the same update/change?

## Code changes

* [x] Are you doing the PR on the `next` branch?
* [x] Was a LLM used? If so, for what?

If the change is a new feature or adding to/changing an existing one:

* [ ] Have you created/updated the relevant documentation page(s)?



