### PR TITLE
Build render cache before rendering Markdown

### DIFF
--- a/components/site/src/lib.rs
+++ b/components/site/src/lib.rs
@@ -343,6 +343,8 @@ impl Site {
         // taxonomy Tera fns are loaded in `register_early_global_fns`
         // so we do need to populate it first.
         self.populate_taxonomies()?;
+        // Build the cache for Tera functions used in Markdown content.
+        Arc::make_mut(&mut self.cache).build(&self.library, &self.taxonomies, &self.tera);
         tpls::register_early_global_fns(self);
         self.render_markdown()?;
         Arc::make_mut(&mut self.library).fill_backlinks();

--- a/components/site/tests/site.rs
+++ b/components/site/tests/site.rs
@@ -144,6 +144,11 @@ fn can_build_site_without_live_reload() {
     assert!(file_contains!(public, "posts/python/index.html", "Basic shortcode"));
     assert!(file_contains!(public, "posts/python/index.html", "Arrrh Bob"));
     assert!(file_contains!(public, "posts/python/index.html", "Arrrh Bob_Sponge"));
+    assert!(file_contains!(
+        public,
+        "posts/python/index.html",
+        "https://replace-this-with-your-url.com/categories/a-category/"
+    ));
     assert!(!file_contains!(public, "posts/python/index.html", "SHOULDNOTAPPEAR"));
     assert!(!file_contains!(public, "posts/python/index.html", "DESCRIPTION"));
 

--- a/test_site/content/posts/python.md
+++ b/test_site/content/posts/python.md
@@ -12,6 +12,7 @@ Same filename but different path
 
 {{ <pirate name="Bob" /> }}
 {{ <pirate name="Bob_Sponge" /> }}
+{{ <taxonomy_url kind="categories" term="a-category" /> }}
 
 {% if page.description %}
 DESCRIPTION: {{page.description}}

--- a/test_site/templates/components.html
+++ b/test_site/templates/components.html
@@ -11,3 +11,7 @@ Arrrh {{ name }}
     <iframe src="https://www.youtube-nocookie.com/embed/{{id}}{% if playlist %}?list={{playlist}}{% endif %}{% if autoplay %}?autoplay=1{% endif %}" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 </div>
 {%- endcomponent %}
+
+{% component taxonomy_url(kind, term) -%}
+{{ get_taxonomy_url(kind=kind, term=term) }}
+{%- endcomponent %}


### PR DESCRIPTION
Content components can call `get_page`, `get_section`, and taxonomy functions while Markdown is rendered. Those functions captured the initial empty `RenderCache`, however, because the cache was only populated after Markdown rendering completed.

Build the cache once from parsed content before registering the early global functions, then retain the existing rebuild after Markdown rendering so final templates receive rendered content and backlinks.

Add an integration assertion that resolves a taxonomy URL from a content component.

Fixes #3260.

## Code changes

* [x] Are you doing the PR on the `next` branch?
* [x] Was a LLM used? If so, for what?
  GitHub Copilot to figure out how to make the smallest change, and to ascertain that this was indeed a regression in the first place.

