### PR TITLE
Resolve qualified wikilinks to colocated assets

### DIFF
--- a/components/markdown/src/lib.rs
+++ b/components/markdown/src/lib.rs
@@ -6,7 +6,7 @@ use errors::Result;
 
 pub use context::MarkdownContext;
 pub use markdown::Rendered;
-pub use wikilinks::{WikilinkError, WikilinkResolver};
+pub use wikilinks::{WikilinkError, WikilinkResolver, WikilinkTarget};
 
 pub fn render_content(content: &str, context: &MarkdownContext) -> Result<Rendered> {
     markdown::State::default().render(content, context)

--- a/components/markdown/src/markdown.rs
+++ b/components/markdown/src/markdown.rs
@@ -15,7 +15,7 @@ use utils::slugs::slugify_anchors;
 use utils::table_of_contents::{Heading, make_table_of_contents};
 use utils::types::InsertAnchor;
 
-use crate::{MarkdownContext, WikilinkError};
+use crate::{MarkdownContext, WikilinkError, WikilinkTarget};
 
 const CONTINUE_READING: &str = "<span id=\"continue-reading\"></span>";
 static EMOJI_REPLACER: LazyLock<EmojiReplacer> = LazyLock::new(EmojiReplacer::new);
@@ -57,6 +57,10 @@ fn is_colocated_asset_link(link: &str) -> bool {
 
 fn resolve_colocated_asset(link: &str, ctx: &MarkdownContext) -> Option<String> {
     let path = link.strip_prefix("@/")?;
+    resolve_colocated_asset_path(path, ctx)
+}
+
+fn resolve_colocated_asset_path(path: &str, ctx: &MarkdownContext) -> Option<String> {
     // `#` in an asset path is probably a mistake, ignore it
     let path = path.split('#').next().unwrap();
     let (owner_md, rel) = ctx.colocated_assets.get(path)?;
@@ -429,15 +433,21 @@ impl<'a> State<'a> {
                 }
                 return Ok(format!("{}#{anchor}", ctx.current_permalink));
             }
-            match ctx.wikilinks.resolve(key) {
-                Ok(md_path) => {
-                    let permalink = &ctx.permalinks[md_path];
+            let resolved = match ctx.wikilinks.resolve(key) {
+                Ok(WikilinkTarget::Content(md_path)) => {
                     self.internal_links.push((md_path.to_string(), anchor.clone()));
-                    match anchor {
-                        Some(a) => format!("{}#{}", permalink, a),
-                        None => permalink.clone(),
-                    }
+                    Ok(ctx.permalinks[md_path].clone())
                 }
+                Ok(WikilinkTarget::Asset(path)) => {
+                    resolve_colocated_asset_path(path, ctx).ok_or(WikilinkError::Missing)
+                }
+                Err(error) => Err(error),
+            };
+            match resolved {
+                Ok(permalink) => match anchor {
+                    Some(a) => format!("{}#{}", permalink, a),
+                    None => permalink,
+                },
                 Err(error) => {
                     let detail = match error {
                         WikilinkError::Missing => String::new(),

--- a/components/markdown/src/wikilinks.rs
+++ b/components/markdown/src/wikilinks.rs
@@ -6,24 +6,40 @@ pub enum WikilinkError {
     Ambiguous { candidates: Vec<String> },
 }
 
-/// Resolves content wikilinks by source path, output alias, or bare stem.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WikilinkTarget {
+    Content(String),
+    Asset(String),
+}
+
+impl WikilinkTarget {
+    fn identity(&self) -> &str {
+        match self {
+            Self::Content(path) => identity(path),
+            Self::Asset(path) => path,
+        }
+    }
+}
+
+/// Resolves content wikilinks by source path, output alias, or bare stem, and asset wikilinks by
+/// path or bare filename.
 ///
-/// For each target, the resolver indexes three forms that point back to the full source path:
+/// Content targets are indexed by three forms that point back to the full source path:
 ///
 /// 1. The source path without its `.md` extension, such as `docs/overview`.
 /// 2. Each existing Zola alias, with surrounding slashes removed, such as `overview-old`.
 /// 3. The bare stem, such as `overview`, when it differs from the full source path.
 ///
-/// A stem that is identical to the full path is not indexed twice. Colliding aliases and stems are
-/// retained so resolution can suggest a qualified key for every matching source path instead of
-/// choosing one arbitrarily. Exact paths take precedence over aliases, and aliases take precedence
-/// over stems.
+/// Assets are indexed by their exact content-root-relative path and bare filename. A short name
+/// that is identical to the full path is not indexed twice. Collisions are retained so resolution
+/// can suggest qualified keys instead of choosing one arbitrarily. Exact paths take precedence over
+/// aliases, and aliases take precedence over short names.
 #[derive(Clone, Debug, Default)]
 pub struct WikilinkResolver {
-    sources: Vec<String>,
+    targets: Vec<WikilinkTarget>,
     paths: AHashMap<String, Vec<usize>>,
     aliases: AHashMap<String, Vec<usize>>,
-    stems: AHashMap<String, Vec<usize>>,
+    names: AHashMap<String, Vec<usize>>,
 }
 
 fn identity(value: &str) -> &str {
@@ -37,49 +53,60 @@ fn normalize_lookup(value: &str) -> Option<&str> {
 
 impl WikilinkResolver {
     pub fn add(&mut self, source_path: &str, aliases: &[String]) {
-        let index = self.sources.len();
-        let id = identity(source_path);
+        self.insert(WikilinkTarget::Content(source_path.to_string()), aliases);
+    }
+
+    pub fn add_asset(&mut self, path: &str) {
+        let Some(path) = normalize_lookup(path) else {
+            return;
+        };
+        self.insert(WikilinkTarget::Asset(path.to_string()), &[]);
+    }
+
+    fn insert(&mut self, target: WikilinkTarget, aliases: &[String]) {
+        let index = self.targets.len();
+        let id = target.identity();
         self.paths.entry(id.to_string()).or_default().push(index);
 
-        // We want to keep the filename only if possible
-        // eg docs/help.md --> help
-        // but help.md --> N/A since it's already the stem
-        if let Some(stem) = id.rsplit('/').next()
-            && stem != id
+        if let Some(name) = id.rsplit('/').next()
+            && name != id
         {
-            self.stems.entry(stem.to_string()).or_default().push(index);
+            self.names.entry(name.to_string()).or_default().push(index);
         }
 
-        for alias in aliases {
-            if let Some(s) = normalize_lookup(alias) {
-                let candidates = self.aliases.entry(s.to_string()).or_default();
-                if !candidates.contains(&index) {
-                    candidates.push(index);
+        if matches!(target, WikilinkTarget::Content(_)) {
+            for alias in aliases {
+                if let Some(s) = normalize_lookup(alias) {
+                    let candidates = self.aliases.entry(s.to_string()).or_default();
+                    if !candidates.contains(&index) {
+                        candidates.push(index);
+                    }
                 }
             }
         }
-        self.sources.push(source_path.to_string());
+        self.targets.push(target);
     }
 
-    fn select(&self, candidates: &[usize]) -> Result<&str, WikilinkError> {
+    fn select(&self, candidates: &[usize]) -> Result<&WikilinkTarget, WikilinkError> {
         if let [index] = candidates {
-            return Ok(&self.sources[*index]);
+            return Ok(&self.targets[*index]);
         }
 
-        let mut paths = candidates.iter().map(|index| &self.sources[*index]).collect::<Vec<_>>();
+        let mut paths =
+            candidates.iter().map(|index| self.targets[*index].identity()).collect::<Vec<_>>();
         paths.sort_unstable();
         paths.dedup();
 
         match paths.as_slice() {
-            [path] => Ok(path),
+            [_] => Ok(&self.targets[candidates[0]]),
             // We can't have missing here since we are only called if we have candidates
             _ => Err(WikilinkError::Ambiguous {
-                candidates: paths.into_iter().map(|path| identity(path).to_string()).collect(),
+                candidates: paths.into_iter().map(str::to_string).collect(),
             }),
         }
     }
 
-    pub fn resolve(&self, target: &str) -> Result<&str, WikilinkError> {
+    pub fn resolve(&self, target: &str) -> Result<&WikilinkTarget, WikilinkError> {
         let Some(normalized) = normalize_lookup(target) else {
             return Err(WikilinkError::Missing);
         };
@@ -91,7 +118,7 @@ impl WikilinkResolver {
             return self.select(candidates);
         }
         if !normalized.contains('/')
-            && let Some(candidates) = self.stems.get(normalized)
+            && let Some(candidates) = self.names.get(normalized)
         {
             return self.select(candidates);
         }
@@ -104,8 +131,16 @@ impl WikilinkResolver {
 mod tests {
     use super::*;
 
+    fn assert_content(resolver: &WikilinkResolver, target: &str, expected: &str) {
+        assert_eq!(resolver.resolve(target), Ok(&WikilinkTarget::Content(expected.to_string())));
+    }
+
+    fn assert_asset(resolver: &WikilinkResolver, target: &str, expected: &str) {
+        assert_eq!(resolver.resolve(target), Ok(&WikilinkTarget::Asset(expected.to_string())));
+    }
+
     #[test]
-    fn resolves_paths_aliases_and_unique_stems() {
+    fn resolves_paths_aliases_and_unique_names() {
         let inputs = vec![
             ("blog/overview.md", Vec::new()),
             ("docs/overview.md", Vec::new()),
@@ -113,28 +148,31 @@ mod tests {
             ("blog/_index.md", Vec::new()),
             ("_index.md", Vec::new()),
             ("guides/quickstart.md", vec!["/start/".to_string()]),
+            ("archive/manual.pdf.md", Vec::new()),
         ];
         let mut resolver = WikilinkResolver::default();
         for (a, b) in inputs {
             resolver.add(a, &b);
         }
+        resolver.add_asset("guides/source.pdf");
+        resolver.add_asset("guides/manual.pdf");
 
         // Full paths always resolve.
-        assert_eq!(resolver.resolve("blog/overview"), Ok("blog/overview.md"));
-        assert_eq!(resolver.resolve("docs/overview"), Ok("docs/overview.md"));
-        assert_eq!(resolver.resolve("about"), Ok("about.md"));
-        assert_eq!(resolver.resolve("blog/_index"), Ok("blog/_index.md"));
-        assert_eq!(resolver.resolve("guides/quickstart"), Ok("guides/quickstart.md"));
+        assert_content(&resolver, "blog/overview", "blog/overview.md");
+        assert_content(&resolver, "docs/overview", "docs/overview.md");
+        assert_content(&resolver, "about", "about.md");
+        assert_content(&resolver, "blog/_index", "blog/_index.md");
+        assert_content(&resolver, "guides/quickstart", "guides/quickstart.md");
 
         // Unique stems and aliases resolve to the same source path.
-        assert_eq!(resolver.resolve("quickstart"), Ok("guides/quickstart.md"));
-        assert_eq!(resolver.resolve("start"), Ok("guides/quickstart.md"));
+        assert_content(&resolver, "quickstart", "guides/quickstart.md");
+        assert_content(&resolver, "start", "guides/quickstart.md");
 
         // The exact root path takes precedence over the colliding blog/_index.md stem.
-        assert_eq!(resolver.resolve("_index"), Ok("_index.md"));
+        assert_content(&resolver, "_index", "_index.md");
 
         // A stem identical to its full path is not indexed separately.
-        assert!(!resolver.stems.contains_key("about"));
+        assert!(!resolver.names.contains_key("about"));
 
         // Colliding bare stems suggest valid qualified keys for an actionable error.
         assert_eq!(
@@ -146,5 +184,20 @@ mod tests {
 
         // Accepting Markdown extensions would be an unrelated syntax expansion.
         assert_eq!(resolver.resolve("about.md"), Err(WikilinkError::Missing));
+
+        // Asset paths and unique filenames use the same resolver.
+        assert_asset(&resolver, "guides/source.pdf", "guides/source.pdf");
+        assert_asset(&resolver, "source.pdf", "guides/source.pdf");
+
+        // Colliding short names require a qualified path regardless of target kind.
+        assert_eq!(
+            resolver.resolve("manual.pdf"),
+            Err(WikilinkError::Ambiguous {
+                candidates: vec!["archive/manual.pdf".to_string(), "guides/manual.pdf".to_string()],
+            })
+        );
+        assert_asset(&resolver, "guides/manual.pdf", "guides/manual.pdf");
+        assert_content(&resolver, "archive/manual.pdf", "archive/manual.pdf.md");
+        assert_eq!(resolver.resolve("manual"), Err(WikilinkError::Missing));
     }
 }

--- a/components/markdown/tests/common.rs
+++ b/components/markdown/tests/common.rs
@@ -17,6 +17,7 @@ fn configurable_render(
     let permalinks = AHashMap::from_iter([
         ("pages/about.md".to_owned(), "https://getzola.org/about/".to_owned()),
         ("guides/quickstart.md".to_owned(), "https://getzola.org/guides/quickstart/".to_owned()),
+        ("guides/index.md".to_owned(), "https://getzola.org/guides/".to_owned()),
         ("about.md".to_owned(), "https://getzola.org/about/".to_owned()),
         ("archive/duplicate.md".to_owned(), "https://getzola.org/archive/duplicate/".to_owned()),
         ("guides/duplicate.md".to_owned(), "https://getzola.org/guides/duplicate/".to_owned()),
@@ -27,18 +28,25 @@ fn configurable_render(
     wikilinks.add("about.md", &vec![]);
     wikilinks.add("archive/duplicate.md", &vec![]);
     wikilinks.add("guides/duplicate.md", &vec![]);
+    wikilinks.add_asset("guides/source.pdf");
+    wikilinks.add_asset("archive/manual.pdf");
+    wikilinks.add_asset("guides/manual.pdf");
+
+    let colocated_assets = AHashMap::from_iter([(
+        "guides/source.pdf".to_owned(),
+        ("guides/index.md".to_owned(), "source.pdf".to_owned()),
+    )]);
 
     tera.register_filter(
         "markdown",
         templates::filters::MarkdownFilter::new(
             config.clone(),
             permalinks.clone(),
-            AHashMap::new(),
+            colocated_assets.clone(),
             wikilinks.clone(),
             tera.clone(),
         ),
     );
-    let colocated_assets = AHashMap::new();
     let context = MarkdownContext {
         tera: &tera,
         config: &config,

--- a/components/markdown/tests/markdown.rs
+++ b/components/markdown/tests/markdown.rs
@@ -502,6 +502,8 @@ fn wikilink_resolution() {
         "[[#details]]",
         "[[#details|Details]]",
         "[[start|Start alias]]",
+        "[[guides/source.pdf|Source]]",
+        "[[source.pdf|Bare source]]",
     ];
 
     let markdown = format!("{}\n\n## Details", cases.join("\n"));
@@ -509,6 +511,7 @@ fn wikilink_resolution() {
     insta::assert_snapshot!(res.body);
     assert!(res.internal_links.contains(&("guides/quickstart.md".into(), Some("install".into()))));
     assert!(res.internal_links.contains(&("my_page.md".into(), Some("details".into()))));
+    assert!(!res.internal_links.iter().any(|(path, _)| path == "guides/source.pdf"));
 }
 
 #[test]
@@ -525,6 +528,12 @@ fn wikilink_errors() {
     config.markdown.wikilinks = true;
     config.link_checker.internal_level = config::LinkCheckerLevel::Error;
     assert!(common::render_with_config("[[nope]]", config.clone()).is_err());
+    let message =
+        common::render_with_config("[[manual.pdf]]", config.clone()).unwrap_err().to_string();
+    assert_eq!(
+        message,
+        "Broken wikilink `[[manual.pdf]]` in my_page.md; target is ambiguous; candidates: archive/manual.pdf, guides/manual.pdf"
+    );
 
     let message = common::render_with_config("[[duplicate]]", config).unwrap_err().to_string();
     assert_eq!(

--- a/components/markdown/tests/snapshots/markdown__wikilink_resolution.snap
+++ b/components/markdown/tests/snapshots/markdown__wikilink_resolution.snap
@@ -8,5 +8,7 @@ expression: res.body
 <a href="https://getzola.org/guides/quickstart/">Get Started</a>
 <a href="https://www.getzola.org/test/#details">#details</a>
 <a href="https://www.getzola.org/test/#details">Details</a>
-<a href="https://getzola.org/guides/quickstart/">Start alias</a></p>
+<a href="https://getzola.org/guides/quickstart/">Start alias</a>
+<a href="https://getzola.org/guides/source.pdf">Source</a>
+<a href="https://getzola.org/guides/source.pdf">Bare source</a></p>
 <h2 id="details">Details</h2>

--- a/components/site/src/wikilinks.rs
+++ b/components/site/src/wikilinks.rs
@@ -1,14 +1,23 @@
+use ahash::AHashSet;
 use content::Library;
 use markdown::WikilinkResolver;
 
 /// We take all pages/sections that will be rendered and build a resolver from those
 pub fn build_wikilinks(library: &Library) -> WikilinkResolver {
     let mut resolver = WikilinkResolver::default();
+    let mut asset_owners = AHashSet::new();
     for p in library.pages.values().filter(|x| x.meta.render) {
         resolver.add(&p.file.relative, &p.meta.aliases);
+        asset_owners.insert(p.file.relative.as_str());
     }
     for s in library.sections.values().filter(|x| x.meta.render) {
         resolver.add(&s.file.relative, &s.meta.aliases);
+        asset_owners.insert(s.file.relative.as_str());
+    }
+    for (path, (owner, _)) in &library.colocated_assets {
+        if asset_owners.contains(owner.as_str()) {
+            resolver.add_asset(path);
+        }
     }
     resolver
 }
@@ -20,7 +29,7 @@ mod tests {
     use super::*;
     use config::Config;
     use content::{Library, Page, PageFrontMatter, Section, SectionFrontMatter};
-    use markdown::WikilinkError;
+    use markdown::{WikilinkError, WikilinkTarget};
 
     fn page(path: &str, aliases: &[&str], render: bool) -> Page {
         let mut page = Page::new(
@@ -52,12 +61,34 @@ mod tests {
         library.insert_page(page("guides/quickstart.md", &["/start/"], true));
         library.insert_page(page("notes/private.md", &["/private-note/"], false));
         library.insert_section(section("docs/_index.md", &["/documentation/"]));
+        library.colocated_assets.insert(
+            "docs/source.pdf".to_string(),
+            ("docs/_index.md".to_string(), "source.pdf".to_string()),
+        );
+        library.colocated_assets.insert(
+            "notes/private.pdf".to_string(),
+            ("notes/private.md".to_string(), "private.pdf".to_string()),
+        );
 
         let resolver = build_wikilinks(&library);
-        assert_eq!(resolver.resolve("start"), Ok("guides/quickstart.md"));
+        assert_eq!(
+            resolver.resolve("start"),
+            Ok(&WikilinkTarget::Content("guides/quickstart.md".to_string()))
+        );
         assert_eq!(resolver.resolve("notes/private"), Err(WikilinkError::Missing));
         assert_eq!(resolver.resolve("private-note"), Err(WikilinkError::Missing));
-        assert_eq!(resolver.resolve("docs/_index"), Ok("docs/_index.md"));
-        assert_eq!(resolver.resolve("documentation"), Ok("docs/_index.md"));
+        assert_eq!(
+            resolver.resolve("docs/_index"),
+            Ok(&WikilinkTarget::Content("docs/_index.md".to_string()))
+        );
+        assert_eq!(
+            resolver.resolve("documentation"),
+            Ok(&WikilinkTarget::Content("docs/_index.md".to_string()))
+        );
+        assert_eq!(
+            resolver.resolve("source.pdf"),
+            Ok(&WikilinkTarget::Asset("docs/source.pdf".to_string()))
+        );
+        assert_eq!(resolver.resolve("private.pdf"), Err(WikilinkError::Missing));
     }
 }

--- a/components/site/tests/site_i18n.rs
+++ b/components/site/tests/site_i18n.rs
@@ -225,7 +225,10 @@ fn correct_translations_on_all_pages() {
 
 #[test]
 fn can_resolve_colocated_assets_language_aware() {
-    let (_, _tmp_dir, public) = build_site("test_site_i18n");
+    let (_, _tmp_dir, public) = build_site_with_setup("test_site_i18n", |mut site| {
+        site.config.markdown.wikilinks = true;
+        (site, true)
+    });
 
     assert!(file_contains!(
         public,
@@ -247,5 +250,15 @@ fn can_resolve_colocated_assets_language_aware() {
         public,
         "fr/blog/with-assets/index.html",
         "src=\"https://example.com/fr/blog/with-assets/some.js\""
+    ));
+    assert!(file_contains!(
+        public,
+        "blog/with-assets/index.html",
+        "en wikilink: <a href=\"https://example.com/blog/with-assets/some.js\">JS</a>"
+    ));
+    assert!(file_contains!(
+        public,
+        "fr/blog/with-assets/index.html",
+        "fr wikilink: <a href=\"https://example.com/fr/blog/with-assets/some.js\">JS</a>"
     ));
 }

--- a/test_site_i18n/content/blog/with-assets/index.fr.md
+++ b/test_site_i18n/content/blog/with-assets/index.fr.md
@@ -7,3 +7,5 @@ Avec des fichiers
 fr asset: {{ get_url(path="@/blog/with-assets/some.js") }}
 
 ![js](@/blog/with-assets/some.js)
+
+fr wikilink: [[some.js|JS]]

--- a/test_site_i18n/content/blog/with-assets/index.md
+++ b/test_site_i18n/content/blog/with-assets/index.md
@@ -7,3 +7,5 @@ With assets
 en asset: {{ get_url(path="@/blog/with-assets/some.js") }}
 
 ![js](@/blog/with-assets/some.js)
+
+en wikilink: [[some.js|JS]]


### PR DESCRIPTION
As discussed in #3116, this PR lets wikilinks such as `[[source.pdf]]` resolve to colocated assets already addressable through Zola's `@/` links.

Asset lookup accepts a bare filename when it is unique. `[[guides/source.pdf]]` remains available as the exact content-root-relative form, and duplicate filenames produce an ambiguity error with qualified candidates. Non-Markdown assets still require their extension.

Unlike the earlier output-target version I linked in #3116, the resolver stores content and asset paths in one typed target index rather than storing emitted URLs. A resolved asset path passes through Zola's existing language-aware `@/` lookup. Asset wikilinks do not create backlinks because they point to assets rather than Markdown content.

The existing resolver and wikilink tests cover exact paths, unique filenames, ambiguous filenames, required extensions, excluded unrendered owners, and backlink behavior. The existing multilingual asset fixture verifies bare-filename links with the emitted English and French URLs.

AI was used for writing the code. GPT-5.6-Sol w/ high effort and a touch of sass. Reviewed by human.

No documentation exists to update yet on the wikilinks branch.
